### PR TITLE
(fix) mark-up explanation added

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -37,6 +37,8 @@ $govuk-colours: (
   "grey-4": #f8f8f8,
   "grey-5": #eeeeee,
   "white": #ffffff,
+  "green-2": #F0FFF1,
+  "green-3": #006435,
 
   "link": #007194,
   "link-hover": #15a0cc,

--- a/app/assets/stylesheets/components/inset-text/_inset-text.scss
+++ b/app/assets/stylesheets/components/inset-text/_inset-text.scss
@@ -1,11 +1,21 @@
 @import "govuk-frontend/components/inset-text/inset-text";
 
-$ccs_inset-text_bg: govuk-colour("grey-4");
-$ccs_inset-text_border: govuk-colour("grey-2");
+$ccs_inset-text_bg_grey: govuk-colour("grey-4");
+$ccs_inset-text_border_grey: govuk-colour("grey-2");
+$ccs_inset-text_bg_green: govuk-colour("green-2");
+$ccs_inset-text_border_green: govuk-colour("green-3");
 
-.govuk-inset-text {
-	background-color:$ccs_inset-text_bg; 
-	border-left:4px solid $ccs_inset-text_border;
+.cmp-inset-text--success {
+	background-color:$ccs_inset-text_bg_green; 
+	border-left:4px solid $ccs_inset-text_border_green;	
+}
+.cmp-inset-text--neutral {
+	background-color:$ccs_inset-text_bg_grey; 
+	border-left:0;
+}
+.cmp-inset-text__body--neutral {
+	font-size: 13px;
+	font-weight: 400;
 }
 .cmp-inset-text__list-item {
 	font-size: 16px;

--- a/app/views/supply_teachers/branches/index.html.erb
+++ b/app/views/supply_teachers/branches/index.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl cmp-page-heading"><%= t('.header') %></h1>
 
-    <div class="govuk-inset-text">
+    <div class="govuk-inset-text cmp-inset-text--success">
       <h2 class="govuk-heading-s"><%= t('.inputs_header') %></h2>
       <ul class="govuk-list govuk-list--bullet">
         <% @journey.inputs.each do |question_key, answer| %>
@@ -38,6 +38,11 @@
         %>
       <% end %>
     </p>
+
+    <div class="govuk-inset-text cmp-inset-text--neutral">
+      <p class="govuk-body cmp-inset-text__body--neutral"><%= t('.mark-up_explanation_html') %></p>
+    </div>
+
     <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
     <% if @branches.any? %>
       <%= render partial: 'branch', collection: @branches %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -273,6 +273,7 @@ en:
           term: Term
           worker_type: Worker type
         inputs_header: Choices used to generate this list
+        mark-up_explanation_html: Results are sorted by mark-up from lowest to highest. Mark-up is the fee the supplier charges for their services. It's a percentage added to the worker's fee by the agency.
         other_radius_html: 'Change this distance to: '
         print: Print this page
         results_found_html: "<strong>%{results}</strong> found"


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/BsYROb7g/260-make-sure-buyers-know-how-the-shortlist-is-sorted-and-what-mark-up-means

## Changes in this PR:
- Changed the colour of inset-text box for the users' requirements section
- Added a new inset-text box for sorting criteria of the page and explanations of mark-up.

## Screenshots of UI changes:

### Before
<img width="1001" alt="screenshot 2018-12-05 at 13 09 01" src="https://user-images.githubusercontent.com/6421298/49515604-45365300-f88f-11e8-8975-1463c012c9d8.png">


### After
<img width="1008" alt="screenshot 2018-12-05 at 13 08 38" src="https://user-images.githubusercontent.com/6421298/49515610-4bc4ca80-f88f-11e8-9e8b-56fb20768c5a.png">


