### PR TITLE
(feature) Obligations of using supplier data added

### DIFF
--- a/app/views/supply_teachers/home/index.html.erb
+++ b/app/views/supply_teachers/home/index.html.erb
@@ -38,5 +38,27 @@
 
       <p class="govuk-body">All suppliers have undergone background screening and safeguarding to DfE's Keeping Children Safe in Education standards. They are audited and accredited against best practice standards in education recruitment.</p>
 
+      <h2 class="govuk-heading-m cmp-start-page__sub-heading">Buyers' obligations for supplier data</h2>
+
+      <p class="govuk-body">This service contains pricing information for suppliers on the Agency Supply Teachers framework agreement. This is confidential and can be considered commercially sensitive.</p> 
+
+      <p class="govuk-body">By using the service, you acknowledge and accept responsibility for keeping this information confidential in accordance with the requirements below, and not sharing it wider than your school.</p>
+
+      <p class="govuk-body">In consideration of being given use of the confidential information included in the service, you and your employees shall:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>keep the confidential information strictly confidential and not directly or indirectly reveal, report, copy, part with possession of, license, publish, transfer, communicate or disclose the confidential information in any manner whatsoever without Crown Commercial Service’s (CCS) prior written consent;</li>
+        <li>not disclose, use or exploit the confidential information for any purpose except to buy services under the CCS framework agreement for supply teachers and temporary staff;</li>
+        <li>ensure that the confidential information is stored securely and that access to it is restricted to those of your employees who need such access for the purposes of buying services under the framework agreement for supply teachers and temporary staff; and</li>
+        <li>immediately notify CCS if you suspect unauthorised access, copying, use or disclosure of the confidential information.</li>
+      </ul>
+
+      <p class="govuk-body">You shall inform your employees of the specially confidential nature of the information and ensure they agree to keep it confidential on terms no less onerous than those contained in this notice. </p>
+
+      <p class="govuk-body">You shall ensure that only employees are given access to the confidential information and you shall not give agents, sub-contractors, third parties nor other non-employees access to the confidential information.</p>
+
+      <p class="govuk-body">By using this service you acknowledge and agree to comply with the above requirements.</p>
+
+
     </div>
   </div>


### PR DESCRIPTION
## Trello card URL:
81-buyers-understand-their-obligations-for-using-supplier-data

## Changes in this PR:
- Added obligations of using supplier data to the bottom of the page.

## Screenshots of UI changes:

### Before
<img width="991" alt="screenshot 2018-12-10 at 16 50 00" src="https://user-images.githubusercontent.com/6421298/49747657-d0eb1d80-fc9b-11e8-9974-59e10b7037c3.png">


### After
<img width="878" alt="screenshot 2018-12-10 at 16 49 48" src="https://user-images.githubusercontent.com/6421298/49747664-d5afd180-fc9b-11e8-8ce5-db6a0a5f61da.png">

