### PR TITLE
(fix) styling the temp-to-perm results page

### DIFF
--- a/app/views/temp_to_perm_calculator/home/fee.html.erb
+++ b/app/views/temp_to_perm_calculator/home/fee.html.erb
@@ -1,16 +1,19 @@
 <div class="govuk-body">
   <div class="govuk-grid-row">
-    <div class="govuk-panel govuk-panel--confirmation">
-      <h1 class="govuk-panel__title">
-        <%= t('.header') %>
-      </h1>
-      <div class="govuk-panel__body">
-        <%= t('.panel_body') %>
-        <br><strong><%= number_to_currency(@calculator.early_hire_fee) %></strong>
+    <div class="govuk-grid-column-full">
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title">
+          <%= t('.header') %>
+        </h1>
+        <div class="govuk-panel__body">
+          <%= t('.panel_body') %>
+          <br><strong><%= number_to_currency(@calculator.early_hire_fee) %></strong>
+        </div>
       </div>
     </div>
-
-    <div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h2>Explanation</h2>
       <% if @calculator.before_national_deal_began? %>
       <p>The contract start date you have given, <%= @calculator.contract_start_date.to_formatted_s(:long) %>, is before the National Deal was awarded. The terms of the deal may not apply to this worker, unless you have since agreed with the supplier that they should.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,7 +320,7 @@ en:
   temp_to_perm_calculator:
     home:
       fee:
-        header: Fee
+        header: Temp-to-perm fee
         panel_body: Based on the information provided you could be charged
     journey:
       contract_start:


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/I94H6lGo/253-temp-to-perm-calculator-results-page-styling

## Changes in this PR:
- Changed the label from `Fee` to `Temp-to-perm fee`
- Put all content into the full width container
- Put the content below the panel into the 2/3 container

## Screenshots of UI changes:

### Before
![screencapture-cmp-cmpdev-crowncommercial-gov-uk-temp-to-perm-calculator-fee-2018-11-29-18_09_14](https://user-images.githubusercontent.com/6421298/49242440-b050d700-f402-11e8-90a8-45250cb90b28.png)


### After
![screencapture-localhost-3000-temp-to-perm-calculator-fee-2018-11-29-18_08_28](https://user-images.githubusercontent.com/6421298/49242451-b646b800-f402-11e8-8a25-682f4e491948.png)
