### PR TITLE
fixed download icons

### DIFF
--- a/app/assets/stylesheets/components/supplier-record/_supplier-record.scss
+++ b/app/assets/stylesheets/components/supplier-record/_supplier-record.scss
@@ -49,7 +49,7 @@
     content: "";
 }
 
-.supplier-record__file-download[href*='.xlsx']:before {
+.supplier-record__file-download[href*='format=xlsx']:before {
     background-color: #007831;
     content: ".XLSX";
 }


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/GLvM4Gf7/210-fix-download-icons

## Changes in this PR:
- Added back the green colour for download icons

## Screenshots of UI changes:

### Before
![screen shot 2018-11-19 at 12 36 20](https://user-images.githubusercontent.com/6421298/48707816-8b858400-ebf8-11e8-9059-85771d632c92.png)


### After
![screen shot 2018-11-19 at 12 36 28](https://user-images.githubusercontent.com/6421298/48707821-90e2ce80-ebf8-11e8-91b4-6e3cf0a5e6c0.png)

