### PR TITLE
WIP: Upload regions for FM suppliers

### DIFF
--- a/app/controllers/facilities_management_suppliers_controller.rb
+++ b/app/controllers/facilities_management_suppliers_controller.rb
@@ -1,14 +1,17 @@
 class FacilitiesManagementSuppliersController < ApplicationController
   def lot1a_suppliers
     @back_path = source_journey.current_step_path
+    @suppliers = FacilitiesManagementSupplier.available_in_lot('1a')
   end
 
   def lot1b_suppliers
     @back_path = source_journey.current_step_path
+    @suppliers = FacilitiesManagementSupplier.available_in_lot('1b')
   end
 
   def lot1c_suppliers
     @back_path = source_journey.current_step_path
+    @suppliers = FacilitiesManagementSupplier.available_in_lot('1c')
   end
 
   private

--- a/app/models/facilities_management_regional_availability.rb
+++ b/app/models/facilities_management_regional_availability.rb
@@ -1,0 +1,15 @@
+class FacilitiesManagementRegionalAvailability < ApplicationRecord
+  LOT_NUMBERS = {
+    '1a' => 'Total contract value up to £7M',
+    '1b' => 'Total contract value £7M - £50M',
+    '1c' => 'Total contract value over £50M'
+  }.freeze
+
+  belongs_to :supplier,
+             class_name: 'FacilitiesManagementSupplier',
+             foreign_key: :facilities_management_supplier_id,
+             inverse_of: :regional_availabilities
+
+  validates :lot_number, presence: true
+  validates :nuts2_code, presence: true
+end

--- a/app/models/facilities_management_supplier.rb
+++ b/app/models/facilities_management_supplier.rb
@@ -1,6 +1,19 @@
 class FacilitiesManagementSupplier < ApplicationRecord
+  has_many :regional_availabilities,
+           class_name: 'FacilitiesManagementRegionalAvailability',
+           inverse_of: :supplier,
+           dependent: :destroy
+
   validates :name, presence: true
   validates :contact_name, presence: true
   validates :contact_email, presence: true
   validates :telephone_number, presence: true
+
+  def self.available_in_lot(lot_number)
+    FacilitiesManagementRegionalAvailability
+      .includes(:supplier)
+      .where(lot_number: lot_number)
+      .map(&:supplier)
+      .uniq
+  end
 end

--- a/app/models/facilities_management_upload.rb
+++ b/app/models/facilities_management_upload.rb
@@ -22,12 +22,24 @@ class FacilitiesManagementUpload
   end
 
   def self.create_supplier!(data)
-    FacilitiesManagementSupplier.create!(
+    supplier = FacilitiesManagementSupplier.create!(
       id: data['supplier_id'],
       name: data['supplier_name'],
       contact_name: data['contact_name'],
       contact_email: data['contact_email'],
       telephone_number: data['contact_phone']
     )
+
+    lots = data.fetch('lots', [])
+    lots.each do |lot|
+      lot_number = lot['lot_number']
+      regions = lot.fetch('regions', [])
+      regions.each do |region|
+        supplier.regional_availabilities.create!(
+          lot_number: lot_number,
+          nuts2_code: region
+        )
+      end
+    end
   end
 end

--- a/app/views/facilities_management_suppliers/lot1a_suppliers.html.erb
+++ b/app/views/facilities_management_suppliers/lot1a_suppliers.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h2>Lot 1a suppliers</h2>
   <p>Total contract value up to &pound;7M</p>
-  <p>27 suppliers</p>
+  <p><%= @suppliers.count %></p>
   <p>
     <a href="https://ccs-agreements.cabinetoffice.gov.uk/suppliers?sm_field_contract_id=%22RM3830%3A1a%22" title="View suppliers">See a list of suppliers without pricing information</a>
   </p>

--- a/app/views/facilities_management_suppliers/lot1b_suppliers.html.erb
+++ b/app/views/facilities_management_suppliers/lot1b_suppliers.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h2>Lot 1b suppliers</h2>
   <p>Total contract value &pound;7M - &pound;50M</p>
-  <p>34 suppliers</p>
+  <p><%= @suppliers.count %></p>
   <p>
     <a href="https://ccs-agreements.cabinetoffice.gov.uk/suppliers?sm_field_contract_id=%22RM3830%3A1b%22" title="View suppliers">See a list of suppliers without pricing information</a>
   </p>

--- a/app/views/facilities_management_suppliers/lot1c_suppliers.html.erb
+++ b/app/views/facilities_management_suppliers/lot1c_suppliers.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h2>Lot 1c suppliers</h2>
   <p>Total contract value &pound;50M+</p>
-  <p>20 suppliers</p>
+  <p><%= @suppliers.count %></p>
   <p>
     <a href="https://ccs-agreements.cabinetoffice.gov.uk/suppliers?sm_field_contract_id=%22RM3830%3A1c%22" title="View suppliers">See a list of suppliers without pricing information</a>
   </p>

--- a/db/migrate/20181031200527_create_facilities_management_regional_availabilities.rb
+++ b/db/migrate/20181031200527_create_facilities_management_regional_availabilities.rb
@@ -1,0 +1,12 @@
+class CreateFacilitiesManagementRegionalAvailabilities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :facilities_management_regional_availabilities, id: :uuid do |t|
+      t.references :facilities_management_supplier,
+                   foreign_key: true, type: :uuid, null: false,
+                   index: { name: 'index_fm_regional_availabilities_on_fm_supplier_id' }
+      t.text :lot_number, null: false
+      t.text :nuts2_code, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_31_191820) do
+ActiveRecord::Schema.define(version: 2018_10_31_200527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -29,6 +29,15 @@ ActiveRecord::Schema.define(version: 2018_10_31_191820) do
     t.text "name"
     t.text "town"
     t.index ["supplier_id"], name: "index_branches_on_supplier_id"
+  end
+
+  create_table "facilities_management_regional_availabilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "facilities_management_supplier_id", null: false
+    t.text "lot_number", null: false
+    t.text "nuts2_code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["facilities_management_supplier_id"], name: "index_fm_regional_availabilities_on_fm_supplier_id"
   end
 
   create_table "facilities_management_suppliers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -59,5 +68,6 @@ ActiveRecord::Schema.define(version: 2018_10_31_191820) do
   end
 
   add_foreign_key "branches", "suppliers"
+  add_foreign_key "facilities_management_regional_availabilities", "facilities_management_suppliers"
   add_foreign_key "rates", "suppliers"
 end


### PR DESCRIPTION
This is a rough sketch of what how I'm planning to model the region data for FM suppliers. You can see an example of the JSON data [here](https://github.com/Crown-Commercial-Service/cmp-supply-teacher-data/blob/master/facilities-management/json/data.json).

@threedaymonk Does what I've done here make sense in the context of what you've done with NUTS regions? Am I right in thinking the region codes in the JSON are NUTS2 codes?

@techbelly Does this make sense given what we were talking about earlier today. I'm imagining adding a similar `FacilitiesManagementSupplier#service_availabilities` association with `lot_number`, `work_package`, `name` & `code` attributes to model the data from the other sheet. Note that this is slightly different from how @chrislo was modelling the associations - see [this commit](https://github.com/Crown-Commercial-Service/crown-marketplace/commit/15f4e640be45f44955e8f4dfdda925c5faf22e92) for details. I'm not planning on modelling the lots or the services in the database, but using static data like we have for the supply teachers.
