### PR TITLE
Supplier mark-up calculation on results page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,11 @@ Metrics/BlockLength:
     Exclude:
         - 'spec/**/*'
 
+Metrics/ParameterLists:
+    Exclude:
+        - 'app/models/supply_teachers/branch_search_result.rb'
+        - 'app/calculators/temp_to_perm_calculator/calculator.rb'
+
 Migration/RequireUUIDPrimaryKeys:
     Include:
         - 'db/migrate/*.rb'

--- a/app/assets/stylesheets/components/supplier-record/_supplier-record.scss
+++ b/app/assets/stylesheets/components/supplier-record/_supplier-record.scss
@@ -57,6 +57,22 @@
     min-height: 35px;
 }
 
+.supplier-record__calculator {
+  margin: 0;
+  background: govuk-colour("grey-4");
+}
+
+.supplier-record__calculator--muted p {
+  color: govuk-colour("grey-2");
+}
+
+.supplier-record__worker-cost,
+.supplier-record__supplier-fee
+{
+  margin: 10px 0 0 0;
+  font-size: 24px;
+}
+
 @media print {
   .supplier-record {
     page-break-inside: avoid;

--- a/app/calculators/temp_to_perm_calculator/calculator.rb
+++ b/app/calculators/temp_to_perm_calculator/calculator.rb
@@ -10,7 +10,6 @@ module TempToPermCalculator
 
     attr_reader :day_rate, :days_per_week, :contract_start_date, :hire_date, :markup_rate, :notice_date
 
-    # rubocop:disable Metrics/ParameterLists
     def initialize(
       day_rate:,
       days_per_week:,
@@ -40,7 +39,6 @@ module TempToPermCalculator
       @holiday_2_start_date = holiday_2_start_date
       @holiday_2_end_date = holiday_2_end_date
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def maximum_fee_for_lack_of_notice
       WORKING_DAYS_NOTICE_PERIOD_REQUIRED_TO_AVOID_LATE_NOTICE_FEE * pro_rata_daily_supplier_fee

--- a/app/controllers/supply_teachers/branches_controller.rb
+++ b/app/controllers/supply_teachers/branches_controller.rb
@@ -23,7 +23,7 @@ module SupplyTeachers
       @location = step.location
       @radius_in_miles = step.radius
       @alternative_radiuses = SEARCH_RADIUSES - [@radius_in_miles]
-      @branches = step.branches
+      @branches = step.branches daily_rates
 
       respond_to do |format|
         format.html
@@ -32,6 +32,10 @@ module SupplyTeachers
           render xlsx: spreadsheet.to_xlsx, filename: 'branches'
         end
       end
+    end
+
+    def daily_rates
+      params[:daily_rate] || {}
     end
   end
 end

--- a/app/models/generic_journey.rb
+++ b/app/models/generic_journey.rb
@@ -63,6 +63,8 @@ class GenericJourney
   end
 
   def previous_questions_and_answers
+    return params if current_step.final?
+
     params.except(*current_step.class.permit_list)
   end
 

--- a/app/models/supply_teachers/branch_search_result.rb
+++ b/app/models/supply_teachers/branch_search_result.rb
@@ -12,7 +12,6 @@ module SupplyTeachers
     attr_accessor :worker_cost
     attr_accessor :supplier_fee
 
-    # rubocop:disable Metrics/ParameterLists
     def initialize(id:, supplier_name:, name:, contact_name:,
                    telephone_number:, contact_email:)
       @id = id
@@ -22,6 +21,5 @@ module SupplyTeachers
       @telephone_number = telephone_number
       @contact_email = contact_email
     end
-    # rubocop:enable Metrics/ParameterLists
   end
 end

--- a/app/models/supply_teachers/branch_search_result.rb
+++ b/app/models/supply_teachers/branch_search_result.rb
@@ -8,7 +8,11 @@ module SupplyTeachers
     attr_reader :contact_email
     attr_accessor :rate
     attr_accessor :distance
+    attr_accessor :daily_rate
+    attr_accessor :worker_cost
+    attr_accessor :supplier_fee
 
+    # rubocop:disable Metrics/ParameterLists
     def initialize(id:, supplier_name:, name:, contact_name:,
                    telephone_number:, contact_email:)
       @id = id
@@ -18,5 +22,6 @@ module SupplyTeachers
       @telephone_number = telephone_number
       @contact_email = contact_email
     end
+    # rubocop:enable Metrics/ParameterLists
   end
 end

--- a/app/models/supply_teachers/branch_search_result.rb
+++ b/app/models/supply_teachers/branch_search_result.rb
@@ -1,5 +1,6 @@
 module SupplyTeachers
   class BranchSearchResult
+    attr_reader :id
     attr_reader :supplier_name
     attr_reader :name
     attr_reader :contact_name
@@ -8,8 +9,9 @@ module SupplyTeachers
     attr_accessor :rate
     attr_accessor :distance
 
-    def initialize(supplier_name:, name:, contact_name:,
+    def initialize(id:, supplier_name:, name:, contact_name:,
                    telephone_number:, contact_email:)
+      @id = id
       @supplier_name = supplier_name
       @name = name
       @contact_name = contact_name

--- a/app/models/supply_teachers/journey/results.rb
+++ b/app/models/supply_teachers/journey/results.rb
@@ -4,12 +4,15 @@ module SupplyTeachers
     include BranchesHelper
     include Geolocatable
 
-    def branches
+    def branches(daily_rates = {})
       point = location.point
       Branch.search(point, rates: rates, radius: radius).map do |branch|
         search_result_for(branch).tap do |result|
           result.rate = rate(branch)
           result.distance = point.distance(branch.location)
+          result.daily_rate = daily_rates.fetch(branch.id, nil)
+          result.worker_cost = calculate_worker_cost(result)
+          result.supplier_fee = calculate_supplier_fee(result)
         end
       end
     end
@@ -23,6 +26,20 @@ module SupplyTeachers
         telephone_number: branch.telephone_number,
         contact_email: branch.contact_email
       )
+    end
+
+    private
+
+    def calculate_worker_cost(result)
+      return unless result.daily_rate
+      return if result.daily_rate.empty?
+      result.daily_rate.to_i / (1 + result.rate)
+    end
+
+    def calculate_supplier_fee(result)
+      return unless result.daily_rate
+      return if result.daily_rate.empty?
+      result.daily_rate.to_i - result.worker_cost
     end
   end
 end

--- a/app/models/supply_teachers/journey/results.rb
+++ b/app/models/supply_teachers/journey/results.rb
@@ -11,8 +11,8 @@ module SupplyTeachers
           result.rate = rate(branch)
           result.distance = point.distance(branch.location)
           result.daily_rate = daily_rates.fetch(branch.id, nil)
-          result.worker_cost = calculate_worker_cost(result)
-          result.supplier_fee = calculate_supplier_fee(result)
+          result.worker_cost = supplier_mark_up(result.daily_rate, result.rate)&.worker_cost
+          result.supplier_fee = supplier_mark_up(result.daily_rate, result.rate)&.supplier_fee
         end
       end
     end
@@ -30,16 +30,11 @@ module SupplyTeachers
 
     private
 
-    def calculate_worker_cost(result)
-      return unless result.daily_rate
-      return if result.daily_rate.empty?
-      result.daily_rate.to_i / (1 + result.rate)
-    end
+    def supplier_mark_up(daily_rate, markup_rate)
+      return unless daily_rate && markup_rate
+      return if daily_rate.empty?
 
-    def calculate_supplier_fee(result)
-      return unless result.daily_rate
-      return if result.daily_rate.empty?
-      result.daily_rate.to_i - result.worker_cost
+      SupplierMarkUp.new(daily_rate: daily_rate, markup_rate: markup_rate)
     end
   end
 end

--- a/app/models/supply_teachers/journey/results.rb
+++ b/app/models/supply_teachers/journey/results.rb
@@ -16,6 +16,7 @@ module SupplyTeachers
 
     def search_result_for(branch)
       BranchSearchResult.new(
+        id: branch.id,
         supplier_name: branch.supplier.name,
         name: display_name_for_branch(branch),
         contact_name: branch.contact_name,

--- a/app/models/supply_teachers/supplier_mark_up.rb
+++ b/app/models/supply_teachers/supplier_mark_up.rb
@@ -1,0 +1,16 @@
+module SupplyTeachers
+  class SupplierMarkUp
+    include Virtus.model
+
+    attribute :daily_rate, Integer
+    attribute :markup_rate, Float
+
+    def worker_cost
+      daily_rate / (1 + markup_rate)
+    end
+
+    def supplier_fee
+      daily_rate - worker_cost
+    end
+  end
+end

--- a/app/views/supply_teachers/branches/_branch.html.erb
+++ b/app/views/supply_teachers/branches/_branch.html.erb
@@ -36,46 +36,48 @@
       </div>
     </div>
   </div>
-  <div class="govuk-!-padding-3 supplier-record__calculator">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <h4 class="govuk-heading-s"><%= t('.calculator.heading') %></h4>
-      </div>
-    </div>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <div class="govuk-form-group govuk-!-margin-0">
-          <label class="govuk-label govuk-!-font-size-16" for="daily_rate_<%= branch.id %>">
-            <%= t('.calculator.daily_rate') %>
-          </label>
-          <div class="calculator-form__day-rate">
-            <%= text_field_tag "daily_rate[#{branch.id}]", branch.daily_rate, class: 'govuk-input govuk-input--width-10 calculator-form__day-rate-input' %>
-            <i class="govuk-body calculator-form__day-rate-icon">£</i>
-          </div>
+  <% if link_to_calculator? %>
+    <div class="govuk-!-padding-3 supplier-record__calculator">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <h4 class="govuk-heading-s"><%= t('.calculator.heading') %></h4>
         </div>
       </div>
-      <div class="govuk-grid-column-one-third <%= 'supplier-record__calculator--muted' unless branch.worker_cost %>">
-        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">
-          <%= t('.calculator.worker_cost') %>
-        </p>
-        <p class="govuk-body supplier-record__worker-cost">
-          <% if branch.worker_cost %>
-            <%= number_to_currency(branch.worker_cost) %>
-          <% end %>
-        </p>
-      </div>
-      <div class="govuk-grid-column-one-third <%= 'supplier-record__calculator--muted' unless branch.supplier_fee %>">
-        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">
-          <%= t('.calculator.supplier_fee') %>
-        </p>
-        <p class="govuk-body supplier-record__supplier-fee">
-          <% if branch.supplier_fee %>
-            <%= number_to_currency(branch.supplier_fee) %>
-          <% end %>
-        </p>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <div class="govuk-form-group govuk-!-margin-0">
+            <label class="govuk-label govuk-!-font-size-16" for="daily_rate_<%= branch.id %>">
+              <%= t('.calculator.daily_rate') %>
+            </label>
+            <div class="calculator-form__day-rate">
+              <%= text_field_tag "daily_rate[#{branch.id}]", branch.daily_rate, class: 'govuk-input govuk-input--width-10 calculator-form__day-rate-input' %>
+              <i class="govuk-body calculator-form__day-rate-icon">£</i>
+            </div>
+          </div>
+        </div>
+        <div class="govuk-grid-column-one-third <%= 'supplier-record__calculator--muted' unless branch.worker_cost %>">
+          <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">
+            <%= t('.calculator.worker_cost') %>
+          </p>
+          <p class="govuk-body supplier-record__worker-cost">
+            <% if branch.worker_cost %>
+              <%= number_to_currency(branch.worker_cost) %>
+            <% end %>
+          </p>
+        </div>
+        <div class="govuk-grid-column-one-third <%= 'supplier-record__calculator--muted' unless branch.supplier_fee %>">
+          <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">
+            <%= t('.calculator.supplier_fee') %>
+          </p>
+          <p class="govuk-body supplier-record__supplier-fee">
+            <% if branch.supplier_fee %>
+              <%= number_to_currency(branch.supplier_fee) %>
+            <% end %>
+          </p>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 </div>

--- a/app/views/supply_teachers/branches/_branch.html.erb
+++ b/app/views/supply_teachers/branches/_branch.html.erb
@@ -39,7 +39,7 @@
   <div class="govuk-!-padding-3 supplier-record__calculator">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <h4 class="govuk-heading-s">Obtain a quote from the supplier to check the breakdown of daily rate</h4>
+        <h4 class="govuk-heading-s"><%= t('.calculator.heading') %></h4>
       </div>
     </div>
 
@@ -47,7 +47,7 @@
       <div class="govuk-grid-column-one-third">
         <div class="govuk-form-group govuk-!-margin-0">
           <label class="govuk-label govuk-!-font-size-16" for="daily_rate_<%= branch.id %>">
-            Enter daily rate
+            <%= t('.calculator.daily_rate') %>
           </label>
           <div class="calculator-form__day-rate">
             <%= text_field_tag "daily_rate[#{branch.id}]", branch.daily_rate, class: 'govuk-input govuk-input--width-10 calculator-form__day-rate-input' %>
@@ -57,7 +57,7 @@
       </div>
       <div class="govuk-grid-column-one-third <%= 'supplier-record__calculator--muted' unless branch.worker_cost %>">
         <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">
-          Cost of the worker
+          <%= t('.calculator.worker_cost') %>
         </p>
         <p class="govuk-body supplier-record__worker-cost">
           <% if branch.worker_cost %>
@@ -67,12 +67,12 @@
       </div>
       <div class="govuk-grid-column-one-third <%= 'supplier-record__calculator--muted' unless branch.supplier_fee %>">
         <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">
-          Supplier fee
+          <%= t('.calculator.supplier_fee') %>
         </p>
         <p class="govuk-body supplier-record__supplier-fee">
           <% if branch.supplier_fee %>
             <%= number_to_currency(branch.supplier_fee) %>
-          <% end%>
+          <% end %>
         </p>
       </div>
     </div>

--- a/app/views/supply_teachers/branches/_branch.html.erb
+++ b/app/views/supply_teachers/branches/_branch.html.erb
@@ -36,5 +36,46 @@
       </div>
     </div>
   </div>
+  <div class="govuk-!-padding-3 supplier-record__calculator">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h4 class="govuk-heading-s">Obtain a quote from the supplier to check the breakdown of daily rate</h4>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <div class="govuk-form-group govuk-!-margin-0">
+          <label class="govuk-label govuk-!-font-size-16" for="daily_rate_<%= branch.id %>">
+            Enter daily rate
+          </label>
+          <div class="calculator-form__day-rate">
+            <%= text_field_tag "daily_rate[#{branch.id}]", branch.daily_rate, class: 'govuk-input govuk-input--width-10 calculator-form__day-rate-input' %>
+            <i class="govuk-body calculator-form__day-rate-icon">£</i>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-grid-column-one-third <%= 'supplier-record__calculator--muted' unless branch.worker_cost %>">
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">
+          Cost of the worker
+        </p>
+        <p class="govuk-body supplier-record__worker-cost">
+          <% if branch.worker_cost %>
+            <%= number_to_currency(branch.worker_cost) %>
+          <% end %>
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-third <%= 'supplier-record__calculator--muted' unless branch.supplier_fee %>">
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">
+          Supplier fee
+        </p>
+        <p class="govuk-body supplier-record__supplier-fee">
+          <% if branch.supplier_fee %>
+            <%= number_to_currency(branch.supplier_fee) %>
+          <% end%>
+        </p>
+      </div>
+    </div>
+  </div>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 </div>

--- a/app/views/supply_teachers/branches/index.html.erb
+++ b/app/views/supply_teachers/branches/index.html.erb
@@ -73,30 +73,32 @@
     </div>
 
     <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <% if @branches.any? %>
-          <%= render partial: 'branch', collection: @branches %>
-        <% end %>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <div class="cmp-sidebar ccs-no-print">
-          <h2 class="govuk-heading-s"><%= t('.related_actions_html') %></h2>
-          <p class="govuk-body govuk-body-s supplier-record__print-option">
-            <a href="javascript:window.print()" class="govuk-link ga-print-link"><%= t('.print') %></a>
-          </p>
-          <p class="govuk-body govuk-body-s supplier-record__print-option">
-            <%= link_to t('.download'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx)), { class: 'supplier-record__file-download ga-download-shortlist', 'aria-label': t('.download_aria_label') } %>
-          </p>
-          <p class="govuk-body govuk-body-s supplier-record__print-option">
-            <% if link_to_calculator? %>
-            <%= link_to t('.download_with_calculator'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx, calculations: 'yes')), { class: 'supplier-record__file-download ga-download-calculator', 'aria-label': t('.download_with_calculator_aria_label') } %>
-            <% end %>
-          </p>
-
+    <%= form_tag @form_path, method: :get do %>
+      <%= hidden_fields_for_previous_steps_and_responses(@journey) %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <% if @branches.any? %>
+            <%= render partial: 'branch', collection: @branches %>
+          <% end %>
+        </div>
+        <div class="govuk-grid-column-one-third">
+          <div class="cmp-sidebar ccs-no-print">
+            <h2 class="govuk-heading-s"><%= t('.related_actions_html') %></h2>
+            <p class="govuk-body govuk-body-s supplier-record__print-option">
+              <a href="javascript:window.print()" class="govuk-link ga-print-link"><%= t('.print') %></a>
+            </p>
+            <p class="govuk-body govuk-body-s supplier-record__print-option">
+              <%= link_to t('.download'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx)), { class: 'supplier-record__file-download ga-download-shortlist', 'aria-label': t('.download_aria_label') } %>
+            </p>
+            <p class="govuk-body govuk-body-s supplier-record__print-option">
+              <% if link_to_calculator? %>
+              <%= link_to t('.download_with_calculator'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx, calculations: 'yes')), { class: 'supplier-record__file-download ga-download-calculator', 'aria-label': t('.download_with_calculator_aria_label') } %>
+              <% end %>
+            </p>
+            <%= submit_tag 'Calculate mark-up', class: "govuk-button" %>
+          </div>
         </div>
       </div>
-    </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/supply_teachers/branches/index.html.erb
+++ b/app/views/supply_teachers/branches/index.html.erb
@@ -90,12 +90,14 @@
             <p class="govuk-body govuk-body-s supplier-record__print-option">
               <%= link_to t('.download'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx)), { class: 'supplier-record__file-download ga-download-shortlist', 'aria-label': t('.download_aria_label') } %>
             </p>
-            <p class="govuk-body govuk-body-s supplier-record__print-option">
-              <% if link_to_calculator? %>
-              <%= link_to t('.download_with_calculator'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx, calculations: 'yes')), { class: 'supplier-record__file-download ga-download-calculator', 'aria-label': t('.download_with_calculator_aria_label') } %>
-              <% end %>
-            </p>
-            <%= submit_tag t('.calculate_markup'), class: "govuk-button" %>
+            <% if link_to_calculator? %>
+              <p class="govuk-body govuk-body-s supplier-record__print-option">
+                <%= link_to t('.download_with_calculator'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx, calculations: 'yes')), { class: 'supplier-record__file-download ga-download-calculator', 'aria-label': t('.download_with_calculator_aria_label') } %>
+              </p>
+              <h2 class="govuk-heading-s"><%= t('.calculate_markup') %></h2>
+              <p class="govuk-body govuk-body-s"><%= t('.calculate_markup_description') %></p>
+              <%= submit_tag t('.calculate_markup'), class: "govuk-button govuk-!-margin-0" %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/supply_teachers/branches/index.html.erb
+++ b/app/views/supply_teachers/branches/index.html.erb
@@ -95,7 +95,7 @@
               <%= link_to t('.download_with_calculator'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx, calculations: 'yes')), { class: 'supplier-record__file-download ga-download-calculator', 'aria-label': t('.download_with_calculator_aria_label') } %>
               <% end %>
             </p>
-            <%= submit_tag 'Calculate mark-up', class: "govuk-button" %>
+            <%= submit_tag t('.calculate_markup'), class: "govuk-button" %>
           </div>
         </div>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -304,13 +304,14 @@ en:
         branch: Branch
         calculator:
           daily_rate: Enter daily rate
-          heading: Obtain a quote from the supplier to check the breakdown of daily rate
+          heading: 'Enter the supplier’s quote to see how much the worker will get paid:'
           supplier_fee: Supplier fee
           worker_cost: Cost of the worker
         markup: Mark-up
         miles: Miles
       index:
         calculate_markup: Calculate mark-up
+        calculate_markup_description: See how much the woker makes and what fee the supplier will get using the figure they quoted you
         distance_aria_label_html: Set the radius to %{radius_setting}
         do_next:
           contact_supplier: contact the supplier of your choice from the list below to find a suitable, available worker and their daily rate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,9 +302,15 @@ en:
     branches:
       branch:
         branch: Branch
+        calculator:
+          daily_rate: Enter daily rate
+          heading: Obtain a quote from the supplier to check the breakdown of daily rate
+          supplier_fee: Supplier fee
+          worker_cost: Cost of the worker
         markup: Mark-up
         miles: Miles
       index:
+        calculate_markup: Calculate mark-up
         distance_aria_label_html: Set the radius to %{radius_setting}
         do_next:
           contact_supplier: contact the supplier of your choice from the list below to find a suitable, available worker and their daily rate

--- a/spec/factories/supply_teachers_branch_search_result.rb
+++ b/spec/factories/supply_teachers_branch_search_result.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :supply_teachers_branch_search_result, class: SupplyTeachers::BranchSearchResult do
+    id { SecureRandom.uuid }
     name { Faker::Company.unique.name }
     supplier_name { Faker::Company.unique.name }
     telephone_number { Faker::PhoneNumber.unique.phone_number }

--- a/spec/features/supply_teachers/supplier_markup_calculator.features_spec.rb
+++ b/spec/features/supply_teachers/supplier_markup_calculator.features_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.feature 'Supplier mark-up calculator', type: :feature do
+  before do
+    Geocoder::Lookup::Test.add_stub(
+      'WC2B 6TE', [{ 'coordinates' => [51.5149666, -0.119098] }]
+    )
+    holborn = create(:supply_teachers_supplier, name: 'holborn')
+    create(
+      :supply_teachers_rate,
+      supplier: holborn,
+      lot_number: 1,
+      job_type: 'fixed_term',
+      mark_up: 0.35
+    )
+    create(
+      :supply_teachers_branch,
+      supplier: holborn,
+      location: Geocoding.point(latitude: 51.5149666, longitude: -0.119098)
+    )
+    westminster = create(:supply_teachers_supplier, name: 'westminster')
+    create(
+      :supply_teachers_rate,
+      supplier: westminster,
+      lot_number: 1,
+      job_type: 'fixed_term',
+      mark_up: 0.30
+    )
+    create(
+      :supply_teachers_branch,
+      supplier: westminster,
+      location: Geocoding.point(latitude: 51.5185614, longitude: -0.1437991)
+    )
+  end
+
+  after do
+    Geocoder::Lookup::Test.reset
+  end
+
+  scenario 'Buyer can calculate the supplier mark-up' do
+    visit_supply_teachers_start
+
+    choose I18n.t('supply_teachers.journey.looking_for.answer_worker')
+    click_on I18n.t('common.submit')
+
+    choose 'Yes'
+    click_on I18n.t('common.submit')
+
+    choose 'No, I want to put the worker on our payroll'
+    click_on I18n.t('common.submit')
+
+    fill_in 'postcode', with: 'WC2B 6TE'
+    click_on I18n.t('common.submit')
+
+    within page.find('.supplier-record:first') do
+      fill_in 'Enter daily rate', with: '150'
+    end
+
+    click_on 'Calculate mark-up'
+
+    within page.find('.supplier-record:first') do
+      expect(page).to have_css('.supplier-record__worker-cost', text: '£115.38')
+      expect(page).to have_css('.supplier-record__supplier-fee', text: '£34.62')
+    end
+  end
+end

--- a/spec/features/supply_teachers/supplier_markup_calculator.features_spec.rb
+++ b/spec/features/supply_teachers/supplier_markup_calculator.features_spec.rb
@@ -9,8 +9,8 @@ RSpec.feature 'Supplier mark-up calculator', type: :feature do
     create(
       :supply_teachers_rate,
       supplier: holborn,
-      lot_number: 1,
-      job_type: 'fixed_term',
+      job_type: 'qt_sen',
+      term: 'twelve_weeks',
       mark_up: 0.35
     )
     create(
@@ -22,8 +22,8 @@ RSpec.feature 'Supplier mark-up calculator', type: :feature do
     create(
       :supply_teachers_rate,
       supplier: westminster,
-      lot_number: 1,
-      job_type: 'fixed_term',
+      job_type: 'qt_sen',
+      term: 'twelve_weeks',
       mark_up: 0.30
     )
     create(
@@ -46,10 +46,12 @@ RSpec.feature 'Supplier mark-up calculator', type: :feature do
     choose 'Yes'
     click_on I18n.t('common.submit')
 
-    choose 'No, I want to put the worker on our payroll'
+    choose 'Yes'
     click_on I18n.t('common.submit')
 
     fill_in 'postcode', with: 'WC2B 6TE'
+    choose '4 weeks to 8 weeks'
+    choose 'Qualified teacher: SEN roles'
     click_on I18n.t('common.submit')
 
     within page.find('.supplier-record:first') do

--- a/spec/models/generic_journey_spec.rb
+++ b/spec/models/generic_journey_spec.rb
@@ -332,12 +332,25 @@ RSpec.describe GenericJourney, type: :model do
       )
     end
 
+    before { allow(journey.current_step).to receive(:final?).and_return(false) }
+
     it 'includes previous questions and answers' do
       expect(journey.previous_questions_and_answers).to include('first_question' => 'first-answer')
     end
 
     it 'does not include current questions and answers' do
       expect(journey.previous_questions_and_answers).not_to include('second_question' => 'second-answer')
+    end
+
+    context 'when it’s the final step' do
+      before { allow(journey.current_step).to receive(:final?).and_return(true) }
+
+      it 'includes all answers' do
+        expect(journey.previous_questions_and_answers).to include(
+          'first_question' => 'first-answer',
+          'second_question' => 'second-answer'
+        )
+      end
     end
   end
 end

--- a/spec/models/supply_teachers/supplier_mark_up_spec.rb
+++ b/spec/models/supply_teachers/supplier_mark_up_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe SupplyTeachers::SupplierMarkUp, type: :model do
+  let(:supplier_mark_up) { described_class.new(daily_rate: daily_rate, markup_rate: markup_rate) }
+  let(:daily_rate) { '220' }
+  let(:markup_rate) { 0.44 }
+
+  describe '#worker_cost' do
+    it 'calculates the worker cost out of the daily rate' do
+      expect(supplier_mark_up.worker_cost).to be_within(0.1).of(152.78)
+    end
+  end
+
+  describe '#supplier_fee' do
+    it 'calculates the supplier’s fee out of the daily rate' do
+      expect(supplier_mark_up.supplier_fee).to be_within(0.1).of(67.22)
+    end
+  end
+end

--- a/spec/views/supply_teachers/branches/_branch.html.erb_spec.rb
+++ b/spec/views/supply_teachers/branches/_branch.html.erb_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'supply_teachers/branches/_branch.html.erb' do
   let(:contact_email) { Faker::Internet.unique.email }
   let(:branch) do
     SupplyTeachers::BranchSearchResult.new(
+      id: supplier.id,
       supplier_name: supplier.name,
       name: branch_name,
       telephone_number: telephone_number,

--- a/spec/views/supply_teachers/branches/_branch.html.erb_spec.rb
+++ b/spec/views/supply_teachers/branches/_branch.html.erb_spec.rb
@@ -19,8 +19,10 @@ RSpec.describe 'supply_teachers/branches/_branch.html.erb' do
       contact_email: contact_email
     )
   end
+  let(:link_to_calculator?) { true }
 
   before do
+    allow(view).to receive(:link_to_calculator?).and_return(link_to_calculator?)
     render 'supply_teachers/branches/branch', branch: branch
   end
 
@@ -45,6 +47,18 @@ RSpec.describe 'supply_teachers/branches/_branch.html.erb' do
 
     it 'does not display branch or its label' do
       expect(rendered).not_to have_content('Branch:')
+    end
+  end
+
+  it 'displays the online calculator' do
+    expect(rendered).to have_content(I18n.t('supply_teachers.branches.branch.calculator.heading'))
+  end
+
+  context 'when shortlisting for teachers on school payroll' do
+    let(:link_to_calculator?) { false }
+
+    it 'does not display the online calculator' do
+      expect(rendered).not_to have_content(I18n.t('supply_teachers.branches.branch.calculator.heading'))
     end
   end
 end

--- a/spec/views/supply_teachers/branches/index.html.erb_spec.rb
+++ b/spec/views/supply_teachers/branches/index.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'supply_teachers/branches/index.html.erb' do
     }
   end
 
-  let(:journey) { instance_double('Journey', params: {}, inputs: inputs) }
+  let(:journey) { instance_double('Journey', params: {}, inputs: inputs, previous_questions_and_answers: {}) }
   let(:first_supplier) { build(:supply_teachers_supplier, name: 'First Supplier') }
   let(:second_supplier) { build(:supply_teachers_supplier, name: 'Second Supplier') }
 
@@ -32,6 +32,8 @@ RSpec.describe 'supply_teachers/branches/index.html.erb' do
   let(:link_to_calculator) { true }
 
   before do
+    view.extend(ApplicationHelper)
+
     assign(:journey, journey)
     assign(:branches, branches)
     assign(:location, location)

--- a/spec/views/supply_teachers/branches/index.html.erb_spec.rb
+++ b/spec/views/supply_teachers/branches/index.html.erb_spec.rb
@@ -80,11 +80,19 @@ RSpec.describe 'supply_teachers/branches/index.html.erb' do
     expect(rendered).to have_link('Download shortlist (with markup calculator)')
   end
 
+  it 'has a button to calculate the mark-up' do
+    expect(rendered).to have_button(I18n.t('supply_teachers.branches.index.calculate_markup'))
+  end
+
   context 'when shortlisting for teachers on school payroll' do
     let(:link_to_calculator) { false }
 
     it 'does not have a link to download the calculator' do
       expect(rendered).not_to have_link('Download shortlist (with markup calculator)')
+    end
+
+    it 'does not have a button to calculate the mark-up' do
+      expect(rendered).not_to have_button(I18n.t('supply_teachers.branches.index.calculate_markup'))
     end
   end
 


### PR DESCRIPTION
# Goal 

We need to allow the supplier mark-up calculation to happen on-screen in a way that the buyer can meaningfully compare the calculations for the quotes from the different suppliers

# Next step

Allow the calculations to be done without submitting the form, via Ajax

# Screenshot

<img width="1004" alt="screenshot 2019-01-21 at 17 05 48" src="https://user-images.githubusercontent.com/2804149/51490282-b760e980-1da2-11e9-856c-347f7ff9a41f.png">

