### PR TITLE
(chore) Make it clear to users why they are not permitted access to s…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,7 +69,7 @@ class ApplicationController < ActionController::Base
   helper_method :logged_in?
 
   def deny_access
-    render template: 'shared/not_permitted', status: 403
+    render template: 'shared/not_permitted', status: 403, locals: { permission_required: @permission_required }
   end
 
   delegate :ccs_homepage_url, to: Marketplace

--- a/app/views/shared/not_permitted.html.erb
+++ b/app/views/shared/not_permitted.html.erb
@@ -2,9 +2,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl"><%= t('.title') %></h1>
+      <h1 class="govuk-heading-xl"><%= t(".#{permission_required.to_s}.title") %></h1>
 
-      <p><%= t('.details') %></p>
+      <p><%= t(".#{permission_required.to_s}.details") %></p>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,8 +292,15 @@ en:
     error_summary:
       there_is_a_problem: There is a problem
     not_permitted:
-      details: You don’t have permission to view this page.
-      title: Not permitted
+      facilities_management:
+        details: You don’t have permission to view this page.
+        title: Not permitted
+      management_consultancy:
+        details: You don’t have permission to view this page.
+        title: Not permitted
+      supply_teachers:
+        details: It looks like you're from a school that's not able to use this service. Only not-for-profit and schools with charitable status are able to get access to the service.
+        title: Not permitted
   suppliers:
     unit:
       one: supplier

--- a/spec/features/authentication.feature_spec.rb
+++ b/spec/features/authentication.feature_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Authentication', type: :feature do
 
     visit '/management-consultancy/start'
 
-    expect(page).to have_text('You don’t have permission to view this page')
+    expect(page).to have_text(I18n.t('shared.not_permitted.management_consultancy.title'))
   end
 
   scenario 'DfE users cannot see school pages if they are from a for-profit school' do
@@ -90,7 +90,7 @@ RSpec.feature 'Authentication', type: :feature do
 
     visit '/supply-teachers/start'
 
-    expect(page).to have_text('You don’t have permission to view this page')
+    expect(page).to have_text(I18n.t('shared.not_permitted.supply_teachers.title'))
   end
 
   scenario 'DfE users cannot see school pages if they are not on the whitelist' do
@@ -105,7 +105,7 @@ RSpec.feature 'Authentication', type: :feature do
 
     visit '/supply-teachers/start'
 
-    expect(page).to have_text('You don’t have permission to view this page')
+    expect(page).to have_text(I18n.t('shared.not_permitted.supply_teachers.title'))
   end
 
   scenario 'Visitors to the normal school gateway do not see a Cognito option when disabled' do


### PR DESCRIPTION
…ervice

Trellocard: https://trello.com/c/2fbP2fUr/970-make-it-clear-to-users-why-they-are-not-permitted-access-to-service

![screenshot 2019-01-24 at 10 29 06](https://user-images.githubusercontent.com/1089521/51674802-a9d97880-1fc9-11e9-8828-c1874f32fff6.png)
