### PR TITLE
(chore) add extra header to the downloadable calculator

### DIFF
--- a/app/models/supply_teachers/spreadsheet.rb
+++ b/app/models/supply_teachers/spreadsheet.rb
@@ -6,6 +6,10 @@ class SupplyTeachers::Spreadsheet
       'Suppliers'
     end
 
+    def title
+      ['Supplier list']
+    end
+
     def headers
       ['Supplier name', 'Branch name', 'Contact name', 'Contact email', 'Telephone number']
     end
@@ -30,9 +34,15 @@ class SupplyTeachers::Spreadsheet
       'Supplier shortlist'
     end
 
+    def title
+      extra_title =
+        ['', '', '', '', '', 'Enter the supplier’s quote to see how much the worker will get paid']
+      super + extra_title
+    end
+
     def headers
       extra_headers =
-        ['Mark-up', 'Daily quote', 'Costs of the worker', 'Supplier fee']
+        ['Mark-up', 'Enter daily rate', 'Cost of the worker', 'Supplier fee']
       super + extra_headers
     end
 
@@ -52,13 +62,13 @@ class SupplyTeachers::Spreadsheet
 
     def style(workbook, sheet)
       workbook.styles do |s|
-        percent = s.add_style(format_code: '00%')
+        percent = s.add_style(format_code: '0%')
         money = s.add_style(format_code: '[$£-809]##,##0.00')
         sheet.col_style 5, percent
         sheet.col_style 6, money
         sheet.col_style 7, money
         sheet.col_style 8, money
-        sheet.column_widths(*Array.new(headers.length))
+        sheet.column_widths(nil, nil, nil, nil, nil, nil, 20, 20, 20)
       end
     end
   end
@@ -68,10 +78,12 @@ class SupplyTeachers::Spreadsheet
     @format = with_calculations ? Shortlist.new : DataDownload.new
   end
 
-  def to_xlsx
+  def to_xlsx(with_calculations: false)
     spreadsheet(@format.sheet_name) do |workbook, sheet|
+      sheet.add_row @format.title
+      sheet.merge_cells 'G1:I1' if with_calculations
       sheet.add_row @format.headers
-      @branches.each.with_index(2) do |branch, i|
+      @branches.each.with_index(3) do |branch, i|
         sheet.add_row @format.row(branch, i), types: @format.types
       end
       @format.style(workbook, sheet)

--- a/spec/models/supply_teachers/spreadsheet_spec.rb
+++ b/spec/models/supply_teachers/spreadsheet_spec.rb
@@ -15,12 +15,18 @@ RSpec.describe SupplyTeachers::Spreadsheet do
       expect(worksheet.sheet_name).to eq 'Suppliers'
     end
 
-    it 'has one header row and two data rows' do
-      expect(worksheet.to_a.size).to eq 3
+    it 'has two header row and two data rows' do
+      expect(worksheet.to_a.size).to eq 4
     end
 
-    it 'has the correct header row' do
+    it 'has the correct header row 1' do
       expect(worksheet[0].cells.map(&:value)).to eq [
+        'Supplier list'
+      ]
+    end
+
+    it 'has the correct header row 2' do
+      expect(worksheet[1].cells.map(&:value)).to eq [
         'Supplier name',
         'Branch name',
         'Contact name',
@@ -30,7 +36,7 @@ RSpec.describe SupplyTeachers::Spreadsheet do
     end
 
     it 'has the correct data for branch 1' do
-      expect(worksheet[1].cells.map(&:value)).to eq [
+      expect(worksheet[2].cells.map(&:value)).to eq [
         branch1.supplier_name,
         branch1.name,
         branch1.contact_name,
@@ -40,7 +46,7 @@ RSpec.describe SupplyTeachers::Spreadsheet do
     end
 
     it 'has the correct data for branch 2' do
-      expect(worksheet[2].cells.map(&:value)).to eq [
+      expect(worksheet[3].cells.map(&:value)).to eq [
         branch2.supplier_name,
         branch2.name,
         branch2.contact_name,
@@ -53,7 +59,7 @@ RSpec.describe SupplyTeachers::Spreadsheet do
       let(:telephone_number) { '01214960123' }
 
       it 'is formatted' do
-        expect(worksheet[1].cells.map(&:value)[4])
+        expect(worksheet[2].cells.map(&:value)[4])
           .to eq('0121 496 0123')
       end
     end
@@ -62,7 +68,7 @@ RSpec.describe SupplyTeachers::Spreadsheet do
       let(:telephone_number) { '0111111111111' }
 
       it 'does not become a number' do
-        expect(worksheet[1].cells.map(&:value)[4])
+        expect(worksheet[2].cells.map(&:value)[4])
           .to eq(telephone_number)
       end
     end


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/fJpIkAHZ/935-change-downloadable-calculator-to-have-clearer-instructions

## Changes in this PR:
- Insert an extra header to the spreadsheets
- Updated the header copy of mark-up calculator
- Added a fixed width for the fields of mark-up calculator
- Do not display the leading 0 if the mark-up percentage is in single digit

## Screenshots of UI changes:

### Before (spreadsheet without calculator)
<img width="1099" alt="screenshot 2019-01-24 at 10 16 44" src="https://user-images.githubusercontent.com/6421298/51827420-4f6f4d80-2324-11e9-96ba-fa445f5eec58.png">

### After  (spreadsheet without calculator)
<img width="1091" alt="screenshot 2019-01-23 at 15 33 22" src="https://user-images.githubusercontent.com/6421298/51827454-66ae3b00-2324-11e9-8cf9-f246bb2fd989.png">

### Before (spreadsheet with calculator)
<img width="1445" alt="screenshot 2019-01-24 at 10 17 10" src="https://user-images.githubusercontent.com/6421298/51827498-8180af80-2324-11e9-8c05-e3712bf9ff71.png">


### After (spreadsheet with calculator)
<img width="1575" alt="screenshot 2019-01-24 at 10 48 02" src="https://user-images.githubusercontent.com/6421298/51827506-87769080-2324-11e9-91bd-b689049806cf.png">
