### PR TITLE
WIP: Rename step params

### DIFF
--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -27,7 +27,7 @@ class BranchesController < ApplicationController
   private
 
   def back_path
-    if params[:nominated_worker] == 'yes' || params[:school_payroll] == 'yes'
+    if params[:worker_type] == 'nominated' || params[:school_payroll] == 'yes'
       search_question_path(slug: 'school-postcode', params: safe_params)
     else
       search_question_path(slug: 'agency-payroll', params: safe_params)
@@ -43,7 +43,7 @@ class BranchesController < ApplicationController
   end
 
   def rates
-    if params[:nominated_worker] == 'yes'
+    if params[:worker_type] == 'nominated'
       Rate.direct_provision.nominated_worker
     elsif params[:school_payroll] == 'yes'
       Rate.direct_provision.fixed_term
@@ -55,7 +55,7 @@ class BranchesController < ApplicationController
   def branch_results_near(point)
     Branch.search(point, rates: rates).map do |branch|
       search_result_for(branch).tap do |result|
-        if params[:nominated_worker] == 'yes'
+        if params[:worker_type] == 'nominated'
           result.rate = branch.supplier.nominated_worker_rate
         elsif params[:school_payroll] == 'yes'
           result.rate = branch.supplier.fixed_term_rate
@@ -90,7 +90,7 @@ class BranchesController < ApplicationController
 
   def safe_params
     params.permit(
-      :postcode, :nominated_worker, :looking_for, :school_payroll, :term,
+      :postcode, :worker_type, :looking_for, :school_payroll, :term,
       :job_type
     )
   end

--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -27,7 +27,7 @@ class BranchesController < ApplicationController
   private
 
   def back_path
-    if params[:worker_type] == 'nominated' || params[:school_payroll] == 'yes'
+    if params[:worker_type] == 'nominated' || params[:payroll_provider] == 'school'
       search_question_path(slug: 'school-postcode', params: safe_params)
     else
       search_question_path(slug: 'agency-payroll', params: safe_params)
@@ -45,9 +45,9 @@ class BranchesController < ApplicationController
   def rates
     if params[:worker_type] == 'nominated'
       Rate.direct_provision.nominated_worker
-    elsif params[:school_payroll] == 'yes'
+    elsif params[:payroll_provider] == 'school'
       Rate.direct_provision.fixed_term
-    elsif params[:school_payroll] == 'no'
+    elsif params[:payroll_provider] == 'agency'
       Rate.direct_provision.rate_for(job_type: job_type, term: term)
     end
   end
@@ -57,9 +57,9 @@ class BranchesController < ApplicationController
       search_result_for(branch).tap do |result|
         if params[:worker_type] == 'nominated'
           result.rate = branch.supplier.nominated_worker_rate
-        elsif params[:school_payroll] == 'yes'
+        elsif params[:payroll_provider] == 'school'
           result.rate = branch.supplier.fixed_term_rate
-        elsif params[:school_payroll] == 'no'
+        elsif params[:payroll_provider] == 'agency'
           result.rate = branch.supplier.rate_for(job_type: job_type, term: term)
         end
         result.distance = point.distance(branch.location)
@@ -90,7 +90,7 @@ class BranchesController < ApplicationController
 
   def safe_params
     params.permit(
-      :postcode, :worker_type, :looking_for, :school_payroll, :term,
+      :postcode, :worker_type, :looking_for, :payroll_provider, :term,
       :job_type
     )
   end

--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -90,7 +90,7 @@ class BranchesController < ApplicationController
 
   def safe_params
     params.permit(
-      :postcode, :nominated_worker, :hire_via_agency, :school_payroll, :term,
+      :postcode, :nominated_worker, :looking_for, :school_payroll, :term,
       :job_type
     )
   end

--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -18,6 +18,6 @@ class SuppliersController < ApplicationController
   private
 
   def managed_service_provider_params
-    params.permit(:hire_via_agency, :master_vendor)
+    params.permit(:looking_for, :master_vendor)
   end
 end

--- a/app/controllers/suppliers_controller.rb
+++ b/app/controllers/suppliers_controller.rb
@@ -18,6 +18,6 @@ class SuppliersController < ApplicationController
   private
 
   def managed_service_provider_params
-    params.permit(:looking_for, :master_vendor)
+    params.permit(:looking_for, :managed_service_provider)
   end
 end

--- a/app/helpers/branches_helper.rb
+++ b/app/helpers/branches_helper.rb
@@ -4,6 +4,6 @@ module BranchesHelper
   end
 
   def link_to_calculator?
-    params[:school_payroll] != 'yes'
+    params[:payroll_provider] != 'school'
   end
 end

--- a/app/models/steps/hire_via_agency.rb
+++ b/app/models/steps/hire_via_agency.rb
@@ -1,13 +1,17 @@
 module Steps
   class HireViaAgency < JourneyStep
-    attribute :hire_via_agency
-    validates :hire_via_agency, yes_no: true
+    attribute :looking_for
+    validates :looking_for,
+              inclusion: {
+                in: ['worker', 'managed_service_provider'],
+                message: 'Please choose an option'
+              }
 
     def next_step_class
-      case hire_via_agency
-      when 'yes'
+      case looking_for
+      when 'worker'
         NominatedWorker
-      when 'no'
+      when 'managed_service_provider'
         ManagedServiceProvider
       end
     end

--- a/app/models/steps/managed_service_provider.rb
+++ b/app/models/steps/managed_service_provider.rb
@@ -1,13 +1,17 @@
 module Steps
   class ManagedServiceProvider < JourneyStep
-    attribute :master_vendor
-    validates :master_vendor, yes_no: true
+    attribute :managed_service_provider
+    validates :managed_service_provider,
+              inclusion: {
+                in: ['master_vendor', 'neutral_vendor'],
+                message: 'Please choose an option'
+              }
 
     def next_step_class
-      case master_vendor
-      when 'yes'
+      case managed_service_provider
+      when 'master_vendor'
         MasterVendorManagedService
-      when 'no'
+      when 'neutral_vendor'
         NeutralVendorManagedService
       end
     end

--- a/app/models/steps/nominated_worker.rb
+++ b/app/models/steps/nominated_worker.rb
@@ -1,13 +1,17 @@
 module Steps
   class NominatedWorker < JourneyStep
-    attribute :nominated_worker
-    validates :nominated_worker, yes_no: true
+    attribute :worker_type
+    validates :worker_type,
+              inclusion: {
+                in: ['nominated', 'agency_supplied'],
+                message: 'Please choose an option'
+              }
 
     def next_step_class
-      case nominated_worker
-      when 'yes'
+      case worker_type
+      when 'nominated'
         SchoolPostcode
-      when 'no'
+      when 'agency_supplied'
         SchoolPayroll
       end
     end

--- a/app/models/steps/school_payroll.rb
+++ b/app/models/steps/school_payroll.rb
@@ -1,13 +1,17 @@
 module Steps
   class SchoolPayroll < JourneyStep
-    attribute :school_payroll
-    validates :school_payroll, yes_no: true
+    attribute :payroll_provider
+    validates :payroll_provider,
+              inclusion: {
+                in: ['school', 'agency'],
+                message: 'Please choose an option'
+              }
 
     def next_step_class
-      case school_payroll
-      when 'yes'
+      case payroll_provider
+      when 'school'
         SchoolPostcode
-      when 'no'
+      when 'agency'
         AgencyPayroll
       end
     end

--- a/app/views/search/agency_payroll.html.erb
+++ b/app/views/search/agency_payroll.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag @form_path, method: :get do %>
   <%= hidden_field_tag :nominated_worker, params[:nominated_worker] %>
-  <%= hidden_field_tag :hire_via_agency, params[:hire_via_agency] %>
+  <%= hidden_field_tag :looking_for, params[:looking_for] %>
   <%= hidden_field_tag :school_payroll, params[:school_payroll] %>
   <div class="govuk-form-group">
     <label class="govuk-label" for="postcode">

--- a/app/views/search/agency_payroll.html.erb
+++ b/app/views/search/agency_payroll.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag @form_path, method: :get do %>
-  <%= hidden_field_tag :nominated_worker, params[:nominated_worker] %>
+  <%= hidden_field_tag :worker_type, params[:worker_type] %>
   <%= hidden_field_tag :looking_for, params[:looking_for] %>
   <%= hidden_field_tag :school_payroll, params[:school_payroll] %>
   <div class="govuk-form-group">

--- a/app/views/search/agency_payroll.html.erb
+++ b/app/views/search/agency_payroll.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag @form_path, method: :get do %>
   <%= hidden_field_tag :worker_type, params[:worker_type] %>
   <%= hidden_field_tag :looking_for, params[:looking_for] %>
-  <%= hidden_field_tag :school_payroll, params[:school_payroll] %>
+  <%= hidden_field_tag :payroll_provider, params[:payroll_provider] %>
   <div class="govuk-form-group">
     <label class="govuk-label" for="postcode">
       What is your school's postcode?

--- a/app/views/search/hire_via_agency.html.erb
+++ b/app/views/search/hire_via_agency.html.erb
@@ -10,12 +10,12 @@
           </legend>
           <div class="govuk-radios">
             <div class="govuk-radios__item">
-              <%= radio_button_tag :hire_via_agency, :yes, checked?(params[:hire_via_agency], 'yes'), class: 'govuk-radios__input' %>
-              <%= label_tag :hire_via_agency_yes, 'An individual worker', class: 'govuk-label govuk-radios__label' %>
+              <%= radio_button_tag :looking_for, :worker, checked?(params[:looking_for], 'worker'), class: 'govuk-radios__input' %>
+              <%= label_tag :looking_for_worker, 'An individual worker', class: 'govuk-label govuk-radios__label' %>
             </div>
             <div class="govuk-radios__item">
-              <%= radio_button_tag :hire_via_agency, :no, checked?(params[:hire_via_agency], 'no'), class: 'govuk-radios__input' %>
-              <%= label_tag :hire_via_agency_no, 'A managed service provider', class: 'govuk-label govuk-radios__label' %>
+              <%= radio_button_tag :looking_for, :managed_service_provider, checked?(params[:looking_for], 'managed_service_provider'), class: 'govuk-radios__input' %>
+              <%= label_tag :looking_for_managed_service_provider, 'A managed service provider', class: 'govuk-label govuk-radios__label' %>
             </div>
           </div>
         </fieldset>

--- a/app/views/search/managed_service_provider.html.erb
+++ b/app/views/search/managed_service_provider.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag @form_path, method: :get do %>
-  <%= hidden_field_tag :hire_via_agency, params[:hire_via_agency] %>
+  <%= hidden_field_tag :looking_for, params[:looking_for] %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/app/views/search/managed_service_provider.html.erb
+++ b/app/views/search/managed_service_provider.html.erb
@@ -9,12 +9,12 @@
       </legend>
       <div class="govuk-radios">
         <div class="govuk-radios__item">
-          <%= radio_button_tag :master_vendor, :yes, checked?(params[:master_vendor], 'yes'), class: 'govuk-radios__input' %>
-          <%= label_tag :master_vendor_yes, 'Master vendor managed service', class: 'govuk-label govuk-radios__label' %>
+          <%= radio_button_tag :managed_service_provider, :master_vendor, checked?(params[:managed_service_provider], 'master_vendor'), class: 'govuk-radios__input' %>
+          <%= label_tag :managed_service_provider_master_vendor, 'Master vendor managed service', class: 'govuk-label govuk-radios__label' %>
         </div>
         <div class="govuk-radios__item">
-          <%= radio_button_tag :master_vendor, :no, checked?(params[:master_vendor], 'no'), class: 'govuk-radios__input' %>
-          <%= label_tag :master_vendor_no, 'Neutral vendor managed service', class: 'govuk-label govuk-radios__label' %>
+          <%= radio_button_tag :managed_service_provider, :neutral_vendor, checked?(params[:managed_service_provider], 'neutral_vendor'), class: 'govuk-radios__input' %>
+          <%= label_tag :managed_service_provider_neutral_vendor, 'Neutral vendor managed service', class: 'govuk-label govuk-radios__label' %>
         </div>
       </div>
     </fieldset>

--- a/app/views/search/nominated_worker.html.erb
+++ b/app/views/search/nominated_worker.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag @form_path, method: :get do %>
-  <%= hidden_field_tag :hire_via_agency, params[:hire_via_agency] %>
+  <%= hidden_field_tag :looking_for, params[:looking_for] %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/app/views/search/nominated_worker.html.erb
+++ b/app/views/search/nominated_worker.html.erb
@@ -9,12 +9,12 @@
       </legend>
       <div class="govuk-radios">
         <div class="govuk-radios__item">
-          <%= radio_button_tag :nominated_worker, :no, checked?(params[:nominated_worker], 'no'), class: 'govuk-radios__input' %>
-          <%= label_tag :nominated_worker_no, 'Yes', class: 'govuk-label govuk-radios__label' %>
+          <%= radio_button_tag :worker_type, :agency_supplied, checked?(params[:worker_type], 'agency_supplied'), class: 'govuk-radios__input' %>
+          <%= label_tag :worker_type_agency_supplied, 'Yes', class: 'govuk-label govuk-radios__label' %>
         </div>
         <div class="govuk-radios__item">
-          <%= radio_button_tag :nominated_worker, :yes, checked?(params[:nominated_worker], 'yes'), class: 'govuk-radios__input' %>
-          <%= label_tag :nominated_worker_yes, "No, I have a worker I want the agency to manage (a 'nominated worker')", class: 'govuk-label govuk-radios__label' %>
+          <%= radio_button_tag :worker_type, :nominated, checked?(params[:worker_type], 'nominated'), class: 'govuk-radios__input' %>
+          <%= label_tag :worker_type_nominated, "No, I have a worker I want the agency to manage (a 'nominated worker')", class: 'govuk-label govuk-radios__label' %>
         </div>
       </div>
     </fieldset>

--- a/app/views/search/school_payroll.html.erb
+++ b/app/views/search/school_payroll.html.erb
@@ -10,12 +10,12 @@
       </legend>
       <div class="govuk-radios">
         <div class="govuk-radios__item">
-          <%= radio_button_tag :school_payroll, :yes, checked?(params[:school_payroll], 'yes'), class: 'govuk-radios__input' %>
-          <%= label_tag :school_payroll_yes, 'Yes', class: 'govuk-label govuk-radios__label' %>
+          <%= radio_button_tag :payroll_provider, :school, checked?(params[:payroll_provider], 'school'), class: 'govuk-radios__input' %>
+          <%= label_tag :payroll_provider_school, 'Yes', class: 'govuk-label govuk-radios__label' %>
         </div>
         <div class="govuk-radios__item">
-          <%= radio_button_tag :school_payroll, :no, checked?(params[:school_payroll], 'no'), class: 'govuk-radios__input' %>
-          <%= label_tag :school_payroll_no, 'No, I want the agency to deal with payroll', class: 'govuk-label govuk-radios__label' %>
+          <%= radio_button_tag :payroll_provider, :agency, checked?(params[:payroll_provider], 'agency'), class: 'govuk-radios__input' %>
+          <%= label_tag :payroll_provider_agency, 'No, I want the agency to deal with payroll', class: 'govuk-label govuk-radios__label' %>
         </div>
       </div>
     </fieldset>

--- a/app/views/search/school_payroll.html.erb
+++ b/app/views/search/school_payroll.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag @form_path, method: :get do %>
-  <%= hidden_field_tag :hire_via_agency, params[:hire_via_agency] %>
+  <%= hidden_field_tag :looking_for, params[:looking_for] %>
   <%= hidden_field_tag :nominated_worker, params[:nominated_worker] %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">

--- a/app/views/search/school_payroll.html.erb
+++ b/app/views/search/school_payroll.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag @form_path, method: :get do %>
   <%= hidden_field_tag :looking_for, params[:looking_for] %>
-  <%= hidden_field_tag :nominated_worker, params[:nominated_worker] %>
+  <%= hidden_field_tag :worker_type, params[:worker_type] %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/app/views/search/school_payroll_question.html.erb
+++ b/app/views/search/school_payroll_question.html.erb
@@ -10,12 +10,12 @@
       </legend>
       <div class="govuk-radios">
         <div class="govuk-radios__item">
-          <%= radio_button_tag :school_payroll, :yes, checked?(params[:school_payroll], 'yes'), class: 'govuk-radios__input' %>
-          <%= label_tag :school_payroll_yes, 'Yes', class: 'govuk-label govuk-radios__label' %>
+          <%= radio_button_tag :payroll_provider, :school, checked?(params[:payroll_provider], 'school'), class: 'govuk-radios__input' %>
+          <%= label_tag :payroll_provider_school, 'Yes', class: 'govuk-label govuk-radios__label' %>
         </div>
         <div class="govuk-radios__item">
-          <%= radio_button_tag :school_payroll, :no, checked?(params[:school_payroll], 'no'), class: 'govuk-radios__input' %>
-          <%= label_tag :school_payroll_no, 'No, I want the agency to deal with payroll', class: 'govuk-label govuk-radios__label' %>
+          <%= radio_button_tag :payroll_provider, :agency, checked?(params[:payroll_provider], 'agency'), class: 'govuk-radios__input' %>
+          <%= label_tag :payroll_provider_agency, 'No, I want the agency to deal with payroll', class: 'govuk-label govuk-radios__label' %>
         </div>
       </div>
     </fieldset>

--- a/app/views/search/school_payroll_question.html.erb
+++ b/app/views/search/school_payroll_question.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag @form_path, method: :get do %>
-  <%= hidden_field_tag :hire_via_agency, params[:hire_via_agency] %>
+  <%= hidden_field_tag :looking_for, params[:looking_for] %>
   <%= hidden_field_tag :nominated_worker, params[:nominated_worker] %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">

--- a/app/views/search/school_payroll_question.html.erb
+++ b/app/views/search/school_payroll_question.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag @form_path, method: :get do %>
   <%= hidden_field_tag :looking_for, params[:looking_for] %>
-  <%= hidden_field_tag :nominated_worker, params[:nominated_worker] %>
+  <%= hidden_field_tag :worker_type, params[:worker_type] %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/app/views/search/school_postcode.html.erb
+++ b/app/views/search/school_postcode.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag @form_path, method: :get do %>
   <%= hidden_field_tag :nominated_worker, params[:nominated_worker] %>
-  <%= hidden_field_tag :hire_via_agency, params[:hire_via_agency] %>
+  <%= hidden_field_tag :looking_for, params[:looking_for] %>
   <%= hidden_field_tag :school_payroll, params[:school_payroll] %>
   <div class="govuk-form-group">
     <h1 class="govuk-label-wrapper">

--- a/app/views/search/school_postcode.html.erb
+++ b/app/views/search/school_postcode.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag @form_path, method: :get do %>
-  <%= hidden_field_tag :nominated_worker, params[:nominated_worker] %>
+  <%= hidden_field_tag :worker_type, params[:worker_type] %>
   <%= hidden_field_tag :looking_for, params[:looking_for] %>
   <%= hidden_field_tag :school_payroll, params[:school_payroll] %>
   <div class="govuk-form-group">

--- a/app/views/search/school_postcode.html.erb
+++ b/app/views/search/school_postcode.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag @form_path, method: :get do %>
   <%= hidden_field_tag :worker_type, params[:worker_type] %>
   <%= hidden_field_tag :looking_for, params[:looking_for] %>
-  <%= hidden_field_tag :school_payroll, params[:school_payroll] %>
+  <%= hidden_field_tag :payroll_provider, params[:payroll_provider] %>
   <div class="govuk-form-group">
     <h1 class="govuk-label-wrapper">
       <label class="govuk-label govuk-label--m" for="postcode">

--- a/spec/controllers/branches_controller_spec.rb
+++ b/spec/controllers/branches_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BranchesController, type: :controller do
       let(:request_params) do
         { postcode: postcode,
           nominated_worker: 'yes',
-          hire_via_agency: 'no',
+          looking_for: 'managed_service_provider',
           school_payroll: 'yes' }
       end
 
@@ -91,7 +91,7 @@ RSpec.describe BranchesController, type: :controller do
         {
           postcode: 'nonsense',
           nominated_worker: 'yes',
-          hire_via_agency: 'yes'
+          looking_for: 'worker'
         }
       end
 
@@ -120,7 +120,7 @@ RSpec.describe BranchesController, type: :controller do
         get :index, params: {
           postcode: postcode,
           nominated_worker: 'yes',
-          hire_via_agency: 'yes'
+          looking_for: 'worker'
         }
       end
 
@@ -130,7 +130,7 @@ RSpec.describe BranchesController, type: :controller do
             slug: 'school-postcode',
             postcode: postcode,
             nominated_worker: 'yes',
-            hire_via_agency: 'yes'
+            looking_for: 'worker'
           )
         )
       end

--- a/spec/controllers/branches_controller_spec.rb
+++ b/spec/controllers/branches_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BranchesController, type: :controller do
         { postcode: postcode,
           worker_type: 'nominated',
           looking_for: 'managed_service_provider',
-          school_payroll: 'yes' }
+          payroll_provider: 'school' }
       end
 
       before do

--- a/spec/controllers/branches_controller_spec.rb
+++ b/spec/controllers/branches_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe BranchesController, type: :controller do
       let(:postcode) { 'W1A 1AA' }
       let(:request_params) do
         { postcode: postcode,
-          nominated_worker: 'yes',
+          worker_type: 'nominated',
           looking_for: 'managed_service_provider',
           school_payroll: 'yes' }
       end
@@ -90,7 +90,7 @@ RSpec.describe BranchesController, type: :controller do
       let(:params) do
         {
           postcode: 'nonsense',
-          nominated_worker: 'yes',
+          worker_type: 'nominated',
           looking_for: 'worker'
         }
       end
@@ -119,7 +119,7 @@ RSpec.describe BranchesController, type: :controller do
         )
         get :index, params: {
           postcode: postcode,
-          nominated_worker: 'yes',
+          worker_type: 'nominated',
           looking_for: 'worker'
         }
       end
@@ -129,7 +129,7 @@ RSpec.describe BranchesController, type: :controller do
           search_question_path(
             slug: 'school-postcode',
             postcode: postcode,
-            nominated_worker: 'yes',
+            worker_type: 'nominated',
             looking_for: 'worker'
           )
         )

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe SearchController, type: :controller do
       params = {
         looking_for: 'worker',
         worker_type: 'agency_supplied',
-        school_payroll: 'yes'
+        payroll_provider: 'school'
       }
       get :question, params: params.merge(slug: 'school-postcode')
       expect(assigns(:back_path)).to eq(
@@ -240,7 +240,7 @@ RSpec.describe SearchController, type: :controller do
       params = {
         looking_for: 'worker',
         worker_type: 'agency_supplied',
-        school_payroll: 'yes',
+        payroll_provider: 'school',
         postcode: postcode
       }
       get :answer, params: params.merge(slug: 'school-postcode')
@@ -278,7 +278,7 @@ RSpec.describe SearchController, type: :controller do
         params = {
           looking_for: 'worker',
           worker_type: 'agency_supplied',
-          school_payroll: 'yes'
+          payroll_provider: 'school'
         }
         get :answer, params: params.merge(slug: 'school-payroll')
         expect(response).to redirect_to(
@@ -292,7 +292,7 @@ RSpec.describe SearchController, type: :controller do
         params = {
           looking_for: 'worker',
           worker_type: 'agency_supplied',
-          school_payroll: 'no'
+          payroll_provider: 'agency'
         }
         get :answer, params: params.merge(slug: 'school-payroll')
         expect(response).to redirect_to(
@@ -306,7 +306,7 @@ RSpec.describe SearchController, type: :controller do
         {
           looking_for: 'worker',
           worker_type: 'agency_supplied',
-          school_payroll: ''
+          payroll_provider: ''
         }
       end
 
@@ -331,7 +331,7 @@ RSpec.describe SearchController, type: :controller do
       params = {
         looking_for: 'worker',
         worker_type: 'agency_supplied',
-        school_payroll: 'no'
+        payroll_provider: 'agency'
       }
       get :question, params: params.merge(slug: 'agency-payroll')
       expect(assigns(:back_path)).to eq(

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe SearchController, type: :controller do
     let(:params) do
       {
         looking_for: 'worker',
-        nominated_worker: nominated_worker
+        worker_type: worker_type
       }
     end
 
@@ -140,7 +140,7 @@ RSpec.describe SearchController, type: :controller do
     end
 
     context 'when nominated worker is yes' do
-      let(:nominated_worker) { 'yes' }
+      let(:worker_type) { 'nominated' }
 
       it 'redirects to non nominated worker outcome' do
         expect(response).to redirect_to(
@@ -150,7 +150,7 @@ RSpec.describe SearchController, type: :controller do
     end
 
     context 'when nominated worker is no' do
-      let(:nominated_worker) { 'no' }
+      let(:worker_type) { 'agency_supplied' }
 
       it 'redirects to school payroll question path' do
         expect(response).to redirect_to(
@@ -160,7 +160,7 @@ RSpec.describe SearchController, type: :controller do
     end
 
     context 'when nominated worker is blank' do
-      let(:nominated_worker) { '' }
+      let(:worker_type) { '' }
 
       it 'redirects to nominated worker question' do
         expect(response).to redirect_to(
@@ -174,7 +174,7 @@ RSpec.describe SearchController, type: :controller do
     end
 
     context 'when nominated worker is unknown' do
-      let(:nominated_worker) { 'blahblah' }
+      let(:worker_type) { 'blahblah' }
 
       it 'redirects to nominated worker question' do
         expect(response).to redirect_to(
@@ -193,7 +193,7 @@ RSpec.describe SearchController, type: :controller do
       get :question, params: {
         slug: 'school-postcode',
         looking_for: 'worker',
-        nominated_worker: 'yes'
+        worker_type: 'nominated'
       }
       expect(response).to render_template('school_postcode')
     end
@@ -201,7 +201,7 @@ RSpec.describe SearchController, type: :controller do
     it 'sets back_path to nominated worker question including params' do
       params = {
         looking_for: 'worker',
-        nominated_worker: 'yes'
+        worker_type: 'nominated'
       }
       get :question, params: params.merge(slug: 'school-postcode')
       expect(assigns(:back_path)).to eq(
@@ -212,7 +212,7 @@ RSpec.describe SearchController, type: :controller do
     it 'sets form_path to school postcode answer path' do
       params = {
         looking_for: 'worker',
-        nominated_worker: 'yes'
+        worker_type: 'nominated'
       }
       get :question, params: params.merge(slug: 'school-postcode')
       expect(assigns(:form_path)).to eq(
@@ -223,7 +223,7 @@ RSpec.describe SearchController, type: :controller do
     it 'sets back path to school payroll question if employing worker on school payroll' do
       params = {
         looking_for: 'worker',
-        nominated_worker: 'no',
+        worker_type: 'agency_supplied',
         school_payroll: 'yes'
       }
       get :question, params: params.merge(slug: 'school-postcode')
@@ -239,7 +239,7 @@ RSpec.describe SearchController, type: :controller do
     it 'redirects to branches path' do
       params = {
         looking_for: 'worker',
-        nominated_worker: 'no',
+        worker_type: 'agency_supplied',
         school_payroll: 'yes',
         postcode: postcode
       }
@@ -252,7 +252,7 @@ RSpec.describe SearchController, type: :controller do
     it 'sets the form path to school payroll answer' do
       params = {
         looking_for: 'worker',
-        nominated_worker: 'no'
+        worker_type: 'agency_supplied'
       }
       get :question, params: params.merge(slug: 'school-payroll')
       expect(assigns(:form_path)).to eq(
@@ -263,7 +263,7 @@ RSpec.describe SearchController, type: :controller do
     it 'sets the back path to the nominated worker question' do
       params = {
         looking_for: 'worker',
-        nominated_worker: 'no'
+        worker_type: 'agency_supplied'
       }
       get :question, params: params.merge(slug: 'school-payroll')
       expect(assigns(:back_path)).to eq(
@@ -277,7 +277,7 @@ RSpec.describe SearchController, type: :controller do
       it 'redirects to postcode form' do
         params = {
           looking_for: 'worker',
-          nominated_worker: 'no',
+          worker_type: 'agency_supplied',
           school_payroll: 'yes'
         }
         get :answer, params: params.merge(slug: 'school-payroll')
@@ -291,7 +291,7 @@ RSpec.describe SearchController, type: :controller do
       it 'redirects to agency payroll outcome' do
         params = {
           looking_for: 'worker',
-          nominated_worker: 'no',
+          worker_type: 'agency_supplied',
           school_payroll: 'no'
         }
         get :answer, params: params.merge(slug: 'school-payroll')
@@ -305,7 +305,7 @@ RSpec.describe SearchController, type: :controller do
       let(:params) do
         {
           looking_for: 'worker',
-          nominated_worker: 'no',
+          worker_type: 'agency_supplied',
           school_payroll: ''
         }
       end
@@ -330,7 +330,7 @@ RSpec.describe SearchController, type: :controller do
     it 'sets the back link to the school payroll question' do
       params = {
         looking_for: 'worker',
-        nominated_worker: 'no',
+        worker_type: 'agency_supplied',
         school_payroll: 'no'
       }
       get :question, params: params.merge(slug: 'agency-payroll')

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -67,18 +67,18 @@ RSpec.describe SearchController, type: :controller do
     before do
       get :answer, params: {
         slug: 'managed-service-provider',
-        master_vendor: master_vendor,
+        managed_service_provider: managed_service_provider,
         looking_for: 'managed_service_provider'
       }
     end
 
     context 'when master vendor is yes' do
-      let(:master_vendor) { 'yes' }
+      let(:managed_service_provider) { 'master_vendor' }
 
       it 'redirects to master vendors path' do
         expect(response).to redirect_to(
           master_vendors_path(
-            master_vendor: master_vendor,
+            managed_service_provider: managed_service_provider,
             looking_for: 'managed_service_provider'
           )
         )
@@ -86,12 +86,12 @@ RSpec.describe SearchController, type: :controller do
     end
 
     context 'when master vendor is no' do
-      let(:master_vendor) { 'no' }
+      let(:managed_service_provider) { 'neutral_vendor' }
 
       it 'redirects to neutral vendors path' do
         expect(response).to redirect_to(
           neutral_vendors_path(
-            master_vendor: master_vendor,
+            managed_service_provider: managed_service_provider,
             looking_for: 'managed_service_provider'
           )
         )
@@ -99,13 +99,13 @@ RSpec.describe SearchController, type: :controller do
     end
 
     context 'when master vendor is blank' do
-      let(:master_vendor) { '' }
+      let(:managed_service_provider) { '' }
 
       it 'redirects to managed service provider question' do
         expect(response).to redirect_to(
           search_question_path(
             slug: 'managed-service-provider',
-            master_vendor: '',
+            managed_service_provider: '',
             looking_for: 'managed_service_provider'
           )
         )

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -14,36 +14,36 @@ RSpec.describe SearchController, type: :controller do
     before do
       get :answer, params: {
         slug: 'hire-via-agency',
-        hire_via_agency: hire_via_agency
+        looking_for: looking_for
       }
     end
 
     context 'when hire via agency is yes' do
-      let(:hire_via_agency) { 'yes' }
+      let(:looking_for) { 'worker' }
 
       it 'redirects to nominated worker question' do
         expect(response).to redirect_to(
-          search_question_path(slug: 'nominated-worker', hire_via_agency: 'yes')
+          search_question_path(slug: 'nominated-worker', looking_for: 'worker')
         )
       end
     end
 
     context 'when hire via agency is no' do
-      let(:hire_via_agency) { 'no' }
+      let(:looking_for) { 'managed_service_provider' }
 
       it 'redirects to managed service providers outcome' do
         expect(response).to redirect_to(
-          search_question_path(slug: 'managed-service-provider', hire_via_agency: 'no')
+          search_question_path(slug: 'managed-service-provider', looking_for: 'managed_service_provider')
         )
       end
     end
 
     context 'when hire via agency is blank' do
-      let(:hire_via_agency) { '' }
+      let(:looking_for) { '' }
 
       it 'redirects to hire via agency question' do
         expect(response).to redirect_to(
-          search_question_path(slug: 'hire-via-agency', hire_via_agency: '')
+          search_question_path(slug: 'hire-via-agency', looking_for: '')
         )
       end
 
@@ -57,7 +57,7 @@ RSpec.describe SearchController, type: :controller do
     it 'renders template' do
       get :question, params: {
         slug: 'managed-service-provider',
-        hire_via_agency: 'no'
+        looking_for: 'managed_service_provider'
       }
       expect(response).to render_template('managed_service_provider')
     end
@@ -68,7 +68,7 @@ RSpec.describe SearchController, type: :controller do
       get :answer, params: {
         slug: 'managed-service-provider',
         master_vendor: master_vendor,
-        hire_via_agency: 'no'
+        looking_for: 'managed_service_provider'
       }
     end
 
@@ -79,7 +79,7 @@ RSpec.describe SearchController, type: :controller do
         expect(response).to redirect_to(
           master_vendors_path(
             master_vendor: master_vendor,
-            hire_via_agency: 'no'
+            looking_for: 'managed_service_provider'
           )
         )
       end
@@ -92,7 +92,7 @@ RSpec.describe SearchController, type: :controller do
         expect(response).to redirect_to(
           neutral_vendors_path(
             master_vendor: master_vendor,
-            hire_via_agency: 'no'
+            looking_for: 'managed_service_provider'
           )
         )
       end
@@ -106,7 +106,7 @@ RSpec.describe SearchController, type: :controller do
           search_question_path(
             slug: 'managed-service-provider',
             master_vendor: '',
-            hire_via_agency: 'no'
+            looking_for: 'managed_service_provider'
           )
         )
       end
@@ -121,7 +121,7 @@ RSpec.describe SearchController, type: :controller do
     it 'renders template' do
       get :question, params: {
         slug: 'nominated-worker',
-        hire_via_agency: 'yes'
+        looking_for: 'worker'
       }
       expect(response).to render_template('nominated_worker')
     end
@@ -130,7 +130,7 @@ RSpec.describe SearchController, type: :controller do
   describe 'GET nominated_worker_answer' do
     let(:params) do
       {
-        hire_via_agency: 'yes',
+        looking_for: 'worker',
         nominated_worker: nominated_worker
       }
     end
@@ -192,7 +192,7 @@ RSpec.describe SearchController, type: :controller do
     it 'renders template' do
       get :question, params: {
         slug: 'school-postcode',
-        hire_via_agency: 'yes',
+        looking_for: 'worker',
         nominated_worker: 'yes'
       }
       expect(response).to render_template('school_postcode')
@@ -200,7 +200,7 @@ RSpec.describe SearchController, type: :controller do
 
     it 'sets back_path to nominated worker question including params' do
       params = {
-        hire_via_agency: 'yes',
+        looking_for: 'worker',
         nominated_worker: 'yes'
       }
       get :question, params: params.merge(slug: 'school-postcode')
@@ -211,7 +211,7 @@ RSpec.describe SearchController, type: :controller do
 
     it 'sets form_path to school postcode answer path' do
       params = {
-        hire_via_agency: 'yes',
+        looking_for: 'worker',
         nominated_worker: 'yes'
       }
       get :question, params: params.merge(slug: 'school-postcode')
@@ -222,7 +222,7 @@ RSpec.describe SearchController, type: :controller do
 
     it 'sets back path to school payroll question if employing worker on school payroll' do
       params = {
-        hire_via_agency: 'yes',
+        looking_for: 'worker',
         nominated_worker: 'no',
         school_payroll: 'yes'
       }
@@ -238,7 +238,7 @@ RSpec.describe SearchController, type: :controller do
 
     it 'redirects to branches path' do
       params = {
-        hire_via_agency: 'yes',
+        looking_for: 'worker',
         nominated_worker: 'no',
         school_payroll: 'yes',
         postcode: postcode
@@ -251,7 +251,7 @@ RSpec.describe SearchController, type: :controller do
   describe 'GET school_payroll_question' do
     it 'sets the form path to school payroll answer' do
       params = {
-        hire_via_agency: 'yes',
+        looking_for: 'worker',
         nominated_worker: 'no'
       }
       get :question, params: params.merge(slug: 'school-payroll')
@@ -262,7 +262,7 @@ RSpec.describe SearchController, type: :controller do
 
     it 'sets the back path to the nominated worker question' do
       params = {
-        hire_via_agency: 'yes',
+        looking_for: 'worker',
         nominated_worker: 'no'
       }
       get :question, params: params.merge(slug: 'school-payroll')
@@ -276,7 +276,7 @@ RSpec.describe SearchController, type: :controller do
     context 'when the answer is yes' do
       it 'redirects to postcode form' do
         params = {
-          hire_via_agency: 'yes',
+          looking_for: 'worker',
           nominated_worker: 'no',
           school_payroll: 'yes'
         }
@@ -290,7 +290,7 @@ RSpec.describe SearchController, type: :controller do
     context 'when the answer is no' do
       it 'redirects to agency payroll outcome' do
         params = {
-          hire_via_agency: 'yes',
+          looking_for: 'worker',
           nominated_worker: 'no',
           school_payroll: 'no'
         }
@@ -304,7 +304,7 @@ RSpec.describe SearchController, type: :controller do
     context 'when the answer is blank' do
       let(:params) do
         {
-          hire_via_agency: 'yes',
+          looking_for: 'worker',
           nominated_worker: 'no',
           school_payroll: ''
         }
@@ -329,7 +329,7 @@ RSpec.describe SearchController, type: :controller do
   describe 'GET agency_payroll_outcome' do
     it 'sets the back link to the school payroll question' do
       params = {
-        hire_via_agency: 'yes',
+        looking_for: 'worker',
         nominated_worker: 'no',
         school_payroll: 'no'
       }

--- a/spec/views/search/nominated_worker.html.erb_spec.rb
+++ b/spec/views/search/nominated_worker.html.erb_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe 'search/nominated_worker.html.erb' do
   it 'stores answer to hire via agency question in hidden field' do
     @back_path = '/'
     @form_path = '/'
-    params[:hire_via_agency] = 'hire-via-agency'
+    params[:looking_for] = 'looking-for'
     render
-    expect(rendered).to have_css('input[name="hire_via_agency"][value="hire-via-agency"]', visible: false)
+    expect(rendered).to have_css('input[name="looking_for"][value="looking-for"]', visible: false)
   end
 end

--- a/spec/views/search/school_payroll.html.erb_spec.rb
+++ b/spec/views/search/school_payroll.html.erb_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe 'search/school_payroll.html.erb' do
   end
 
   it 'stores answer to hire via agency question in hidden field' do
-    params[:hire_via_agency] = 'hire-via-agency'
+    params[:looking_for] = 'looking-for'
     render
-    expect(rendered).to have_css('input[name="hire_via_agency"][value="hire-via-agency"]', visible: false)
+    expect(rendered).to have_css('input[name="looking_for"][value="looking-for"]', visible: false)
   end
 
   it 'stores answer to nominated worker question in hidden field' do

--- a/spec/views/search/school_payroll.html.erb_spec.rb
+++ b/spec/views/search/school_payroll.html.erb_spec.rb
@@ -18,15 +18,15 @@ RSpec.describe 'search/school_payroll.html.erb' do
     expect(rendered).to have_css('input[name="worker_type"][value="worker-type"]', visible: false)
   end
 
-  it 'selects "yes" if school payroll is "yes"' do
-    params[:school_payroll] = 'yes'
+  it 'selects "school" if payroll provider is "school"' do
+    params[:payroll_provider] = 'school'
     render
-    expect(rendered).to have_css('input[type="radio"][name="school_payroll"][value="yes"][checked]')
+    expect(rendered).to have_css('input[type="radio"][name="payroll_provider"][value="school"][checked]')
   end
 
-  it 'selects "no" if school payroll is "no"' do
-    params[:school_payroll] = 'no'
+  it 'selects "agency" if payroll provider is "agency"' do
+    params[:payroll_provider] = 'agency'
     render
-    expect(rendered).to have_css('input[type="radio"][name="school_payroll"][value="no"][checked]')
+    expect(rendered).to have_css('input[type="radio"][name="payroll_provider"][value="agency"][checked]')
   end
 end

--- a/spec/views/search/school_payroll.html.erb_spec.rb
+++ b/spec/views/search/school_payroll.html.erb_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe 'search/school_payroll.html.erb' do
   end
 
   it 'stores answer to nominated worker question in hidden field' do
-    params[:nominated_worker] = 'nominated-worker'
+    params[:worker_type] = 'worker-type'
     render
-    expect(rendered).to have_css('input[name="nominated_worker"][value="nominated-worker"]', visible: false)
+    expect(rendered).to have_css('input[name="worker_type"][value="worker-type"]', visible: false)
   end
 
   it 'selects "yes" if school payroll is "yes"' do

--- a/spec/views/search/school_postcode.html.erb_spec.rb
+++ b/spec/views/search/school_postcode.html.erb_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe 'search/school_postcode.html.erb' do
   end
 
   it 'stores answer to school payroll question in hidden field' do
-    params[:school_payroll] = 'school-payroll'
+    params[:payroll_provider] = 'payroll-provider'
     render
-    expect(rendered).to have_css('input[name="school_payroll"][value="school-payroll"]', visible: false)
+    expect(rendered).to have_css('input[name="payroll_provider"][value="payroll-provider"]', visible: false)
   end
 end

--- a/spec/views/search/school_postcode.html.erb_spec.rb
+++ b/spec/views/search/school_postcode.html.erb_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe 'search/school_postcode.html.erb' do
   end
 
   it 'stores answer to hire via agency question in hidden field' do
-    params[:hire_via_agency] = 'hire-via-agency'
+    params[:looking_for] = 'looking-for'
     render
-    expect(rendered).to have_css('input[name="hire_via_agency"][value="hire-via-agency"]', visible: false)
+    expect(rendered).to have_css('input[name="looking_for"][value="looking-for"]', visible: false)
   end
 
   it 'stores answer to nominated worker question in hidden field' do

--- a/spec/views/search/school_postcode.html.erb_spec.rb
+++ b/spec/views/search/school_postcode.html.erb_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe 'search/school_postcode.html.erb' do
   end
 
   it 'stores answer to nominated worker question in hidden field' do
-    params[:nominated_worker] = 'nominated-worker'
+    params[:worker_type] = 'worker-type'
     render
-    expect(rendered).to have_css('input[name="nominated_worker"][value="nominated-worker"]', visible: false)
+    expect(rendered).to have_css('input[name="worker_type"][value="worker-type"]', visible: false)
   end
 
   it 'stores answer to school payroll question in hidden field' do


### PR DESCRIPTION
The parameter names became a bit confusing after we renamed some of the questions and options.

I _think_ the changes in this PR make the names a bit clearer but I'm not 100%.

NOTE. If we think this is a good idea then I still need to:

* Rename JourneyStep classes and template
* Update test descriptions to reflect the parameter name changes.
