### PR TITLE
Add a link to the header so that users can go back to the start page …

### DIFF
--- a/app/assets/stylesheets/components/header/_header.scss
+++ b/app/assets/stylesheets/components/header/_header.scss
@@ -21,8 +21,21 @@ $ccs_header_fg: govuk-colour("white");
   height: 90px;
 }
 
+.govuk-header__content {
+  display: flex;
+  justify-content: space-between;
+}
+
+.govuk-header__link--service-name {
+  font-weight: $govuk-font-weight-semi-bold;
+}
+
 .govuk-header__navigation  {
   text-align: right;
+}
+
+.govuk-header__navigation-item {
+  padding: 0;
 }
 
 .ccs-header__signout {

--- a/app/views/facilities_management/_link_to_start_page.html.erb
+++ b/app/views/facilities_management/_link_to_start_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to 'Facilities management', facilities_management_path %>
+<%= link_to t('home.index.facilities_management_link'), facilities_management_path, { class: 'govuk-header__link govuk-header__link--service-name', 'aria-label' => t('layouts.header.go_start_page_aria_label', service_name:t('home.index.facilities_management_link')) } %>

--- a/app/views/management_consultancy/_link_to_start_page.html.erb
+++ b/app/views/management_consultancy/_link_to_start_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to 'Management consultancy', management_consultancy_path %>
+<%= link_to t('home.index.management_consultancy_link'), management_consultancy_path, { class: 'govuk-header__link govuk-header__link--service-name', 'aria-label' => t('layouts.header.go_start_page_aria_label', service_name:t('home.index.management_consultancy_link')) } %>

--- a/app/views/supply_teachers/_link_to_start_page.html.erb
+++ b/app/views/supply_teachers/_link_to_start_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to 'Supply teachers', supply_teachers_path %>
+<%= link_to t('home.index.supply_teachers_link'), supply_teachers_path, { class: 'govuk-header__link govuk-header__link--service-name', 'aria-label' => t('layouts.header.go_start_page_aria_label', service_name:t('home.index.supply_teachers_link')) } %>

--- a/app/views/temp_to_perm_calculator/_link_to_start_page.html.erb
+++ b/app/views/temp_to_perm_calculator/_link_to_start_page.html.erb
@@ -1,1 +1,1 @@
-<%= link_to 'Temp-to-perm calculator', temp_to_perm_calculator_path %>
+<%= link_to t('home.index.temp_to_perm_calculator_link'), temp_to_perm_calculator_path, { class: 'govuk-header__link govuk-header__link--service-name', 'aria-label' => t('layouts.header.go_start_page_aria_label', service_name:t('home.index.temp_to_perm_calculator_link')) } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,8 @@ en:
       support_aria_label: Email us for support with this service
       support_email_html: Email %{link} for support.
       title: Crown Commercial Service
+    header:
+      go_start_page_aria_label: Go to start page of %{service_name}
   management_consultancy:
     journey:
       choose_expenses:


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/MoHIbdGc/255-buyers-can-go-back-to-the-start-page

## Changes in this PR:
- Style the link of service name in the header area
- Add aria-label to the link of service name

## Screenshots of UI changes:

### Before
![screenshot 2018-11-28 at 15 22 49 copy](https://user-images.githubusercontent.com/6421298/49163011-07cc4580-f324-11e8-8fa8-f012fcea4cd8.png)
![screenshot 2018-11-28 at 15 23 01 copy](https://user-images.githubusercontent.com/6421298/49163012-0864dc00-f324-11e8-91a6-c6574d492072.png)
![screenshot 2018-11-28 at 15 23 25 copy](https://user-images.githubusercontent.com/6421298/49163013-0864dc00-f324-11e8-9481-68660cdc3d77.png)
![screenshot 2018-11-28 at 15 23 43 copy](https://user-images.githubusercontent.com/6421298/49163016-0864dc00-f324-11e8-88e5-1af5ebc3fa90.png)


### After
![screenshot 2018-11-28 at 15 22 49](https://user-images.githubusercontent.com/6421298/49162910-cdfb3f00-f323-11e8-8732-95f6d33721b8.png)
![screenshot 2018-11-28 at 15 23 01](https://user-images.githubusercontent.com/6421298/49162912-cdfb3f00-f323-11e8-9d2d-8ead41fcbb1c.png)
![screenshot 2018-11-28 at 15 23 25](https://user-images.githubusercontent.com/6421298/49162913-ce93d580-f323-11e8-87f6-83458565a3bf.png)
![screenshot 2018-11-28 at 15 23 43](https://user-images.githubusercontent.com/6421298/49162914-ce93d580-f323-11e8-8605-aa02b4bc05fc.png)

