### PR TITLE
Improve typography for supply teachers

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -3,8 +3,6 @@
 @import "govuk-frontend/components/breadcrumbs/breadcrumbs";
 @import "govuk-frontend/components/checkboxes/checkboxes";
 @import "govuk-frontend/components/date-input/date-input";
-@import "govuk-frontend/components/error-message/error-message";
-@import "govuk-frontend/components/error-summary/error-summary";
 @import "govuk-frontend/components/file-upload/file-upload";
 @import "govuk-frontend/components/hint/hint";
 @import "govuk-frontend/components/input/input";
@@ -22,6 +20,8 @@
 @import "back-link/back-link";
 @import "button/button";
 @import "details/details";
+@import "error-message/error-message";
+@import "error-summary/error-summary";
 @import "header/header";
 @import "footer/footer";
 @import "fieldset/fieldset";

--- a/app/assets/stylesheets/components/error-message/_error-message.scss
+++ b/app/assets/stylesheets/components/error-message/_error-message.scss
@@ -1,0 +1,5 @@
+@import "govuk-frontend/components/error-message/error-message";
+
+.govuk-error-message {
+	font-weight: $govuk-font-weight-semi-bold;
+}

--- a/app/assets/stylesheets/components/error-summary/_error-summary.scss
+++ b/app/assets/stylesheets/components/error-summary/_error-summary.scss
@@ -1,0 +1,9 @@
+@import "govuk-frontend/components/error-summary/error-summary";
+
+.govuk-error-summary__title {
+	font-weight: $govuk-font-weight-semi-bold;
+}
+
+.govuk-error-summary__list a {
+	font-weight: $govuk-font-weight-semi-bold;	
+}

--- a/app/assets/stylesheets/components/label/_label.scss
+++ b/app/assets/stylesheets/components/label/_label.scss
@@ -3,4 +3,5 @@
 .govuk-label--m {
   line-height: 2;
   margin-bottom: 5px;
+  font-weight: $govuk-font-weight-semi-bold;
 }

--- a/app/assets/stylesheets/components/master-vendor-record/_master-vendor-record.scss
+++ b/app/assets/stylesheets/components/master-vendor-record/_master-vendor-record.scss
@@ -3,6 +3,6 @@
 }
 
 .master-vendor-record__markup-rate {
-  font-weight: 600;
+  font-weight: $govuk-font-weight-semi-bold;
   margin-bottom: 0;
 }

--- a/app/assets/stylesheets/components/supplier-record/_supplier-record.scss
+++ b/app/assets/stylesheets/components/supplier-record/_supplier-record.scss
@@ -20,7 +20,7 @@
 
 .supplier-record__markup-rate,
 .supplier-record__distance {
-    font-weight: 600;
+    font-weight: $govuk-font-weight-semi-bold;;
     margin-bottom: 0;
 }
 
@@ -45,7 +45,7 @@
     text-align: center;
     line-height: 2.45;
     text-transform: uppercase;
-    font-weight: 600;
+    font-weight: $govuk-font-weight-semi-bold;;
     content: "";
 }
 

--- a/app/assets/stylesheets/components/typography/_typography.scss
+++ b/app/assets/stylesheets/components/typography/_typography.scss
@@ -1,7 +1,15 @@
 @import "govuk-frontend/core/typography";
 
+strong {
+	font-weight: $govuk-font-weight-semi-bold;	
+}
 .govuk-heading-xl {
 	font-weight: $govuk-font-weight-light;
 	margin-bottom: 36px;
 	line-height: 1.15;
+}
+.govuk-heading-l,
+.govuk-heading-m,
+.govuk-heading-s {
+	font-weight: $govuk-font-weight-semi-bold;
 }

--- a/app/views/journey/_managed_service_providers_explanation.html.erb
+++ b/app/views/journey/_managed_service_providers_explanation.html.erb
@@ -2,12 +2,15 @@
   <%= t('.header') %>
 </h2>
 <p class="govuk-body"><%= t('.introduction') %></p>
-<h4 class="govuk-heading-s"><%= t('.option1_header') %></h4>
+<h3 class="govuk-heading-s"><%= t('.option1_header') %></h3>
 <p class="govuk-body">
-  <%= t('.option1_body_html') %>
+  <%= t('.option1_body_html1') %>
+</p>
+<p class="govuk-body">
+  <%= t('.option1_body_html2') %>
 </p>
 <p class="govuk-body"><%= t('.option_separator') %></p>
-<h4 class="govuk-heading-s"><%= t('.option2_header') %></h4>
+<h3 class="govuk-heading-s"><%= t('.option2_header') %></h3>
 <p class="govuk-body">
   <%= t('.option2_body_html') %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,10 +82,10 @@ en:
     managed_service_providers_explanation:
       header: Managed service providers
       introduction: 'You will need to choose either:'
-      option1_body_html: |
-        These supply whatever candidates they can. Where they don’t have a suitable candidate themselves, they find other suppliers who do.
-        <br>
-        You will then need to contact all the suppliers and run a further competition.
+      option1_body_html1: 'These supply whatever candidates they can. Where they don’t have a suitable candidate themselves, they find other suppliers who do.
+
+'
+      option1_body_html2: You will then need to contact all the suppliers and run a further competition.
       option1_header: A master vendor
       option2_body_html: 'A neutral vendor only provides candidates from other suppliers - they have no candidates of their own.
 


### PR DESCRIPTION
Improved font-weight of Supply Teachers in general. Also fixed spacing problems of typography in the individual worker / managed service provider selection page. 