### PR TITLE
(fix) Revert logout_uri change from b25aacbcf635c4095147094cdfd0acbc4…

### DIFF
--- a/app/lib/cognito.rb
+++ b/app/lib/cognito.rb
@@ -9,7 +9,7 @@ module Cognito
 
   def self.logout_url(redirect)
     if pool_site.present?
-      "#{pool_site}/logout?client_id=#{client_id}&redirect_uri=#{redirect}"
+      "#{pool_site}/logout?client_id=#{client_id}&logout_uri=#{redirect}"
     else
       redirect
     end


### PR DESCRIPTION
…45a44e7

This change was not necessary in PR #68. 

Instead, https://github.com/Crown-Commercial-Service/CMpDevEnvironment/pull/4 should fix the "first signout error" in https://trello.com/c/nTwYhW9n/909-exception-when-signing-out-via-cognito