### PR TITLE
(fix) added pound sign to the day rate input

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -17,6 +17,7 @@
 /* Override with my own components */
 @import "back-link/back-link";
 @import "button/button";
+@import "calculator-form/calculator-form";
 @import "details/details";
 @import "error-message/error-message";
 @import "error-summary/error-summary";

--- a/app/assets/stylesheets/components/calculator-form/_calculator-form.scss
+++ b/app/assets/stylesheets/components/calculator-form/_calculator-form.scss
@@ -1,0 +1,18 @@
+.calculator-form__day-rate {
+	position: relative;
+}
+.calculator-form__day-rate-input {
+	padding-left: 25px;
+}
+.calculator-form__day-rate-icon {
+	font-style: normal;
+	left: 12px;
+	margin-bottom: 0;
+	position: absolute;
+	top: 8px;
+}
+.calculator-form__day-rate-pound-sign {
+	bottom: 6px;
+	left: 8px;
+	position: absolute;
+}

--- a/app/views/supply_teachers/journey/contract_start.html.erb
+++ b/app/views/supply_teachers/journey/contract_start.html.erb
@@ -70,7 +70,10 @@
         <span class="govuk-hint">
           <%= t('.day_rate_question_hint') %>
         </span>
-        <%= text_field_tag :day_rate, params[:day_rate], class: css_classes_for_input(@journey, :day_rate, ['govuk-input--width-10']) %>
+        <div class="calculator-form__day-rate">
+          <%= text_field_tag :day_rate, params[:day_rate], class: css_classes_for_input(@journey, :day_rate, ['govuk-input--width-10 calculator-form__day-rate-input']) %>
+          <i class="govuk-body calculator-form__day-rate-icon"><%= t('.day_rate_icon') %></i>
+        </div>
       <% end %>
 
       <%= govuk_form_group_with_optional_error(@journey, :markup_rate) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -321,6 +321,7 @@ en:
       contract_start:
         contract_start_question: When did the worker's current contract start?
         contract_start_question_hint: For example, 31 3 1980
+        day_rate_icon: "£"
         day_rate_question: What does the agency charge you per day for the worker?
         day_rate_question_hint: An amount in pounds. For example, 150
         days_per_week_question: How many days per week is the worker contracted for?


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/YMnbQsSg/251-update-temp-to-perm-calculator-total-day-rate-page

## Changes in this PR:
- Added a pound sign to the day rate input box

## Screenshots of UI changes:

### Before
![screenshot 2018-12-06 at 11 21 11](https://user-images.githubusercontent.com/6421298/49581262-47f57e80-f949-11e8-8fc9-d8f55cd863d2.png)

### After
![screenshot 2018-12-06 at 11 21 19](https://user-images.githubusercontent.com/6421298/49581267-4deb5f80-f949-11e8-86a7-ddc9c09a6714.png)
