### PR TITLE
(fix) combine the last 2 paragraphs

### DIFF
--- a/app/views/supply_teachers/suppliers/neutral_vendors.html.erb
+++ b/app/views/supply_teachers/suppliers/neutral_vendors.html.erb
@@ -54,7 +54,6 @@
               <p class="govuk-body">
                 <%= t('.daily_fee_html', daily_fee:number_to_currency(rate.daily_fee)) %>
               </p>
-              <p class="govuk-body"><%= t('.daily_fee_explanation_html') %></p>
               <% end %>
             <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -411,8 +411,7 @@ en:
         header: Master vendor managed service providers
         page_title: Master vendor managed service providers
       neutral_vendors:
-        daily_fee_explanation_html: This is charged if the agency finds you a worker, or if they take on someone you have them to manage (a ‘nominated worker’).
-        daily_fee_html: A %{daily_fee} daily fee is charged each day in addition to this mark-up rate.
+        daily_fee_html: A %{daily_fee} daily fee is charged each day in addition to this mark-up rate. This is charged if the agency finds you a worker, or if they take on someone you have them to manage (a ‘nominated worker’).
         do_next:
           contact_supplier: contact the supplier for this worker and for all your future temporary recruitment needs
           header: What to do next


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/5fLXI9XF/289-improve-content-on-neutral-vendor-supplier-list

## Changes in this PR:
- Combine the last 2 paragraphs for neutral vendor page

## Screenshots of UI changes:

### Before
<img width="915" alt="screenshot 2018-12-12 at 16 57 21" src="https://user-images.githubusercontent.com/6421298/49934228-b6948800-fec5-11e8-94d5-3fbde6bbe5ac.png">


### After
<img width="892" alt="screenshot 2018-12-13 at 10 56 31" src="https://user-images.githubusercontent.com/6421298/49934265-c6ac6780-fec5-11e8-8aed-49ec7106f916.png">

