### PR TITLE
(fix) updated what to do next section for master vendor page

### DIFF
--- a/app/views/supply_teachers/suppliers/master_vendors.html.erb
+++ b/app/views/supply_teachers/suppliers/master_vendors.html.erb
@@ -14,15 +14,14 @@
       <div class="govuk-details__text">
         <ul class="govuk-list govuk-list--bullet">
           <li>
-            <%= t('.do_next.further_competition') %>
-          </li>
-          <li>
-            <%= t('.do_next.competition_online') %>
+            <%= t('.do_next.further_competition_html', 
+                advice_url: 'https://www.gov.uk/guidance/buying-for-schools/run-a-mini-competition') %>
+            <%= t('.do_next.competition_online_html', 
+                esourcing_url: 'https://www.gov.uk/government/publications/esourcing-suite-guidance-for-customers') %>
           </li>
           <li>
             <%= t('.do_next.sign_form_html',
-                  form_url: 'https://ccs-agreements.cabinetoffice.gov.uk/sites/default/files/contracts/RM3826%20Supply%20Teachers%20-%20Order%20Form%20Template%20%28Full%20Version%29%20V1.docx',
-                  framework_url: 'https://ccs-agreements.cabinetoffice.gov.uk/contracts/rm3826') %>
+                  form_url: 'https://ccs-agreements.cabinetoffice.gov.uk/contracts/rm3826') %>
           </li>
         </ul>
         <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,11 +425,11 @@ en:
         column2: Supplier mark-up
       master_vendors:
         do_next:
-          competition_online: you can also run a competition fully online, using CCS’s esourcing tool
-          further_competition: run a further competition to select a supplier - there is advice from CCS on how to do this
+          competition_online_html: you can also do this online, <a href="%{esourcing_url}">using CCS’s esourcing tool</a>
+          further_competition_html: run a further competition to select a supplier - there is <a href="%{advice_url}">advice from CCS</a> on how to do this -
           header: What to do next
           more_help: Contact supplyteachers@crowncommercial.gov.uk if you need more help running a further competition.
-          sign_form_html: select a supplier and sign the <a href="%{form_url}">full version order form</a> (also available in the documents section of the <a href="%{framework_url}">CCS framework</a> as ‘RM3826 Supply Teachers - Order Form Template (Full Version).docx’)
+          sign_form_html: select a supplier and <a href="%{form_url}">sign the full version order form</a> listed in the documents section of the CCS framework as ‘RM3826 Supply Teachers - Order Form Template (Full Version) V1.docx’
         header: Master vendor managed service providers
         page_title: Master vendor managed service providers
       neutral_vendors:


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/lGpj9c4N/325-change-guidance-for-user-on-what-to-do-with-supplier-list-master-vendor-route

## Changes in this PR:
- Added link for information of further competition
- Added esourcing link
- Updated link of full version order form

## Screenshots of UI changes:

### Before
![screenshot 2018-12-17 at 12 52 45](https://user-images.githubusercontent.com/6421298/50088588-553d2380-01fb-11e9-9565-3ddf7dc9129b.png)


### After
![screenshot 2018-12-17 at 12 52 25](https://user-images.githubusercontent.com/6421298/50088596-5b330480-01fb-11e9-8e41-306bd5f84213.png)

