### PR TITLE
(fix) update styling of mark-up input of calculator

### DIFF
--- a/app/assets/stylesheets/components/calculator-form/_calculator-form.scss
+++ b/app/assets/stylesheets/components/calculator-form/_calculator-form.scss
@@ -11,8 +11,18 @@
 	position: absolute;
 	top: 8px;
 }
-.calculator-form__day-rate-pound-sign {
-	bottom: 6px;
-	left: 8px;
+.calculator-form__markup-rate {
+	position: relative;
+	display: inline;
+}
+.calculator-form__markup-rate-input {
+	padding-right: 25px;
+	position: relative;
+}
+.calculator-form__markup-percentage-icon {
+	font-style: normal;
+	right: 12px;
+	margin-bottom: 0;
 	position: absolute;
+	top: -4px;
 }

--- a/app/views/supply_teachers/journey/temp_to_perm_calculator.html.erb
+++ b/app/views/supply_teachers/journey/temp_to_perm_calculator.html.erb
@@ -84,7 +84,10 @@
         <span class="govuk-hint">
           <%= t('.markup_rate_question_hint') %>
         </span>
-        <%= text_field_tag :markup_rate, params[:markup_rate], class: css_classes_for_input(@journey, :markup_rate, ['govuk-input--width-10']) %>
+        <div class="calculator-form__markup-rate">
+          <%= text_field_tag :markup_rate, params[:markup_rate], class: css_classes_for_input(@journey, :markup_rate, ['govuk-input--width-10 calculator-form__markup-rate-input']) %>
+          <i class="govuk-body calculator-form__markup-percentage-icon"><%= t('.markup_percentage_icon') %></i>
+        </div>
       <% end %>
 
       <%= govuk_form_group_with_optional_error(@journey, :hire_date, :hire_date_day, :hire_date_month, :hire_date_year) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -437,8 +437,9 @@ en:
         holiday_2_end_date_question_hint: Leave this blank if there weren't any holidays between the contract start date and the hire date
         holiday_2_start_date_question: What date did the second school holiday start?
         holiday_2_start_date_question_hint: Leave this blank if there weren't any holidays between the contract start date and the hire date
+        markup_percentage_icon: "%"
         markup_rate_question: What mark-up does the agency charge for the worker?
-        markup_rate_question_hint: This is the percentage fee you agreed with the supplier. For example, 40
+        markup_rate_question_hint: This is the percentage fee you agreed with the supplier. For example, 20
         notice_date_question: What date did you notify the supplier that you wish to hire the worker?
         notice_date_question_hint: Leave this blank if you haven't yet notified the supplier
       worker_type:


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/uLV1yMSF/252-update-mark-up-question-on-temp-to-perm-calculator

## Changes in this PR:
- Added % sign to the mark-up input box
- Changed the example of mark-up from 40 to 20

## Screenshots of UI changes:

### Before
![screenshot 2018-12-10 at 14 41 03](https://user-images.githubusercontent.com/6421298/49739669-5f56a380-fc8a-11e8-83be-59fa5ee509bd.png)


### After
![screenshot 2018-12-10 at 14 40 49](https://user-images.githubusercontent.com/6421298/49739677-654c8480-fc8a-11e8-98fc-7e64bb6048c4.png)
