### PR TITLE
Fix: Allow notice date to be the same day as contract start and hire dates

### DIFF
--- a/app/models/supply_teachers/journey/temp_to_perm_calculator.rb
+++ b/app/models/supply_teachers/journey/temp_to_perm_calculator.rb
@@ -173,14 +173,14 @@ module SupplyTeachers
 
     def ensure_notice_date_is_after_contract_start_date
       return if notice_date.blank? || contract_start_date.blank?
-      return if notice_date > contract_start_date
+      return if notice_date >= contract_start_date
 
       errors.add(:notice_date, :before_contract_start_date)
     end
 
     def ensure_notice_date_is_before_hire_date
       return if notice_date.blank? || hire_date.blank?
-      return if notice_date < hire_date
+      return if notice_date <= hire_date
 
       errors.add(:notice_date, :after_hire_date)
     end

--- a/spec/features/supply_teachers/temp_to_perm_calculator.feature_spec.rb
+++ b/spec/features/supply_teachers/temp_to_perm_calculator.feature_spec.rb
@@ -51,28 +51,28 @@ RSpec.feature 'Temp to Perm fee calculator', type: :feature do
     visit_temp_to_perm_calculator
 
     fill_in_contract_start_date start_of_1st_week
-    fill_in_hire_date start_of_14th_week
+    fill_in_hire_date start_of_13th_week
     fill_in 'days_per_week', with: 5
     fill_in 'day_rate', with: 110
     fill_in 'markup_rate', with: 10
     fill_in_notice_date start_of_13th_week
     click_on I18n.t('common.submit')
 
-    expect_fee 100
+    expect_fee 200
   end
 
   scenario 'Making a worker permanent after 12 weeks of the start of their contract but without enough notice period when they work fewer than 5 days per week' do
     visit_temp_to_perm_calculator
 
     fill_in_contract_start_date start_of_1st_week
-    fill_in_hire_date start_of_14th_week
+    fill_in_hire_date start_of_13th_week
     fill_in 'days_per_week', with: 2
     fill_in 'day_rate', with: 110
     fill_in 'markup_rate', with: 10
     fill_in_notice_date start_of_13th_week
     click_on I18n.t('common.submit')
 
-    expect_fee 40
+    expect_fee 80
   end
 
   private


### PR DESCRIPTION
To help support this change the feature spec has been reverted to use the same day as the hire date.