### PR TITLE
(chore) Temp-to-perm calculator heading better reflects DfE policy

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,7 +403,7 @@ en:
         day_rate_question_hint: An amount in pounds. For example, 150
         days_per_week_question: How many days per week is the worker contracted for?
         days_per_week_question_hint: For example, 5
-        header: Calculate the temp-to-perm fee for a worker
+        header: Find out how much you’ll be charged if you make an agency worker permanent
         hire_date_question: What date do you want to take the worker on permanently from?
         hire_date_question_hint: For example, 31 3 1980
         holiday_1_end_date_question: What date did the first school holiday end?


### PR DESCRIPTION
This is now in line with the supply teachers landing page on GOV.UK