### PR TITLE
(bugfix) Cast school type ids to strings

### DIFF
--- a/app/models/login/dfe_login.rb
+++ b/app/models/login/dfe_login.rb
@@ -26,7 +26,7 @@ module Login
     private
 
     def school_type
-      SupplyTeachers::SchoolType.find_by(id: @extra['school_id'])
+      SupplyTeachers::SchoolType.find_by(id: @extra['school_id'].to_s)
     end
 
     def whitelisted?

--- a/spec/models/login/dfe_login_spec.rb
+++ b/spec/models/login/dfe_login_spec.rb
@@ -95,6 +95,29 @@ RSpec.describe Login::DfeLogin, type: :model do
       end
     end
 
+    context 'when the school type is non-profit and a number' do
+      let(:school_type) do
+        {
+          'id' => 28,
+          'name' => 'Academy sponsor led'
+        }
+      end
+
+      context 'and email whitelisting is disabled' do
+        let(:whitelist_enabled) { false }
+
+        it 'permits access to any email address' do
+          expect(login.permit?(:supply_teachers)).to be true
+        end
+
+        it 'logs the attempt' do
+          login.permit?(:supply_teachers)
+          expect(Rails.logger).to have_received(:info)
+            .with('Login attempt from dfe > email: user@example.com, school type id: 28, result: successful')
+        end
+      end
+    end
+
     context 'when the school type is for-profit' do
       let(:school_type) do
         {


### PR DESCRIPTION
Suspect that the issue with https://trello.com/c/iWC1sXTr/971-allow-multi-academy-trusts-to-login is that the school type ID is being cast to a number after MAT's choose their desired school on DfE login.

Even if this is not the case, this is still a nice belt-and-braces solution