### PR TITLE
Add table prefix to supply teacher tables

### DIFF
--- a/app/models/supply_teachers.rb
+++ b/app/models/supply_teachers.rb
@@ -1,2 +1,5 @@
 module SupplyTeachers
+  def self.table_name_prefix
+    'supply_teachers_'
+  end
 end

--- a/app/models/supply_teachers/branch.rb
+++ b/app/models/supply_teachers/branch.rb
@@ -2,7 +2,9 @@ module SupplyTeachers
   class Branch < ApplicationRecord
     DEFAULT_SEARCH_RANGE_IN_MILES = 25
 
-    belongs_to :supplier
+    belongs_to :supplier,
+               foreign_key: :supply_teachers_supplier_id,
+               inverse_of: :branches
 
     validates :postcode, presence: true, postcode: true
     validates :location, presence: true
@@ -24,7 +26,7 @@ module SupplyTeachers
       Branch.near(point, within_metres: metres)
             .joins(supplier: [:rates])
             .merge(rates)
-            .order('rates.mark_up')
+            .order('supply_teachers_rates.mark_up')
             .order(Arel.sql("ST_Distance(location, '#{point}')"))
     end
   end

--- a/app/models/supply_teachers/rate.rb
+++ b/app/models/supply_teachers/rate.rb
@@ -26,7 +26,9 @@ module SupplyTeachers
       'more_than_twelve_weeks' => 'Over 12 weeks'
     }.freeze
 
-    belongs_to :supplier
+    belongs_to :supplier,
+               foreign_key: :supply_teachers_supplier_id,
+               inverse_of: :branches
 
     validates :lot_number, presence: true,
                            uniqueness: { scope: %i[supplier term job_type] },

--- a/app/models/supply_teachers/supplier.rb
+++ b/app/models/supply_teachers/supplier.rb
@@ -1,7 +1,13 @@
 module SupplyTeachers
   class Supplier < ApplicationRecord
-    has_many :branches, dependent: :destroy
-    has_many :rates, dependent: :destroy
+    has_many :branches,
+             foreign_key: :supply_teachers_supplier_id,
+             inverse_of: :supplier,
+             dependent: :destroy
+    has_many :rates,
+             foreign_key: :supply_teachers_supplier_id,
+             inverse_of: :supplier,
+             dependent: :destroy
 
     validates :name, presence: true
 

--- a/db/migrate/20181113163200_add_supply_teachers_prefixes.rb
+++ b/db/migrate/20181113163200_add_supply_teachers_prefixes.rb
@@ -1,0 +1,17 @@
+class AddSupplyTeachersPrefixes < ActiveRecord::Migration[5.2]
+  def up
+    rename_table :branches, :supply_teachers_branches
+    rename_column :supply_teachers_branches, :supplier_id, :supply_teachers_supplier_id
+    rename_table :rates, :supply_teachers_rates
+    rename_column :supply_teachers_rates, :supplier_id, :supply_teachers_supplier_id
+    rename_table :suppliers, :supply_teachers_suppliers
+  end
+
+  def down
+    rename_table :supply_teachers_suppliers, :suppliers
+    rename_column :supply_teachers_rates, :supply_teachers_supplier_id, :supplier_id
+    rename_table :supply_teachers_rates, :rates
+    rename_column :supply_teachers_branches, :supply_teachers_supplier_id, :supplier_id
+    rename_table :supply_teachers_branches, :branches
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,26 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_13_140044) do
+ActiveRecord::Schema.define(version: 2018_11_13_163200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "postgis"
-
-  create_table "branches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "supplier_id", null: false
-    t.string "postcode", limit: 8, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
-    t.text "contact_name"
-    t.text "contact_email"
-    t.text "telephone_number"
-    t.text "name"
-    t.text "town"
-    t.index ["supplier_id"], name: "index_branches_on_supplier_id"
-  end
 
   create_table "facilities_management_regional_availabilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "facilities_management_supplier_id", null: false
@@ -75,8 +61,22 @@ ActiveRecord::Schema.define(version: 2018_11_13_140044) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "rates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "supplier_id", null: false
+  create_table "supply_teachers_branches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "supply_teachers_supplier_id", null: false
+    t.string "postcode", limit: 8, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
+    t.text "contact_name"
+    t.text "contact_email"
+    t.text "telephone_number"
+    t.text "name"
+    t.text "town"
+    t.index ["supply_teachers_supplier_id"], name: "index_supply_teachers_branches_on_supply_teachers_supplier_id"
+  end
+
+  create_table "supply_teachers_rates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "supply_teachers_supplier_id", null: false
     t.text "job_type", null: false
     t.float "mark_up"
     t.datetime "created_at", null: false
@@ -84,18 +84,18 @@ ActiveRecord::Schema.define(version: 2018_11_13_140044) do
     t.text "term"
     t.integer "lot_number", default: 1, null: false
     t.money "daily_fee", scale: 2
-    t.index ["supplier_id"], name: "index_rates_on_supplier_id"
+    t.index ["supply_teachers_supplier_id"], name: "index_supply_teachers_rates_on_supply_teachers_supplier_id"
   end
 
-  create_table "suppliers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "supply_teachers_suppliers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "branches", "suppliers"
   add_foreign_key "facilities_management_regional_availabilities", "facilities_management_suppliers"
   add_foreign_key "facilities_management_service_offerings", "facilities_management_suppliers"
   add_foreign_key "management_consultancy_service_offerings", "management_consultancy_suppliers"
-  add_foreign_key "rates", "suppliers"
+  add_foreign_key "supply_teachers_branches", "supply_teachers_suppliers"
+  add_foreign_key "supply_teachers_rates", "supply_teachers_suppliers"
 end


### PR DESCRIPTION
This makes them consistent with facilities management, and avoids the confusion of a `suppliers` table that could apply to different models.