### PR TITLE
WIP: Capture latitude and longitude in import

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -29,6 +29,7 @@ class Upload
       contact_email = branch.dig('contacts', 0, 'email')
       s.branches.create!(
         postcode: branch['postcode'],
+        location: Geocoding.point_factory.point(branch['lon'], branch['lat']),
         telephone_number: branch['telephone'],
         contact_name: contact_name,
         contact_email: contact_email


### PR DESCRIPTION
TODO: Consider adding validation for `Branch#location`. Note that `RGeo::Geographic::Factory#point` seems to convert a `nil` lat/lon into zero, so we might need to introduce `Branch#latitude` & `Branch#longitude` if we want to use standard ActiveRecord validation to protect against this.