### PR TITLE
WIP: Replace select list with radio buttons

### DIFF
--- a/app/views/supply_teachers/journey/agency_payroll.html.erb
+++ b/app/views/supply_teachers/journey/agency_payroll.html.erb
@@ -17,12 +17,22 @@
   <% end %>
 
   <%= govuk_form_group_with_optional_error(@journey, :job_type) do %>
-    <label class="govuk-label govuk-label--m" for="job_type">
-      <%= t('.worker_type_question') %>
-    </label>
-    <select class="govuk-select" id="job_type" name="job_type">
-      <%= options_from_collection_for_select(SupplyTeachers::JobType.roles, :code, :description, params[:job_type]) %>
-    </select>
+    <%= govuk_fieldset_with_optional_error(@journey, :job_type) do %>
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        <h1 class="govuk-fieldset__heading">
+          <%= t('.worker_type_question') %>
+        </h1>
+      </legend>
+      <%= display_error(@journey, :job_type) %>
+      <div class="govuk-radios">
+        <div class="govuk-radios__item">
+          <% SupplyTeachers::JobType.roles.each do |job_type| %>
+            <%= radio_button_tag :job_type, job_type.code, checked?(params[:job_type], job_type.code), class: 'govuk-radios__input' %>
+            <%= label_tag "job_type_#{job_type.code}", job_type.description, class: 'govuk-label govuk-radios__label' %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 
   <%= govuk_form_group_with_optional_error(@journey, :term) do %>

--- a/spec/features/supply_teachers/workers_on_agency_payroll.features_spec.rb
+++ b/spec/features/supply_teachers/workers_on_agency_payroll.features_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Workers on agency payroll', type: :feature do
 
     fill_in 'postcode', with: 'WC2B 6TE'
     select '4 weeks to 8 weeks', from: 'term'
-    select 'Qualified teacher: SEN roles', from: 'job_type'
+    choose 'Qualified teacher: SEN roles'
     click_on I18n.t('common.submit')
 
     expect(page).not_to have_text('whitechapel'), 'suppliers without appropriate rates should not be displayed'


### PR DESCRIPTION
The accessibility testing highlighted problems with the fairly long
entries in the list pushing the dropdown arrow off the screen on mobile
devices.

In addition, the GOV.UK Design System[1] says:

> The select component should only be used as a last resort in
public-facing services because research shows that some users find
selects very difficult to use.

[1]: https://design-system.service.gov.uk/components/select/#when-to-use-this-component