### PR TITLE
Google analytics link tracking

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,4 @@
 //= require rails-ujs
 //= require activestorage
 //= require govuk-frontend/all
+//= require google_analytics

--- a/app/assets/javascripts/google_analytics.js
+++ b/app/assets/javascripts/google_analytics.js
@@ -1,6 +1,8 @@
 document.addEventListener('DOMContentLoaded', function() {
   var cssClassToClickPath = {
-    'ga-crown-logo': 'crown_logo'
+    'ga-crown-logo': 'crown_logo',
+    'ga-feedback-mailto': 'feedback',
+    'ga-support-mailto': 'support'
   };
 
   if (window.gaTrackingId) {

--- a/app/assets/javascripts/google_analytics.js
+++ b/app/assets/javascripts/google_analytics.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', function() {
+  var cssClassToClickPath = {
+    'ga-crown-logo': 'crown_logo'
+  };
+
+  if (window.gaTrackingId) {
+    for (var cssClass in cssClassToClickPath) {
+      var elements = document.getElementsByClassName(cssClass);
+      for (var idx=0; idx < elements.length; idx++) {
+        var element = elements[idx];
+        var onClick = function(cssClass) {
+          return function() {
+            var page = cssClassToClickPath[cssClass];
+            var params = {
+              'anonymize_ip': true,
+              'page_title': page,
+              'page_path': '/external/'+page
+            };
+            gtag('config', window.gaTrackingId, params);
+          }
+        }(cssClass);
+        element.addEventListener('click', onClick, false);
+      }
+    }
+  }
+});

--- a/app/assets/javascripts/google_analytics.js
+++ b/app/assets/javascripts/google_analytics.js
@@ -2,7 +2,10 @@ document.addEventListener('DOMContentLoaded', function() {
   var cssClassToClickPath = {
     'ga-crown-logo': 'crown_logo',
     'ga-feedback-mailto': 'feedback',
-    'ga-support-mailto': 'support'
+    'ga-support-mailto': 'support',
+    'ga-print-link': 'print',
+    'ga-download-shortlist': 'shortlist_download',
+    'ga-download-calculator': 'calculator_download'
   };
 
   if (window.gaTrackingId) {

--- a/app/assets/javascripts/google_analytics.js
+++ b/app/assets/javascripts/google_analytics.js
@@ -3,6 +3,8 @@ document.addEventListener('DOMContentLoaded', function() {
     'ga-crown-logo': 'crown_logo',
     'ga-feedback-mailto': 'feedback',
     'ga-support-mailto': 'support',
+    'ga-auth-cognito': 'cognito_login',
+    'ga-auth-dfe': 'dfe_login',
     'ga-print-link': 'print',
     'ga-download-shortlist': 'shortlist_download',
     'ga-download-calculator': 'calculator_download'

--- a/app/assets/stylesheets/components/analytics.scss
+++ b/app/assets/stylesheets/components/analytics.scss
@@ -1,0 +1,6 @@
+.ga-crown-logo
+{
+  // these classes are used by google analytics to mark external
+  // links. Included here for documentation. See:
+  //   /assets/javascripts/google_analytics.js
+}

--- a/app/assets/stylesheets/components/analytics.scss
+++ b/app/assets/stylesheets/components/analytics.scss
@@ -1,4 +1,6 @@
-.ga-crown-logo
+.ga-crown-logo,
+.ga-feedback-mailto,
+.ga-support-mailto
 {
   // these classes are used by google analytics to mark external
   // links. Included here for documentation. See:

--- a/app/assets/stylesheets/components/analytics.scss
+++ b/app/assets/stylesheets/components/analytics.scss
@@ -1,6 +1,8 @@
 .ga-crown-logo,
 .ga-feedback-mailto,
 .ga-support-mailto,
+.ga-auth-cognito,
+.ga-auth-dfe,
 .ga-print-link,
 .ga-download-shortlist,
 .ga-download-calculator

--- a/app/assets/stylesheets/components/analytics.scss
+++ b/app/assets/stylesheets/components/analytics.scss
@@ -1,6 +1,9 @@
 .ga-crown-logo,
 .ga-feedback-mailto,
-.ga-support-mailto
+.ga-support-mailto,
+.ga-print-link,
+.ga-download-shortlist,
+.ga-download-calculator
 {
   // these classes are used by google analytics to mark external
   // links. Included here for documentation. See:

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,14 +10,16 @@ module ApplicationHelper
   def feedback_email_link
     govuk_email_link(
       Marketplace.feedback_email_address,
-      t('layouts.application.feedback_aria_label')
+      t('layouts.application.feedback_aria_label'),
+      css_class: 'govuk-link ga-feedback-mailto'
     )
   end
 
   def support_email_link(label)
     govuk_email_link(
       Marketplace.support_email_address,
-      label
+      label,
+      css_class: 'govuk-link ga-support-mailto'
     )
   end
 

--- a/app/views/facilities_management/gateway/index.html.erb
+++ b/app/views/facilities_management/gateway/index.html.erb
@@ -7,7 +7,7 @@
       <p><%= t('.cmp_support_email_html', link: support_email_link(t('.cmp_support_aria_label'))) %></p>
 
       <p>
-        <%= link_to 'Sign in with beta credentials', cognito_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' %>
+        <%= link_to 'Sign in with beta credentials', cognito_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8 ga-auth-cognito' %>
       </p>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
       <div class="govuk-header__container govuk-width-container">
 
         <div class="govuk-header__logo">
-          <a href="<%= ccs_homepage_url %>" class="govuk-header__link govuk-header__link--homepage" aria-label="Crown Commercial Service homepage">
+          <a href="<%= ccs_homepage_url %>" class="govuk-header__link govuk-header__link--homepage ga-crown-logo" aria-label="Crown Commercial Service homepage">
             <span class="govuk-header__logotype">
               <%= render partial: '/layouts/logotype' %>
             </span>

--- a/app/views/management_consultancy/gateway/index.html.erb
+++ b/app/views/management_consultancy/gateway/index.html.erb
@@ -7,7 +7,7 @@
       <p><%= t('.cmp_support_email_html', link: support_email_link(t('.cmp_support_aria_label'))) %></p>
 
       <p>
-        <%= link_to 'Sign in with beta credentials', cognito_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' %>
+        <%= link_to 'Sign in with beta credentials', cognito_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8 ga-auth-cognito' %>
       </p>
     </div>
   </div>

--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -2,6 +2,7 @@
 <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GA_TRACKING_ID'] %>"></script>
 <script>
 window.dataLayer = window.dataLayer || [];
+window.gaTrackingId = '<%= ENV['GA_TRACKING_ID'] %>';
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
 gtag('config', '<%= ENV['GA_TRACKING_ID'] %>', { 'anonymize_ip': true });

--- a/app/views/supply_teachers/branches/index.html.erb
+++ b/app/views/supply_teachers/branches/index.html.erb
@@ -52,14 +52,14 @@
 <div class="govuk-grid-row ccs-no-print">
   <div class="govuk-grid-column-full">
     <p class="govuk-body supplier-record__print-option">
-      <a href="javascript:window.print()" class="govuk-link"><%= t('.print') %></a>
+      <a href="javascript:window.print()" class="govuk-link ga-print-link"><%= t('.print') %></a>
     </p>
     <p class="govuk-body supplier-record__print-option">
-      <%= link_to t('.download'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx)), { class: 'supplier-record__file-download', 'aria-label': t('.download_aria_label') } %>
+      <%= link_to t('.download'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx)), { class: 'supplier-record__file-download ga-download-shortlist', 'aria-label': t('.download_aria_label') } %>
     </p>
     <p class="govuk-body supplier-record__print-option">
       <% if link_to_calculator? %>
-      <%= link_to t('.download_with_calculator'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx, calculations: 'yes')), { class: 'supplier-record__file-download', 'aria-label': t('.download_with_calculator_aria_label') } %>
+      <%= link_to t('.download_with_calculator'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx, calculations: 'yes')), { class: 'supplier-record__file-download ga-download-calculator', 'aria-label': t('.download_with_calculator_aria_label') } %>
       <% end %>
     </p>
   </div>

--- a/app/views/supply_teachers/gateway/index.html.erb
+++ b/app/views/supply_teachers/gateway/index.html.erb
@@ -7,9 +7,9 @@
       <p><%= t('.cmp_support_email_html', link: support_email_link(t('.cmp_support_aria_label'))) %></p>
 
       <p>
-        <%= link_to 'Sign in with beta credentials', cognito_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' %>
+        <%= link_to 'Sign in with beta credentials', cognito_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8 ga-auth-cognito' %>
         <% if DFE_SIGNIN_ENABLED %>
-          <%= link_to 'Sign in with DfE Sign-in', dfe_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' %>
+          <%= link_to 'Sign in with DfE Sign-in', dfe_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8 ga-auth-dfe' %>
         <% end %>
       </p>
     </div>


### PR DESCRIPTION
This pull request adds explicit click tracking via javascript eventhandlers for various links and actions that don't resolve to an HTML page load on the site. For example, clicking the 'print this page' or downloading a spreadsheet of suppliers.

This is ready to merge but in the course of doing the work, I discovered that GA already has some functionality to do this by default and we may just be able to enable that! 

So, I'm tucking this away here in case we still need it.

In testing this, I found the Google Chrome tag assistant extension very helpful.