### PR TITLE
(fix) visually distinguished the calculator option

### DIFF
--- a/app/views/supply_teachers/journey/looking_for.html.erb
+++ b/app/views/supply_teachers/journey/looking_for.html.erb
@@ -22,6 +22,7 @@
               <%= radio_button_tag :looking_for, :managed_service_provider, checked?(params[:looking_for], 'managed_service_provider'), class: 'govuk-radios__input' %>
               <%= label_tag :looking_for_managed_service_provider, t('.answer_managed_service_provider'), class: 'govuk-label govuk-radios__label' %>
             </div>
+            <div class="govuk-radios__divider">or</div>
             <div class="govuk-radios__item">
               <%= radio_button_tag :looking_for, :calculate_temp_to_perm_fee, checked?(params[:looking_for], 'calculate_temp_to_perm_fee'), class: 'govuk-radios__input' %>
               <%= label_tag :looking_for_calculate_temp_to_perm_fee, t('.answer_calculate_temp_to_perm_fee'), class: 'govuk-label govuk-radios__label' %>


### PR DESCRIPTION
## Trello card URL:
275-visually-distinguish-the-calculator-option-from-the-options-to-continue-the-primary-journey

## Changes in this PR:
- Added "or" to visually distinguish the calculator option from others.

## Screenshots of UI changes:

### Before
![screencapture-cmp-cmpdev-crowncommercial-gov-uk-supply-teachers-looking-for-2018-12-03-08_54_13](https://user-images.githubusercontent.com/6421298/49363754-702b7600-f6da-11e8-8fea-33a3362ae49e.png)


### After
![screencapture-localhost-3000-supply-teachers-looking-for-2018-12-03-09_00_27](https://user-images.githubusercontent.com/6421298/49363734-64d84a80-f6da-11e8-9e14-d2e31d9ad676.png)

