### PR TITLE
Buyers selection section redesigned

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -6,7 +6,6 @@
 @import "govuk-frontend/components/file-upload/file-upload";
 @import "govuk-frontend/components/hint/hint";
 @import "govuk-frontend/components/input/input";
-@import "govuk-frontend/components/inset-text/inset-text";
 @import "govuk-frontend/components/panel/panel";
 @import "govuk-frontend/components/tabs/tabs";
 @import "govuk-frontend/components/radios/radios";
@@ -25,6 +24,7 @@
 @import "footer/footer";
 @import "fieldset/fieldset";
 @import "fm-supplier-record/fm-supplier-record";
+@import "inset-text/inset-text";
 @import "label/label";
 @import "master-vendor-record/master-vendor-record";
 @import "mc-supplier-record/mc-supplier-record";

--- a/app/assets/stylesheets/components/inset-text/_inset-text.scss
+++ b/app/assets/stylesheets/components/inset-text/_inset-text.scss
@@ -1,0 +1,12 @@
+@import "govuk-frontend/components/inset-text/inset-text";
+
+$ccs_inset-text_bg: govuk-colour("grey-4");
+$ccs_inset-text_border: govuk-colour("grey-2");
+
+.govuk-inset-text {
+	background-color:$ccs_inset-text_bg; 
+	border-left:4px solid $ccs_inset-text_border;
+}
+.cmp-inset-text__list-item {
+	font-size: 16px;
+}

--- a/app/views/supply_teachers/branches/index.html.erb
+++ b/app/views/supply_teachers/branches/index.html.erb
@@ -2,17 +2,15 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl cmp-page-heading"><%= t('.header') %></h1>
 
-    <table class="govuk-table inputs">
-      <caption class="govuk-table__caption"><%= t('.inputs_header') %></caption>
-      <tbody class="govuk-table__body">
+    <div class="govuk-inset-text">
+      <h2 class="govuk-heading-s"><%= t('.inputs_header') %></h2>
+      <ul class="govuk-list govuk-list--bullet">
         <% @journey.inputs.each do |question_key, answer| %>
-          <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="row"><%= t(".inputs.#{question_key}") %></th>
-            <td class="govuk-table__cell"><%= answer %></td>
-          </tr>
+        <li class="cmp-inset-text__list-item"><%= t(".inputs.#{question_key}") %>: <%= answer %></li>
         <% end %>
-      </tbody>
-    </table>
+      </ul>
+    </div>
+
     <p class="govuk-body">
       <% if @location %>
       <span class="govuk-body-l"><%= @branches.count %></span> <%= t('.results_found_with_location_html', range: default_search_range, postcode: @location.postcode) %>

--- a/spec/views/supply_teachers/branches/index.html.erb_spec.rb
+++ b/spec/views/supply_teachers/branches/index.html.erb_spec.rb
@@ -43,16 +43,10 @@ RSpec.describe 'supply_teachers/branches/index.html.erb' do
     render
   end
 
-  it 'displays the inputs to the list' do
-    expect(rendered).to have_css('.inputs td', text: /Individual worker/)
-    expect(rendered).to have_css('.inputs td', text: /Nominated/)
-    expect(rendered).to have_css('.inputs td', text: /SW1A 1AA/)
-  end
-
-  it 'displays headings for the inputs' do
-    expect(rendered).to have_css('.inputs th', text: /Looking for/)
-    expect(rendered).to have_css('.inputs th', text: /Worker type/)
-    expect(rendered).to have_css('.inputs th', text: /Postcode/)
+  it 'displays the buyers selection' do
+    expect(rendered).to have_css('.govuk-inset-text li', text: /Looking for\: Individual worker/)
+    expect(rendered).to have_css('.govuk-inset-text li', text: /Worker type\: Nominated/)
+    expect(rendered).to have_css('.govuk-inset-text li', text: /Postcode\: SW1A 1AA/)
   end
 
   it 'displays headings for suppliers for each branch' do


### PR DESCRIPTION
## Trello card URL:
60-buyers-can-see-the-selections-theyve-made-to-refine-the-shortlist-of-suppliers

## Changes in this PR:
- Use inset-text and list instead of table for the Buyers Selection section

## Screenshots of UI changes:

### Before
![screen shot 2018-11-20 at 11 33 52](https://user-images.githubusercontent.com/6421298/48772848-79214e00-ecbd-11e8-8703-83c85c5951c3.png)


### After
![screen shot 2018-11-20 at 11 33 31](https://user-images.githubusercontent.com/6421298/48772853-80485c00-ecbd-11e8-8b84-e2065d4eecc7.png)
