### PR TITLE
(fix) Temp-to-perm calculator dates now require a year

### DIFF
--- a/app/models/supply_teachers/journey/temp_to_perm_calculator.rb
+++ b/app/models/supply_teachers/journey/temp_to_perm_calculator.rb
@@ -116,48 +116,71 @@ module SupplyTeachers
     validate :ensure_notice_date_is_after_contract_start_date
     validate :ensure_notice_date_is_before_hire_date
 
+    PARSED_DATE_FORMAT = '%Y-%m-%d'.freeze
+
     def next_step_class
       Journey::TempToPermFee
     end
 
     def contract_start_date
-      Date.parse("#{contract_start_date_year}-#{contract_start_date_month}-#{contract_start_date_day}")
+      Date.strptime(
+        "#{contract_start_date_year}-#{contract_start_date_month}-#{contract_start_date_day}",
+        PARSED_DATE_FORMAT
+      )
     rescue ArgumentError
       nil
     end
 
     def hire_date
-      Date.parse("#{hire_date_year}-#{hire_date_month}-#{hire_date_day}")
+      Date.strptime(
+        "#{hire_date_year}-#{hire_date_month}-#{hire_date_day}",
+        PARSED_DATE_FORMAT
+      )
     rescue ArgumentError
       nil
     end
 
     def notice_date
-      Date.parse("#{notice_date_year}-#{notice_date_month}-#{notice_date_day}")
+      Date.strptime(
+        "#{notice_date_year}-#{notice_date_month}-#{notice_date_day}",
+        PARSED_DATE_FORMAT
+      )
     rescue ArgumentError
       nil
     end
 
     def holiday_1_start_date
-      Date.parse("#{holiday_1_start_date_year}-#{holiday_1_start_date_month}-#{holiday_1_start_date_day}")
+      Date.strptime(
+        "#{holiday_1_start_date_year}-#{holiday_1_start_date_month}-#{holiday_1_start_date_day}",
+        PARSED_DATE_FORMAT
+      )
     rescue ArgumentError
       nil
     end
 
     def holiday_1_end_date
-      Date.parse("#{holiday_1_end_date_year}-#{holiday_1_end_date_month}-#{holiday_1_end_date_day}")
+      Date.strptime(
+        "#{holiday_1_end_date_year}-#{holiday_1_end_date_month}-#{holiday_1_end_date_day}",
+        PARSED_DATE_FORMAT
+      )
     rescue ArgumentError
       nil
     end
 
     def holiday_2_start_date
-      Date.parse("#{holiday_2_start_date_year}-#{holiday_2_start_date_month}-#{holiday_2_start_date_day}")
+      Date.strptime(
+        "#{holiday_2_start_date_year}-#{holiday_2_start_date_month}-#{holiday_2_start_date_day}",
+        PARSED_DATE_FORMAT
+      )
     rescue ArgumentError
       nil
     end
 
     def holiday_2_end_date
-      Date.parse("#{holiday_2_end_date_year}-#{holiday_2_end_date_month}-#{holiday_2_end_date_day}")
+      Date.strptime(
+        "#{holiday_2_end_date_year}-#{holiday_2_end_date_month}-#{holiday_2_end_date_day}",
+        PARSED_DATE_FORMAT
+      )
     rescue ArgumentError
       nil
     end

--- a/spec/models/supply_teachers/journey/temp_to_perm_calculator_spec.rb
+++ b/spec/models/supply_teachers/journey/temp_to_perm_calculator_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe SupplyTeachers::Journey::TempToPermCalculator, type: :model do
 
   let(:model_key) { 'activemodel.errors.models.supply_teachers/journey/temp_to_perm_calculator' }
 
-  let(:contract_start_date_day) { 1 }
+  let(:contract_start_date_day) { 11 }
   let(:contract_start_date_month) { 1 }
   let(:contract_start_date_year) { 1970 }
 
-  let(:hire_date_day) { 2 }
+  let(:hire_date_day) { 12 }
   let(:hire_date_month) { 1 }
   let(:hire_date_year) { 1970 }
 
@@ -74,7 +74,7 @@ RSpec.describe SupplyTeachers::Journey::TempToPermCalculator, type: :model do
 
   describe '#contract_start_date' do
     it 'returns date instance constructed from day, month & year' do
-      expect(step.contract_start_date).to eq(Date.parse('1970-01-01'))
+      expect(step.contract_start_date).to eq(Date.parse('1970-01-11'))
     end
 
     context 'when day is missing' do
@@ -93,7 +93,7 @@ RSpec.describe SupplyTeachers::Journey::TempToPermCalculator, type: :model do
       end
     end
 
-    context 'when day is missing' do
+    context 'when year is missing' do
       let(:contract_start_date_year) { nil }
 
       it 'returns nil' do
@@ -104,7 +104,7 @@ RSpec.describe SupplyTeachers::Journey::TempToPermCalculator, type: :model do
 
   describe '#hire_date' do
     it 'returns date instance constructed from day, month & year' do
-      expect(step.hire_date).to eq(Date.parse('1970-01-02'))
+      expect(step.hire_date).to eq(Date.parse('1970-01-12'))
     end
 
     context 'when day is missing' do
@@ -123,7 +123,7 @@ RSpec.describe SupplyTeachers::Journey::TempToPermCalculator, type: :model do
       end
     end
 
-    context 'when day is missing' do
+    context 'when year is missing' do
       let(:hire_date_year) { nil }
 
       it 'returns nil' do
@@ -133,12 +133,12 @@ RSpec.describe SupplyTeachers::Journey::TempToPermCalculator, type: :model do
   end
 
   describe '#notice_date' do
-    let(:notice_date_day) { 3 }
+    let(:notice_date_day) { 13 }
     let(:notice_date_month) { 1 }
     let(:notice_date_year) { 1970 }
 
     it 'returns date instance constructed from day, month & year' do
-      expect(step.notice_date).to eq(Date.parse('1970-01-03'))
+      expect(step.notice_date).to eq(Date.parse('1970-01-13'))
     end
 
     context 'when day is missing' do
@@ -167,12 +167,12 @@ RSpec.describe SupplyTeachers::Journey::TempToPermCalculator, type: :model do
   end
 
   describe '#holiday_1_start_date' do
-    let(:holiday_1_start_date_day) { 4 }
+    let(:holiday_1_start_date_day) { 14 }
     let(:holiday_1_start_date_month) { 1 }
     let(:holiday_1_start_date_year) { 1970 }
 
     it 'returns date instance constructed from day, month & year' do
-      expect(step.holiday_1_start_date).to eq(Date.parse('1970-01-04'))
+      expect(step.holiday_1_start_date).to eq(Date.parse('1970-01-14'))
     end
 
     context 'when day is missing' do
@@ -201,12 +201,12 @@ RSpec.describe SupplyTeachers::Journey::TempToPermCalculator, type: :model do
   end
 
   describe '#holiday_1_end_date' do
-    let(:holiday_1_end_date_day) { 5 }
+    let(:holiday_1_end_date_day) { 15 }
     let(:holiday_1_end_date_month) { 1 }
     let(:holiday_1_end_date_year) { 1970 }
 
     it 'returns date instance constructed from day, month & year' do
-      expect(step.holiday_1_end_date).to eq(Date.parse('1970-01-05'))
+      expect(step.holiday_1_end_date).to eq(Date.parse('1970-01-15'))
     end
 
     context 'when day is missing' do
@@ -235,12 +235,12 @@ RSpec.describe SupplyTeachers::Journey::TempToPermCalculator, type: :model do
   end
 
   describe '#holiday_2_start_date' do
-    let(:holiday_2_start_date_day) { 6 }
+    let(:holiday_2_start_date_day) { 16 }
     let(:holiday_2_start_date_month) { 1 }
     let(:holiday_2_start_date_year) { 1970 }
 
     it 'returns date instance constructed from day, month & year' do
-      expect(step.holiday_2_start_date).to eq(Date.parse('1970-01-06'))
+      expect(step.holiday_2_start_date).to eq(Date.parse('1970-01-16'))
     end
 
     context 'when day is missing' do
@@ -269,12 +269,12 @@ RSpec.describe SupplyTeachers::Journey::TempToPermCalculator, type: :model do
   end
 
   describe '#holiday_2_end_date' do
-    let(:holiday_2_end_date_day) { 1970 }
+    let(:holiday_2_end_date_day) { 17 }
     let(:holiday_2_end_date_month) { 1 }
-    let(:holiday_2_end_date_year) { 7 }
+    let(:holiday_2_end_date_year) { 1970 }
 
     it 'returns date instance constructed from day, month & year' do
-      expect(step.holiday_2_end_date).to eq(Date.parse('1970-01-07'))
+      expect(step.holiday_2_end_date).to eq(Date.parse('1970-01-17'))
     end
 
     context 'when day is missing' do


### PR DESCRIPTION
We had an issue with using `Date.parse("YYYY-MM-DD")`, if you leave the year off it defaults to this year. Our tests that check for the presence of 'year' were passing incorrectly because they were using a single digit month for the day, which combined with the absence of the year produced an ArgumentError as expected. eg. `Date.parse("-1-1")` is invalid as our tests expected but `Date.parse("-1-11")` is valid

To get the tests failing in the right way we had to change the day used for each fixture to double digits.

We then fixed the check for the presence of year by telling the `Date` object which format we expect the date string to be in. Now if you omit the year you get an ArgumentError as expected.