### PR TITLE
(fix) added accreditation message to start page

### DIFF
--- a/app/assets/stylesheets/components/typography/_typography.scss
+++ b/app/assets/stylesheets/components/typography/_typography.scss
@@ -13,3 +13,6 @@ strong {
 .govuk-heading-s {
 	font-weight: $govuk-font-weight-semi-bold;
 }
+.cmp-start-page__sub-heading {
+	margin-top: 40px;
+}

--- a/app/views/supply_teachers/home/index.html.erb
+++ b/app/views/supply_teachers/home/index.html.erb
@@ -1,10 +1,10 @@
-<div class="govuk-body">
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
       <h1 class="govuk-heading-xl">Find supply teachers and agency workers</h1>
 
-      <p>Use this service to:</p>
+      <p class="govuk-body">Use this service to:</p>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>find and hire a worker, using an agency</li>
@@ -17,18 +17,22 @@
 
       <h2 class="govuk-heading-m">Before you start</h2>
 
-      <p>To use the service, you will need to register for an account and get login details.</p>
+      <p class="govuk-body">To use the service, you will need to register for an account and get login details.</p>
 
-      <p>You will also need to have:</p>
+      <p class="govuk-body">You will also need to have:</p>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>your school’s postcode</li>
         <li>details of how long you will want the worker</li>
       </ul>
 
-      <p>You can’t use this service if you’re an independent school, unless you have charitable status.</p>
+      <p class="govuk-body">You can’t use this service if you’re an independent school, unless you have charitable status.</p>
 
-      <p>To find permanent teaching staff, use the <a href="https://teaching-jobs.service.gov.uk/">Teaching Jobs</a> service.</p>
+      <p class="govuk-body">To find permanent teaching staff, use the <a href="https://teaching-jobs.service.gov.uk/">Teaching Jobs</a> service.</p>
+
+      <h2 class="govuk-heading-m cmp-start-page__sub-heading">Accreditation of suppliers</h2>
+
+      <p class="govuk-body">All suppliers have undergone background screening and safeguarding to DfE's Keeping Children Safe in Education standards. They are audited and accredited against best practice standards in education recruitment.</p>
+
     </div>
   </div>
-</div>


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/6P7FatyC/264-explain-what-accreditation-these-suppliers-have-and-what-it-tells-buyers-about-them

## Changes in this PR:
- Added the explanation of accreditation suppliers to the bottom of Start page

## Screenshots of UI changes:

### Before
<img width="998" alt="screenshot 2018-12-03 at 16 41 44" src="https://user-images.githubusercontent.com/6421298/49387848-ba344c00-f71a-11e8-99f8-057da2256bd4.png">


### After
<img width="1012" alt="screenshot 2018-12-03 at 16 41 28" src="https://user-images.githubusercontent.com/6421298/49387853-bf919680-f71a-11e8-96d8-ca7780fa594e.png">
