### PR TITLE
(fix) add information about calculator to Start page of Supply Teachers

### DIFF
--- a/app/views/supply_teachers/home/index.html.erb
+++ b/app/views/supply_teachers/home/index.html.erb
@@ -11,6 +11,7 @@
         <li>hire a specific person (a ‘nominated worker’)</li>
         <li>find a managed service provider, who can take on all your temporary staff needs</li>
         <li>create a shortlist of suppliers based on your needs and download it</li>
+        <li>calculate the maximum you could be charged to make your agency worker permanent</li>
       </ul>
 
       <%= link_to 'Start now', journey_start_url(journey: SupplyTeachers::Journey.journey_name), role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' %>


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/JUqFTkut/294-add-information-about-calculator-to-supply-teachers-start-page

## Changes in this PR:
- Add a bullet point to the Start page of Supply Teachers to provide information about the calculator.

## Screenshots of UI changes:

### Before
![screenshot 2018-12-06 at 15 26 47](https://user-images.githubusercontent.com/6421298/49593519-a5022c00-f96b-11e8-89f6-7c5ff96ae16f.png)


### After
![screenshot 2018-12-06 at 15 26 32](https://user-images.githubusercontent.com/6421298/49593523-aa5f7680-f96b-11e8-8d6a-844a99e7dd2d.png)

