### PR TITLE
(fix) move DfE sign-in notice above the start button

### DIFF
--- a/app/views/supply_teachers/home/index.html.erb
+++ b/app/views/supply_teachers/home/index.html.erb
@@ -15,15 +15,15 @@
         <li>calculate the maximum you could be charged to make your agency worker permanent</li>
       </ul>
 
-      <%= link_to 'Start now', journey_start_url(journey: SupplyTeachers::Journey.journey_name), role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', 'aria-label': 'Start finding supply teachers and agency workers' %>
-
-      <h2 class="govuk-heading-m">Before you start</h2>
-
       <p class="govuk-body">
         To use the service, you will need your DFE Sign-in email and password.
       </p>
 
-      <p class="govuk-body">You will also need to have:</p>
+      <%= link_to 'Start now', journey_start_url(journey: SupplyTeachers::Journey.journey_name), role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', 'aria-label': 'Start finding supply teachers and agency workers' %>
+
+      <h2 class="govuk-heading-m">Before you start</h2>
+
+      <p class="govuk-body">You will need to have:</p>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>your school’s postcode</li>
@@ -32,7 +32,7 @@
 
       <p class="govuk-body">You can’t use this service if you’re an independent school, unless you have charitable status.</p>
 
-      <p class="govuk-body">To find permanent teaching staff, use the <a aria-label="Visit the Teaching Vacancies service website" href="https://teaching-jobs.service.gov.uk/">Teaching Jobs</a> service.</p>
+      <p class="govuk-body">To find permanent teaching staff, use the <a aria-label="Visit the Teaching Vacancies service website" href="https://teaching-jobs.service.gov.uk/">Teaching Vacancies</a> service.</p>
 
       <h2 class="govuk-heading-m cmp-start-page__sub-heading">Accreditation of suppliers</h2>
 


### PR DESCRIPTION
## Trello card URL:
316-minor-content-change-to-start-page

## Changes in this PR:
- Move the DfE sign-in notice to above the start button
- Change the copy of below the start button

## Screenshots of UI changes:

### Before
<img width="655" alt="screenshot 2018-12-10 at 17 07 12" src="https://user-images.githubusercontent.com/6421298/49748754-7ef7c700-fc9e-11e8-9026-2689f223261d.png">


### After
<img width="645" alt="screenshot 2018-12-10 at 17 07 29" src="https://user-images.githubusercontent.com/6421298/49748759-83bc7b00-fc9e-11e8-8207-af57d9170a70.png">

