### PR TITLE
Re order dockerfile for yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM ruby:2.5-alpine
+
+# Build information
+ARG GIT_OWNER
+LABEL git_owner=$GIT_OWNER
+ENV GIT_OWNER=$GIT_OWNER
+
+ARG GIT_REPO
+LABEL git_repo=$GIT_REPO
+ENV GIT_REPO=$GIT_REPO
+
+ARG GIT_BRANCH
+LABEL git_branch=$GIT_BRANCH
+ENV GIT_BRANCH=$GIT_BRANCH
+
+ARG GIT_COMMIT
+LABEL git_commit=$GIT_COMMIT
+ENV GIT_COMMIT=$GIT_COMMIT
+
+ARG BUILD_TIME
+LABEL build_time=$BUILD_TIME
+ENV BUILD_TIME=$BUILD_TIME
+
+ARG CCS_VERSION
+LABEL ccs_version=$CCS_VERSION
+ENV CCS_VERSION=$CCS_VERSION
+
+ENV BUILD_PACKAGES curl-dev ruby-dev sqlite-dev build-base
+
+# Update and install base packages
+RUN apk update && apk upgrade && apk add bash $BUILD_PACKAGES nodejs
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+# Create app directory
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["ruby", "bin/rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,13 +41,13 @@ WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock ./
 
+COPY . .
+
 # Install Gem dependencies
 RUN bundle install --deployment --without development test
 
 # Install Node.js dependencies
 RUN yarn install
-
-COPY . .
 
 # Run app in production environment
 ENV RAILS_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ ENV RAILS_ENV=production
 # Configure Rails to serve the assets
 ENV RAILS_SERVE_STATIC_FILES=true
 
+# Send logs to STDOUT so that they can be sent to CloudWatch
+ENV RAILS_LOG_TO_STDOUT=true
+
 # Compile assets
 RUN GOOGLE_GEOCODING_API_KEY=dummy SECRET_KEY_BASE=dummy bundle exec rails assets:precompile
 

--- a/README.md
+++ b/README.md
@@ -38,4 +38,27 @@ To install dependencies:
 
 Visit [localhost:3000](http://localhost:3000).
 
+## Docker
+
+The Dockerfile configures the Rails app to run in production.
+
+    # Build image
+    $ docker build \
+    -t crown-marketplace-production \
+    .
+
+    # Run server
+    $ docker run \
+    -p8080:8080 \
+    --env GOOGLE_GEOCODING_API_KEY=<key> \
+    --env SECRET_KEY_BASE=<key> \
+    --env CCS_DEFAULT_DB_HOST=<database-host> \
+    --env CCS_DEFAULT_DB_PORT=<database-port> \
+    --env CCS_DEFAULT_DB_NAME=<database-name> \
+    --env CCS_DEFAULT_DB_USER=<database-username> \
+    --env CCS_DEFAULT_DB_PASSWORD=<database-password> \
+    crown-marketplace-production
+
+NOTE. You can set `CCS_DEFAULT_DB_HOST` to `docker.for.mac.localhost` to connect to a database running on your host machine.
+
 [geocoding-key]: https://console.developers.google.com/flows/enableapi?apiid=geocoding_backend&keyType=SERVER_SIDE

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,7 @@
 <div class="govuk-body">
   <h1>Home#index</h1>
   <p>Find me in app/views/home/index.html.erb</p>
+
+  <h2>Supplier count</h2>
+  <%= Supplier.count %>
 </div>

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+bundle exec rails db:migrate
+
+bundle exec rails server

--- a/config/database.yml
+++ b/config/database.yml
@@ -80,6 +80,8 @@ test:
 #
 production:
   <<: *default
-  database: marketplace_production
-  username: marketplace
-  password: <%= ENV['MARKETPLACE_DATABASE_PASSWORD'] %>
+  host: <%= ENV['CCS_DEFAULT_DB_HOST'] %>
+  port: <%= ENV['CCS_DEFAULT_DB_PORT'] %>
+  database: <%= ENV['CCS_DEFAULT_DB_NAME'] %>
+  username: <%= ENV['CCS_DEFAULT_DB_USER'] %>
+  password: <%= ENV['CCS_DEFAULT_DB_PASSWORD'] %>


### PR DESCRIPTION
If the files (perhaps only package-lock.json ?) aren't copied into the container before `yarn install` is run, then the assets aren't correctly copied.

This gets picked up locally when yarn install is executed a second time as part of assets:precompile, but there are some conditions (AWS Codebuild, DIND) that mean it doesn't find any changes.

By moving the `COPY . .` command before the bundle and yarn commands, everything works in both scenarios. 