### PR TITLE
(feature) styling the distance switcher

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -31,6 +31,7 @@
 @import "neutral-vendor-record/neutral-vendor-record";
 @import "phase-banner/phase-banner";
 @import "sidebar/sidebar";
+@import "st-supplier-page/st-supplier-page";
 @import "supplier-record/supplier-record";
 @import "table/table";
 @import "tag/tag";

--- a/app/assets/stylesheets/components/st-supplier-page/_st-supplier-page.scss
+++ b/app/assets/stylesheets/components/st-supplier-page/_st-supplier-page.scss
@@ -1,0 +1,3 @@
+.st-supplier-page__radius-list-item {
+	margin-right: 10px;
+}

--- a/app/views/supply_teachers/branches/index.html.erb
+++ b/app/views/supply_teachers/branches/index.html.erb
@@ -14,11 +14,15 @@
     <p class="govuk-body">
       <% if @location %>
         <span class="govuk-body-l"><%= @branches.count %></span> <%= t('.results_found_with_location_html', range: number_to_human(@radius_in_miles, units: :miles), postcode: @location.postcode) %>
+        <%= t('.other_radius_html') %>
         <% @alternative_radiuses.each do |radius| %>
+          <span class="st-supplier-page__radius-list-item">
           <%= link_to(
                 number_to_human(radius, units: :miles),
-                supply_teachers_branches_path(@journey.params.merge(radius: radius))
+                supply_teachers_branches_path(@journey.params.merge(radius: radius)),
+                'aria-label' => t('.distance_aria_label_html', radius_setting:number_to_human(radius, units: :miles)) 
               ) %>
+          </span>
         <% end %>
       <% else %>
         <span class="govuk-body-l"><%= @branches.count %></span> <%= t('.results_found') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,6 +212,7 @@ en:
         markup: Mark-up
         miles: Miles
       index:
+        distance_aria_label_html: Set the radius to %{radius_setting}
         download: Download shortlist of suppliers
         download_aria_label: Download shortlist as Microsoft Excel file
         download_with_calculator: Download shortlist (with markup calculator)
@@ -227,9 +228,10 @@ en:
           term: Term
           worker_type: Worker type
         inputs_header: Choices used to generate this list
+        other_radius_html: 'Change this distance to: '
         print: Print this page
         results_found: results found
-        results_found_with_location_html: results found within <strong>%{range}</strong> of <strong>%{postcode}</strong>
+        results_found_with_location_html: results found within <strong>%{range}</strong> of <strong>%{postcode}</strong> .
     journey:
       agency_payroll:
         postcode_question: What is your school’s postcode?


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/xTQuNtzq/226-buyers-can-refine-the-search-results-by-location-search-radius

## Changes in this PR:
- Styled the distance switcher

## Screenshots of UI changes:

### Before
![screen shot 2018-11-26 at 10 24 39](https://user-images.githubusercontent.com/6421298/49008517-f0475e00-f165-11e8-8a5c-d003c8c5b09d.png)


### After
![screen shot 2018-11-26 at 10 11 46](https://user-images.githubusercontent.com/6421298/49008527-f5a4a880-f165-11e8-8f0d-b27dcda3f04a.png)
