### PR TITLE
(fix) show distance selectors when printing supplier list

### DIFF
--- a/app/views/supply_teachers/branches/index.html.erb
+++ b/app/views/supply_teachers/branches/index.html.erb
@@ -51,7 +51,7 @@
         %>
         <%= t('.other_radius_html') %>
         <% @alternative_radiuses.each do |radius| %>
-          <span class="ccs-no-print st-supplier-page__radius-list-item"><%=
+          <span class="st-supplier-page__radius-list-item"><%=
             link_to(
               number_to_human(radius, units: :miles),
               supply_teachers_branches_path(@journey.params.merge(radius: radius)),
@@ -82,7 +82,7 @@
           <% end %>
         </div>
         <div class="govuk-grid-column-one-third">
-          <div class="cmp-sidebar ccs-no-print">
+          <div class="cmp-sidebar">
             <h2 class="govuk-heading-s"><%= t('.related_actions_html') %></h2>
             <p class="govuk-body govuk-body-s supplier-record__print-option">
               <a href="javascript:window.print()" class="govuk-link ga-print-link"><%= t('.print') %></a>


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/WiatSrp6/963-print-page-content

## Changes in this PR:
- Show distance selectors when printing the supplier list
- Show sidebar options when printing the supplier list

## Screenshots of UI changes:

### Before
<img width="1018" alt="screenshot 2019-01-28 at 20 54 48" src="https://user-images.githubusercontent.com/6421298/51837805-8d2d9f80-233f-11e9-9b67-d4e6bd5b099d.png">


### After
<img width="1015" alt="screenshot 2019-01-28 at 20 54 11" src="https://user-images.githubusercontent.com/6421298/51837814-91f25380-233f-11e9-95f8-a5b2e32cfba1.png">
