### PR TITLE
styling the master vendor page

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -11,7 +11,6 @@
 @import "govuk-frontend/components/tabs/tabs";
 @import "govuk-frontend/components/radios/radios";
 @import "govuk-frontend/components/select/select";
-@import "govuk-frontend/components/table/table";
 @import "govuk-frontend/components/textarea/textarea";
 @import "govuk-frontend/components/warning-text/warning-text";
 
@@ -32,5 +31,6 @@
 @import "phase-banner/phase-banner";
 @import "sidebar/sidebar";
 @import "supplier-record/supplier-record";
+@import "table/table";
 @import "tag/tag";
 @import "typography/typography";

--- a/app/assets/stylesheets/components/master-vendor-record/_master-vendor-record.scss
+++ b/app/assets/stylesheets/components/master-vendor-record/_master-vendor-record.scss
@@ -6,3 +6,7 @@
   font-weight: $govuk-font-weight-semi-bold;
   margin-bottom: 0;
 }
+
+.master-vendor-record__markup-column {
+	width: 20%;
+}

--- a/app/assets/stylesheets/components/table/_table.scss
+++ b/app/assets/stylesheets/components/table/_table.scss
@@ -1,0 +1,18 @@
+@import "govuk-frontend/components/table/table";
+
+.govuk-table__caption {
+  font-weight: $govuk-font-weight-semi-bold;
+  margin-bottom: 10px;	
+}
+
+.govuk-table__header {
+  font-weight: $govuk-font-weight-semi-bold;
+}
+
+.govuk-table__cell--numeric {
+  font-family: $govuk-font-family;
+}
+
+.govuk-table__header, .govuk-table__cell {
+	padding-right: 0;
+}

--- a/app/models/supply_teachers/rate.rb
+++ b/app/models/supply_teachers/rate.rb
@@ -22,7 +22,7 @@ module SupplyTeachers
 
     TERMS = {
       'one_week' => 'Up to 1 week',
-      'twelve_weeks' => '1 week to 12 weeks',
+      'twelve_weeks' => '1 to 12 weeks',
       'more_than_twelve_weeks' => 'Over 12 weeks'
     }.freeze
 

--- a/app/views/supply_teachers/suppliers/_master_vendor.html.erb
+++ b/app/views/supply_teachers/suppliers/_master_vendor.html.erb
@@ -1,45 +1,36 @@
 <div class="master-vendor-record">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m govuk-!-font-size-27"><%= master_vendor.name %></h2>
-    </div>
-  </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
-      <p><strong><%= t('.column1') %>:</strong></p>
-    </div>
-    <div class="govuk-grid-column-two-thirds">
-      <p><strong><%= t('.column2') %>:</strong></p>
-    </div>
-  </div>
-  <% master_vendor.master_vendor_rates_grouped_by_job_type.each do |job_type, rates| %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <p><%= SupplyTeachers::Rate::JOB_TYPES[job_type] %></p>
-      </div>
-      <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-grid-row">
+
+  <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-!-font-size-27"><%= master_vendor.name %></caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"><strong><%= t('.column1') %></strong></th>
+        <th class="govuk-table__header govuk-table__cell--numeric" scope="col" colspan="3"><strong><%= t('.column2') %></strong></th>
+      </tr>
+    </thead>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col"></th>
+        <th class="govuk-table__header govuk-table__header--numeric master-vendor-record__markup-column" scope="col"><strong><%= SupplyTeachers::Rate::TERMS['one_week'] %></strong></th>
+        <th class="govuk-table__header govuk-table__header--numeric master-vendor-record__markup-column" scope="col"><strong><%= SupplyTeachers::Rate::TERMS['twelve_weeks'] %></strong></th>
+        <th class="govuk-table__header govuk-table__header--numeric master-vendor-record__markup-column" scope="col"><strong><%= SupplyTeachers::Rate::TERMS['more_than_twelve_weeks'] %></strong></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% master_vendor.master_vendor_rates_grouped_by_job_type.each do |job_type, rates| %>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row"><%= SupplyTeachers::Rate::JOB_TYPES[job_type] %></th>
           <% if rates.length == 1 %>
-            <div class="govuk-grid-column-full">
-              <p class="govuk-body govuk-!-font-size-36 master-vendor-record__markup-rate">
-                <%= number_to_percentage(rates.first.mark_up * 100, precision: 1) %>
-              </p>
-            </div>
+            <% 3.times do %>
+              <td class="govuk-table__cell govuk-table__cell--numeric master-vendor-record__markup-column"><%= number_to_percentage(rates.first.mark_up * 100, precision: 1) %></td>
+            <% end %>          
           <% elsif rates.length == 3 %>
             <% rates.each do |rate| %>
-              <div class="govuk-grid-column-one-third">
-                <p class="govuk-body govuk-!-font-size-36 master-vendor-record__markup-rate">
-                  <%= number_to_percentage(rate.mark_up * 100, precision: 1) %>
-                </p>
-                <p>
-                  <%= SupplyTeachers::Rate::TERMS[rate.term] %>
-                </p>
-              </div>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_to_percentage(rate.mark_up * 100, precision: 1) %></td>
             <% end %>
           <% end %>
-        </div>
-      </div>
-    </div>
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-  <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 </div>

--- a/spec/features/managed_service_providers.features_spec.rb
+++ b/spec/features/managed_service_providers.features_spec.rb
@@ -33,12 +33,12 @@ RSpec.feature 'Managed service providers', type: :feature do
     click_on I18n.t('common.submit')
 
     expect(page).to have_css('h1', text: 'Master vendor managed service')
-    expect(page).to have_css('h2', text: supplier.name)
+    expect(page).to have_css('caption', text: supplier.name)
 
     expect(page).to have_rates(job_type: 'Qualified Teacher - Non-SEN', percentages: [11.0, 12.0, 13.0])
     expect(page).to have_rates(job_type: 'Qualified Teacher - SEN', percentages: [21.0, 22.0, 23.0])
-    expect(page).to have_rates(job_type: 'Nominated workers', percentages: [30.0], with_terms: false)
-    expect(page).to have_rates(job_type: 'Fixed Term workers', percentages: [40.0], with_terms: false)
+    expect(page).to have_rates(job_type: 'Nominated workers', percentages: [30.0, 30.0, 30.0])
+    expect(page).to have_rates(job_type: 'Fixed Term workers', percentages: [40.0, 40.0, 40.0])
   end
 
   scenario 'Buyer wants to hire a neutral vendor managed service' do
@@ -59,9 +59,9 @@ RSpec.feature 'Managed service providers', type: :feature do
     expect(page).to have_css('h1', text: 'Neutral vendor managed service')
     expect(page).to have_css('h2', text: 'neutral-vendor-supplier')
 
-    expect(page).to have_rates(job_type: 'Nominated workers', percentages: [30.0], with_terms: false)
+    expect(page).to have_rates(job_type: 'Nominated workers', percentages: [30.0])
     expect(page).to have_rates(job_type: 'Neutral vendor managed service provider fee (per day)',
-                               percentages: [], amount: 1.23, with_terms: false)
+                               percentages: [], amount: 1.23)
   end
 
   scenario 'Buyer changes mind about hiring a managed service provider' do
@@ -112,13 +112,12 @@ RSpec.feature 'Managed service providers', type: :feature do
 
   private
 
-  def have_rates(job_type:, percentages:, amount: nil, with_terms: true)
+  def have_rates(job_type:, percentages:, amount: nil)
     rate_patterns = if percentages.any?
                       percentages.map { |p| rate_pattern(p) }
                     else
                       [daily_fee_pattern(amount)]
                     end
-    rate_patterns = rate_patterns.dup.zip(SupplyTeachers::Rate::TERMS.values) if with_terms
     combined_pattern = [Regexp.escape(job_type), *rate_patterns].join('\s+')
     have_text(Regexp.new(combined_pattern))
   end

--- a/spec/views/supply_teachers/suppliers/_master_vendor.html.erb_spec.rb
+++ b/spec/views/supply_teachers/suppliers/_master_vendor.html.erb_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe 'supply_teachers/suppliers/_master_vendor.html.erb' do
     end
 
     it 'displays rates for each term' do
-      expect(rendered).to have_text(/11\.0%\s+Up to 1 week/)
-      expect(rendered).to have_text(/12\.0%\s+1 week to 12 weeks/)
-      expect(rendered).to have_text(/13\.0%\s+Over 12 weeks/)
+      expect(rendered).to have_text(/11\.0%\s/)
+      expect(rendered).to have_text(/12\.0%\s/)
+      expect(rendered).to have_text(/13\.0%\s/)
     end
   end
 


### PR DESCRIPTION
# WIP - rake test need to be fixed

- `features/managed_service_providers.features_spec.rb:38` fails. We believe this is because the `with_terms` parameter of `have_rates` is now obsolete because every row has a value?
- We fixed `_master_vendor.html.erb_spec.rb` by removing the `terms` from `expect(rendered).to have_text(/11\.0%\s/)`. Please confirm if this is the correct way.

## Trello card URL: 
https://trello.com/c/pyhVSZIJ/167-clean-up-repeating-labels-on-master-service-provider-page

## Changes in this PR:
- Mark-up label moved to the top
- govuk-table introduced
- New styling for supplier records
- Fixed term / Nominated workers rates repeated 3 times

## Screenshots of UI changes:

### Before
![screencapture-cmp-cmpdev-crowncommercial-gov-uk-supply-teachers-master-vendors-2018-11-15-12_03_01](https://user-images.githubusercontent.com/6421298/48551837-92e22000-e8ce-11e8-865a-930e59f2f32a.png)

### After
![screencapture-localhost-3000-supply-teachers-master-vendors-2018-11-15-12_03_12](https://user-images.githubusercontent.com/6421298/48551850-983f6a80-e8ce-11e8-8436-f82053aa1101.png)
