### PR TITLE
(fix) re-wording and re-writing calculator questions

### DIFF
--- a/app/views/supply_teachers/journey/contract_start.html.erb
+++ b/app/views/supply_teachers/journey/contract_start.html.erb
@@ -47,6 +47,45 @@
         <% end %>
       <% end %>
 
+      <%= govuk_form_group_with_optional_error(@journey, :days_per_week) do %>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <h1 class="govuk-fieldset__heading">
+            <%= t('.days_per_week_question') %>
+          </h1>
+        </legend>
+        <%= display_error(@journey, :days_per_week) %>
+        <span class="govuk-hint">
+          <%= t('.days_per_week_question_hint') %>
+        </span>
+        <%= text_field_tag :days_per_week, params[:days_per_week], class: css_classes_for_input(@journey, :days_per_week, ['govuk-input--width-10']) %>
+      <% end %>
+
+      <%= govuk_form_group_with_optional_error(@journey, :day_rate) do %>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <h1 class="govuk-fieldset__heading">
+            <%= t('.day_rate_question') %>
+          </h1>
+        </legend>
+        <%= display_error(@journey, :day_rate) %>
+        <span class="govuk-hint">
+          <%= t('.day_rate_question_hint') %>
+        </span>
+        <%= text_field_tag :day_rate, params[:day_rate], class: css_classes_for_input(@journey, :day_rate, ['govuk-input--width-10']) %>
+      <% end %>
+
+      <%= govuk_form_group_with_optional_error(@journey, :markup_rate) do %>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <h1 class="govuk-fieldset__heading">
+            <%= t('.markup_rate_question') %>
+          </h1>
+        </legend>
+        <%= display_error(@journey, :markup_rate) %>
+        <span class="govuk-hint">
+          <%= t('.markup_rate_question_hint') %>
+        </span>
+        <%= text_field_tag :markup_rate, params[:markup_rate], class: css_classes_for_input(@journey, :markup_rate, ['govuk-input--width-10']) %>
+      <% end %>
+
       <%= govuk_form_group_with_optional_error(@journey, :hire_date_day, :hire_date_month, :hire_date_year) do %>
         <%= govuk_fieldset_with_optional_error(@journey, :hire_date_day, :hire_date_month, :hire_date_year) do %>
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
@@ -88,46 +127,7 @@
           </div>
         <% end %>
       <% end %>
-
-      <%= govuk_form_group_with_optional_error(@journey, :days_per_week) do %>
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('.days_per_week_question') %>
-          </h1>
-        </legend>
-        <%= display_error(@journey, :days_per_week) %>
-        <span class="govuk-hint">
-          <%= t('.days_per_week_question_hint') %>
-        </span>
-        <%= text_field_tag :days_per_week, params[:days_per_week], class: css_classes_for_input(@journey, :days_per_week, ['govuk-input--width-10']) %>
-      <% end %>
-
-      <%= govuk_form_group_with_optional_error(@journey, :day_rate) do %>
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('.day_rate_question') %>
-          </h1>
-        </legend>
-        <%= display_error(@journey, :day_rate) %>
-        <span class="govuk-hint">
-          <%= t('.day_rate_question_hint') %>
-        </span>
-        <%= text_field_tag :day_rate, params[:day_rate], class: css_classes_for_input(@journey, :day_rate, ['govuk-input--width-10']) %>
-      <% end %>
-
-      <%= govuk_form_group_with_optional_error(@journey, :markup_rate) do %>
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('.markup_rate_question') %>
-          </h1>
-        </legend>
-        <%= display_error(@journey, :markup_rate) %>
-        <span class="govuk-hint">
-          <%= t('.markup_rate_question_hint') %>
-        </span>
-        <%= text_field_tag :markup_rate, params[:markup_rate], class: css_classes_for_input(@journey, :markup_rate, ['govuk-input--width-10']) %>
-      <% end %>
-
+      
       <%= submit_tag t('common.submit'), class: "govuk-button" %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,15 +286,15 @@ en:
         worker_term_question: How long do you need the worker for?
         worker_type_question: What type of worker do you need?
       contract_start:
-        contract_start_question: What date was the worker first supplied to you on their current contract?
+        contract_start_question: When did the worker's current contract start?
         contract_start_question_hint: For example, 31 3 1980
-        day_rate_question: What is the supplier’s total day rate for the worker?
-        day_rate_question_hint: An amount in pounds. For example, 500
-        days_per_week_question: How many days per week is the worker contracted to work?
+        day_rate_question: What does the agency charge you per day for the worker?
+        day_rate_question_hint: An amount in pounds. For example, 150
+        days_per_week_question: How many days per week is the worker contracted for?
         days_per_week_question_hint: For example, 5
-        hire_date_question: What date do you want to hire them from?
+        hire_date_question: What date do you want to take the worker on permanently from?
         hire_date_question_hint: For example, 31 3 1980
-        markup_rate_question: What mark-up does the supplier charge for the worker?
+        markup_rate_question: What mark-up does the agency charge for the worker?
         markup_rate_question_hint: This is the percentage fee you agreed with the supplier. For example, 40
       looking_for:
         answer_calculate_temp_to_perm_fee: To calculate the fee you'll be charged if you make an agency worker permanent


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/ZFEIIHXN/209-iterate-the-content-for-temp-to-perm-calculation

## Changes in this PR:
- Re-wording the 5 questions
- Re-ordering the questions
- Changed the hint of day rate

## Screenshots of UI changes:

### Before
![screencapture-cmp-cmpdev-crowncommercial-gov-uk-supply-teachers-contract-start-2018-12-03-17_35_44](https://user-images.githubusercontent.com/6421298/49392233-ca055d80-f725-11e8-9eaf-2ee1ca49da81.png)


### After
![screencapture-localhost-3000-supply-teachers-contract-start-2018-12-03-17_56_08](https://user-images.githubusercontent.com/6421298/49392243-ce317b00-f725-11e8-990b-d47efd7cccc4.png)
