### PR TITLE
(chore) Set logging level in production environments via an env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ environments:
 * `CCS_DEFAULT_DB_USER`
 * `CCS_DEFAULT_DB_PASSWORD`
 
+#### Log level
+
+* `LOG_LEVEL` can be used to manipulate the log level in production. Set to `'debug'` to see debug output; the default (if not set) is `:info`
+
 ## Run
 
 Execute the following command:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV['LOG_LEVEL'].present? ? ENV['LOG_LEVEL'] : :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
The production CMp application was showing a lot of unneeded logging. The `log_level` in `production.rb` is set to `:debug` which is too low for production (normally)

This change means the log level can be set on deployment (via Terraform etc). If the log level param is not set, it defaults to `:info`

If the log level needs to be changed for whatever reason, it can be done via ops.