### PR TITLE
Neutral vendor page re-designed

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -28,6 +28,7 @@
 @import "label/label";
 @import "master-vendor-record/master-vendor-record";
 @import "mc-supplier-record/mc-supplier-record";
+@import "neutral-vendor-record/neutral-vendor-record";
 @import "phase-banner/phase-banner";
 @import "sidebar/sidebar";
 @import "supplier-record/supplier-record";

--- a/app/assets/stylesheets/components/neutral-vendor-record/_neutral-vendor-record.scss
+++ b/app/assets/stylesheets/components/neutral-vendor-record/_neutral-vendor-record.scss
@@ -1,0 +1,12 @@
+.neutral-vendor-record {
+  padding-bottom: 20px;
+}
+
+.neutral-vendor-record__markup-rate {
+  font-weight: $govuk-font-weight-semi-bold;
+  margin-bottom: 0;
+}
+
+.neutral-vendor-record__markup-column {
+	width: 20%;
+}

--- a/app/views/supply_teachers/suppliers/neutral_vendors.html.erb
+++ b/app/views/supply_teachers/suppliers/neutral_vendors.html.erb
@@ -2,6 +2,48 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl cmp-page-heading"><%= t('.header') %></h1>
     <% SupplyTeachers::Supplier.with_neutral_vendor_rates.each do |supplier| %>
+      <div class="neutral-vendor-record">
+        <table class="govuk-table">
+          <caption class="govuk-table__caption govuk-!-font-size-27"><%= supplier.name %></caption>
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col"><strong><%= t('.column1') %></strong></th>
+              <th class="govuk-table__header govuk-table__cell--numeric" scope="col" colspan="3"><strong><%= t('.column2') %></strong></th>
+            </tr>
+          </thead>
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col"></th>
+              <th class="govuk-table__header govuk-table__header--numeric master-vendor-record__markup-column" scope="col"><strong><%= SupplyTeachers::Rate::TERMS['one_week'] %></strong></th>
+              <th class="govuk-table__header govuk-table__header--numeric master-vendor-record__markup-column" scope="col"><strong><%= SupplyTeachers::Rate::TERMS['twelve_weeks'] %></strong></th>
+              <th class="govuk-table__header govuk-table__header--numeric master-vendor-record__markup-column" scope="col"><strong><%= SupplyTeachers::Rate::TERMS['more_than_twelve_weeks'] %></strong></th>
+            </tr>
+          </thead>
+          <% supplier.rates.each do |rate| %>
+          <tbody class="govuk-table__body">
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="row"><%= SupplyTeachers::Rate::JOB_TYPES[rate.job_type] %></th>
+                <% 3.times do %>
+                <td class="govuk-table__cell govuk-table__cell--numeric master-vendor-record__markup-column">
+                  <% if rate.percentage_mark_up? %>
+                    <%= number_to_percentage(rate.mark_up * 100, precision: 1) %>
+                  <% else %>
+                    <%= number_to_currency(rate.daily_fee, unit: '£') %>
+                  <% end %>
+                </td>
+                <% end %>          
+               </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  </div>
+
+<!--
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl cmp-page-heading"><%= t('.header') %></h1>
+    <% SupplyTeachers::Supplier.with_neutral_vendor_rates.each do |supplier| %>
       <h2 class="govuk-heading-m"><%= supplier.name %></h2>
       <% supplier.rates.each do |rate| %>
         <p>
@@ -15,4 +57,5 @@
       <% end %>
     <% end %>
   </div>
+-->
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,8 @@ en:
       master_vendors:
         header: Master vendor managed service providers
       neutral_vendors:
+        column1: Job type
+        column2: Supplier mark-up
         header: Neutral vendor managed service providers
   temp_to_perm_calculator:
     home:

--- a/spec/features/managed_service_providers.features_spec.rb
+++ b/spec/features/managed_service_providers.features_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Managed service providers', type: :feature do
     click_on I18n.t('common.submit')
 
     expect(page).to have_css('h1', text: 'Neutral vendor managed service')
-    expect(page).to have_css('h2', text: 'neutral-vendor-supplier')
+    expect(page).to have_css('caption', text: 'neutral-vendor-supplier')
 
     expect(page).to have_rates(job_type: 'Nominated workers', percentages: [30.0])
     expect(page).to have_rates(job_type: 'Neutral vendor managed service provider fee (per day)',


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/bOymrBH7/200-apply-this-same-table-layout-to-the-neutral-vendor-page

## Changes in this PR:
- Applied `<table>` to the Neutral vendor managed service providers page

## Screenshots of UI changes:

### Before
![screencapture-cmp-cmpdev-crowncommercial-gov-uk-supply-teachers-neutral-vendors-2018-11-20-14_22_04](https://user-images.githubusercontent.com/6421298/48779532-b2fb5000-eccf-11e8-9bec-cf5b8da5d549.png)


### After
![screencapture-localhost-3000-supply-teachers-neutral-vendors-2018-11-19-17_00_02](https://user-images.githubusercontent.com/6421298/48779468-93fcbe00-eccf-11e8-8325-02c4801f23e9.png)
