### PR TITLE
(fix) fixed legend margins on Samsung Internet browser

### DIFF
--- a/app/assets/stylesheets/components/fieldset/_fieldset.scss
+++ b/app/assets/stylesheets/components/fieldset/_fieldset.scss
@@ -2,4 +2,6 @@
 
 .govuk-fieldset__legend--m {
 	font-weight: $govuk-font-weight-semi-bold;
+	padding-bottom: 15px;
+	margin: 0;
 }


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/dpM6Smiv/308-browser-testing-legend-margins

## Changes in this PR:
- Set margin of the questions `legend` to 0
- Set padding-bottom of the question `legend` to 15

## Screenshots of UI changes:

### Before
<img width="372" alt="android_-_samsung_-_2" src="https://user-images.githubusercontent.com/6421298/50083722-86622780-01ec-11e9-9394-868ed80502e6.png">

<img width="371" alt="android_-_samsung_-_4" src="https://user-images.githubusercontent.com/6421298/50083723-86fabe00-01ec-11e9-9955-96cf24d981f4.png">


### After
![screenshot 2018-12-17 at 10 57 37](https://user-images.githubusercontent.com/6421298/50083738-91b55300-01ec-11e9-8cf1-7daf03d6ac39.png)

![screenshot 2018-12-17 at 10 58 47](https://user-images.githubusercontent.com/6421298/50083739-91b55300-01ec-11e9-942e-74357dbece4e.png)

![screenshot 2018-12-17 at 10 59 36](https://user-images.githubusercontent.com/6421298/50083740-91b55300-01ec-11e9-847a-b0a0ec375f15.png)

