### PR TITLE
Changes to the mark-up explanation text

### DIFF
--- a/app/assets/stylesheets/components/inset-text/_inset-text.scss
+++ b/app/assets/stylesheets/components/inset-text/_inset-text.scss
@@ -14,7 +14,7 @@ $ccs_inset-text_border_green: govuk-colour("green-3");
 	border-left:0;
 }
 .cmp-inset-text__body--neutral {
-	font-size: 13px;
+	font-size: 16px;
 	font-weight: 400;
 }
 .cmp-inset-text__list-item {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -325,7 +325,7 @@ en:
           term: Term
           worker_type: Worker type
         inputs_header: Choices used to generate this list
-        mark-up_explanation_html: Results are sorted by mark-up from lowest to highest. Mark-up is the fee the supplier charges for their services. It’s a percentage added to the worker’s fee by the agency.
+        mark-up_explanation_html: Results are sorted by mark-up from lowest to highest. Mark-up is the percentage the agency charges on top of the charge for the worker. It includes things like overheads, the agencies’ profits and management charges.
         other_radius_html: 'Change this distance to: '
         page_title: Suppliers
         print: Print this page


### PR DESCRIPTION
- Make the text in line with the supply teachers landing page on GOV.UK
- Increase the font size slightly

# Before 
<img width="998" alt="screenshot 2019-01-09 at 14 25 38" src="https://user-images.githubusercontent.com/2804149/50905323-7835ae80-141a-11e9-9aa1-05fac2bf8285.png">


# After 
<img width="984" alt="screenshot 2019-01-09 at 14 24 38" src="https://user-images.githubusercontent.com/2804149/50905268-59cfb300-141a-11e9-8f28-bf1c5ef068aa.png">
