### PR TITLE
(fix) update the layout of neutral vendor page

### DIFF
--- a/app/views/supply_teachers/suppliers/neutral_vendors.html.erb
+++ b/app/views/supply_teachers/suppliers/neutral_vendors.html.erb
@@ -24,6 +24,10 @@
       </div>
     </details>
 
+    <% if @suppliers.length == 1 %>
+      <p class="govuk-body"><%= t('.one_vendor_found_html') %></p>
+    <% end %>
+
     <% SupplyTeachers::Supplier.with_neutral_vendor_rates.each do |supplier| %>
       <div class="neutral-vendor-record">
         <h2 class="govuk-heading-m"><%= supplier.name %></h2>
@@ -38,52 +42,27 @@
           </p>
         <% end %>
 
-        <table class="govuk-table">
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th class="govuk-table__header" scope="col"><strong><%= t('.column1') %></strong></th>
-              <th class="govuk-table__header govuk-table__header--numeric master-vendor-record__markup-column" scope="col"><strong><%= t('.column2') %><br><%= SupplyTeachers::Rate::TERMS['one_week'] %></strong></th>
-              <th class="govuk-table__header govuk-table__header--numeric master-vendor-record__markup-column" scope="col"><strong><%= t('.column2') %><br><%= SupplyTeachers::Rate::TERMS['twelve_weeks'] %></strong></th>
-              <th class="govuk-table__header govuk-table__header--numeric master-vendor-record__markup-column" scope="col"><strong><%= t('.column2') %><br><%= SupplyTeachers::Rate::TERMS['more_than_twelve_weeks'] %></strong></th>
-            </tr>
-          </thead>
-          <% supplier.rates.each do |rate| %>
-          <tbody class="govuk-table__body">
-              <tr class="govuk-table__row">
-                <th class="govuk-table__header" scope="row"><%= SupplyTeachers::Rate::JOB_TYPES[rate.job_type] %></th>
-                <% 3.times do %>
-                <td class="govuk-table__cell govuk-table__cell--numeric master-vendor-record__markup-column">
-                  <% if rate.percentage_mark_up? %>
-                    <%= number_to_percentage(rate.mark_up * 100, precision: 1) %>
-                  <% else %>
-                    <%= number_to_currency(rate.daily_fee) %>
-                  <% end %>
-                </td>
-                <% end %>
-               </tr>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <% supplier.rates.each do |rate| %>                
+              <% if rate.percentage_mark_up? %>
+              <p class="govuk-body">
+                <%= t('.mark_up_html', mark_up:number_to_percentage(rate.mark_up * 100, precision: 1)) %>
+              </p>
+              <p class="govuk-body"><%= t('.mark_up_explanation_html') %></p>
+              <% else %>
+              <p class="govuk-body">
+                <%= t('.daily_fee_html', daily_fee:number_to_currency(rate.daily_fee)) %>
+              </p>
+              <p class="govuk-body"><%= t('.daily_fee_explanation_html') %></p>
+              <% end %>
             <% end %>
-          </tbody>
-        </table>
+
+          </div>
+          <div class="govuk-grid-column-one-third"></div>
+        </div>
+
       </div>
     <% end %>
   </div>
-
-<!--
-  <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl cmp-page-heading"><%= t('.header') %></h1>
-    <% SupplyTeachers::Supplier.with_neutral_vendor_rates.each do |supplier| %>
-      <h2 class="govuk-heading-m"><%= supplier.name %></h2>
-      <% supplier.rates.each do |rate| %>
-        <p>
-          <%= SupplyTeachers::Rate::JOB_TYPES[rate.job_type] %>
-          <% if rate.percentage_mark_up? %>
-            <%= number_to_percentage(rate.mark_up * 100, precision: 1) %>
-          <% else %>
-            <%= number_to_currency(rate.daily_fee) %>
-          <% end %>
-        </p>
-      <% end %>
-    <% end %>
-  </div>
--->
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -411,11 +411,14 @@ en:
         header: Master vendor managed service providers
         page_title: Master vendor managed service providers
       neutral_vendors:
-        column1: Job type
-        column2: Supplier mark-up
+        daily_fee_explanation_html: This is charged if the agency finds you a worker, or if they take on someone you have them to manage (a ‘nominated worker’).
+        daily_fee_html: A %{daily_fee} daily fee is charged each day in addition to this mark-up rate.
         do_next:
           contact_supplier: contact the supplier for this worker and for all your future temporary recruitment needs
           header: What to do next
           sign_form_html: sign the <a href="%{form_url}">full version order form</a> (also available in the documents section of the <a href="%{framework_url}">CCS framework</a> as ‘RM3826 Supply Teachers - Order Form Template (Full Version).docx’)
         header: Neutral vendor managed service providers
+        mark_up_explanation_html: The mark-up varies for all other workers. Contact the supplier to find out the mark-up rate for the type of worker you need.
+        mark_up_html: A %{mark_up} mark-up is charged if you use the agency to hire a specific person for you (a ‘nominated worker’).
+        one_vendor_found_html: There is only one neutral vendor on this framework.
         page_title: Neutral vendor managed service providers

--- a/spec/features/supply_teachers/managed_service_providers.features_spec.rb
+++ b/spec/features/supply_teachers/managed_service_providers.features_spec.rb
@@ -66,9 +66,8 @@ RSpec.feature 'Managed service providers', type: :feature do
     expect(page).to have_css('h1', text: 'Neutral vendor managed service')
     expect(page).to have_css('h2', text: 'neutral-vendor-supplier')
 
-    expect(page).to have_rates(job_type: 'A specific person', percentages: [30.0])
-    expect(page).to have_rates(job_type: 'Neutral vendor managed service provider fee (per day)',
-                               percentages: [], amount: 1.23)
+    expect(page).to have_text(/A 30.0% mark-up is charged/)
+    expect(page).to have_text(/A £1.23 daily fee is charged/)
   end
 
   scenario 'Buyer changes mind about hiring a managed service provider' do


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/5fLXI9XF/289-improve-content-on-neutral-vendor-supplier-list

## Changes in this PR:
- Removed the table layout for supplier records in neutral vendor page
- Used paragraphs to supplier records
- Added `There is only one neutral vendor on this framework.` to the top when there's only one supplier

## Screenshots of UI changes:

### Before
<img width="1032" alt="screenshot 2018-12-12 at 16 57 11" src="https://user-images.githubusercontent.com/6421298/49886760-5dc7df80-fe32-11e8-82e6-598993b41ebb.png">

### After
<img width="915" alt="screenshot 2018-12-12 at 16 57 21" src="https://user-images.githubusercontent.com/6421298/49886766-628c9380-fe32-11e8-86fc-33c1f690e632.png">

## Next steps:
@chrisroos as discussed please help to see if you can fix the test. In `managed_service_providers.features_spec.rb` there are 2 lines checking the mark-up and daily fee but table label `job_type` is removed so we need to change it in spec too. 
