### PR TITLE
(fix) ST homepage bullet point updated

### DIFF
--- a/app/views/supply_teachers/home/index.html.erb
+++ b/app/views/supply_teachers/home/index.html.erb
@@ -10,7 +10,7 @@
         <li>find and hire a worker, using an agency</li>
         <li>hire a specific person (a ‘nominated worker’)</li>
         <li>find a managed service provider, who can take on all your temporary staff needs</li>
-        <li>create a shortlist of suppliers based on your needs and download or save it</li>
+        <li>create a shortlist of suppliers based on your needs and download it</li>
       </ul>
 
       <%= link_to 'Start now', journey_start_url(journey: SupplyTeachers::Journey.journey_name), role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' %>


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/61z7N0qv/278-amend-start-page-content-to-remove-reference-to-saving

## Changes in this PR:
- Update bullet point content of homepage of Supply Teachers

## Screenshots of UI changes:

### Before
<img width="1015" alt="screenshot 2018-12-03 at 15 29 05" src="https://user-images.githubusercontent.com/6421298/49383463-b6033100-f710-11e8-990a-1146c83abb8b.png">

### After
<img width="1028" alt="screenshot 2018-12-03 at 15 29 17" src="https://user-images.githubusercontent.com/6421298/49383468-b996b800-f710-11e8-9495-42d255010297.png">

