### PR TITLE
Add marker for Parameter Store variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ ARG CCS_VERSION
 LABEL ccs_version=$CCS_VERSION
 ENV CCS_VERSION=$CCS_VERSION
 
+##_PARAMETER_STORE_MARKER_##
+
 ENV BUILD_PACKAGES curl-dev ruby-dev postgresql-dev build-base tzdata
 
 # Update and install base packages


### PR DESCRIPTION
This adds a marker comment that the build process will use to add ENV variables, based upon entries within the Parameter Store, that will arrive in a later PR within the CMpDevEnvironment repository.