### PR TITLE
(fix) Footer logo size fixed

### DIFF
--- a/app/assets/stylesheets/components/footer/_footer.scss
+++ b/app/assets/stylesheets/components/footer/_footer.scss
@@ -57,7 +57,7 @@ a.ccs-footer__links {
 }
 
 .govuk-footer__logotype svg {
-  width: 110px;
+  width: 233px;
   height: 90px;
 }
 
@@ -68,7 +68,7 @@ a.ccs-footer__links {
 @media (min-width: 641px) {
 
   .govuk-footer__logotype svg {
-    width: 140px;
+    width: 292px;
   }
 
   .govuk-footer__logotype svg,


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/YjSHwvEH/961-footer-logo-need-to-be-resized-also

## Changes in this PR:
- Fixed size of footer logo 

## Screenshots of UI changes:

### Before
<img width="992" alt="screenshot 2019-01-16 at 16 02 55" src="https://user-images.githubusercontent.com/6421298/51261585-6dde5c00-19a8-11e9-8ebd-fa39297b62e8.png">


### After
<img width="994" alt="screenshot 2019-01-16 at 16 03 04" src="https://user-images.githubusercontent.com/6421298/51261596-72a31000-19a8-11e9-87ab-99139662b7a3.png">
