### PR TITLE
Add build test scripts

### DIFF
--- a/pipeline_pre_build_tests.sh
+++ b/pipeline_pre_build_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/postgresql.list'
+apt update
+apt-get install -y build-essential
+apt install -y postgresql-9.6-postgis-2.3
+service postgresql start 9.6
+sudo -u postgres createuser --superuser root; sudo -u postgres createdb root
+curl -sL https://deb.nodesource.com/setup_8.x | bash -
+apt-get install -y nodejs
+alias node=nodejs
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+sh -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" >> /etc/apt/sources.list.d/yarn.list'
+apt update
+apt install --no-install-recommends yarn

--- a/pipeline_run_build_tests.sh
+++ b/pipeline_run_build_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export RAILS_ENV=test
+bundle install
+yarn install
+bundle exec rake db:test:prepare
+bundle exec rake assets:precompile
+bundle exec rake


### PR DESCRIPTION
This adds two scripts that can integrate with the AWS CodePipline and CodeBuild to run the same tests that Travis/CI is currrently executing.

They will not be used unless the deployment specifies running tests, via enable_tests within the terraform definition.