### PR TITLE
(fix) remove url from distance and download items when printing

### DIFF
--- a/app/assets/stylesheets/components/sidebar/_sidebar.scss
+++ b/app/assets/stylesheets/components/sidebar/_sidebar.scss
@@ -2,3 +2,8 @@
 	background-color: govuk-colour("grey-4");
 	padding: 25px;
 }
+@media print {
+	.cmp-sidebar a[href]:after { 
+		content: none !important; 
+	}
+}

--- a/app/assets/stylesheets/components/st-supplier-page/_st-supplier-page.scss
+++ b/app/assets/stylesheets/components/st-supplier-page/_st-supplier-page.scss
@@ -2,3 +2,8 @@
 	margin-right: 10px;
 	white-space: nowrap;
 }
+@media print {
+	.st-supplier-page__radius-list-item a[href]:after { 
+		content: none !important; 
+	}
+}


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/WiatSrp6/963-print-page-content

## Changes in this PR:
- Removed URLs from distance selectors and download items when printing pages

## Screenshots of UI changes:

### Before
<img width="1015" alt="screenshot 2019-01-28 at 20 54 11" src="https://user-images.githubusercontent.com/6421298/51844870-4a74c300-2351-11e9-9fe1-e8d17d6237a5.png">


### After
<img width="1011" alt="screenshot 2019-01-28 at 22 58 21" src="https://user-images.githubusercontent.com/6421298/51844878-4f397700-2351-11e9-9f7d-53b0f092b0ca.png">
