### PR TITLE
(fix) Change service name for Supply Teachers

### DIFF
--- a/app/views/supply_teachers/home/index.html.erb
+++ b/app/views/supply_teachers/home/index.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">Find supply teachers and non-teaching staff</h1>
+      <h1 class="govuk-heading-xl">Find supply teachers and agency workers</h1>
 
       <p>Use this service to:</p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,7 +113,7 @@ en:
       intro_paragraph: 'Use this service to:'
       management_consultancy_link: Find management consultancy services
       service_title: Crown Marketplace
-      supply_teachers_link: Find supply teachers and non-teaching staff
+      supply_teachers_link: Find supply teachers and agency workers
       temp_to_perm_calculator_link: Calculate the fee you have to pay when recruiting a supply teacher
   journey:
     error_summary:


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/l4hycEA2/257-change-service-name

## Changes in this PR:
- Change service name from 'Find supply teachers and non-teaching staff' to 'Find supply teachers and agency workers'

## Screenshots of UI changes:

### Before
![screenshot 2018-11-28 at 12 03 52](https://user-images.githubusercontent.com/6421298/49150911-2e7b8380-f306-11e8-8e5b-8fcdc275be80.png)

![screenshot 2018-11-28 at 12 03 41](https://user-images.githubusercontent.com/6421298/49150917-31767400-f306-11e8-935e-ed528a8f8b35.png)


### After
![screenshot 2018-11-28 at 12 03 18](https://user-images.githubusercontent.com/6421298/49150934-3cc99f80-f306-11e8-81b5-27e6f26bc802.png)

![screenshot 2018-11-28 at 12 03 28](https://user-images.githubusercontent.com/6421298/49150939-405d2680-f306-11e8-81da-37765c72ba26.png)

