### PR TITLE
(fix) wrap distance items to avoid word breaks

### DIFF
--- a/app/assets/stylesheets/components/st-supplier-page/_st-supplier-page.scss
+++ b/app/assets/stylesheets/components/st-supplier-page/_st-supplier-page.scss
@@ -1,3 +1,4 @@
 .st-supplier-page__radius-list-item {
 	margin-right: 10px;
+	white-space: nowrap;
 }


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/KPFZx1w8/309-browser-testing-word-breaks

## Changes in this PR:
- Add CSS to wrap the distance items in order to avoid word breaks

## Screenshots of UI changes:

### Before
![screenshot 2018-12-13 at 15 12 15](https://user-images.githubusercontent.com/6421298/49947794-fa00ed80-fee9-11e8-8ee7-450c37457cd6.png)


### After
![screenshot 2018-12-13 at 15 12 25](https://user-images.githubusercontent.com/6421298/49947799-fcfbde00-fee9-11e8-8680-33bff69c8568.png)

