### PR TITLE
(chore) online calculator content update

### DIFF
--- a/app/assets/stylesheets/components/supplier-record/_supplier-record.scss
+++ b/app/assets/stylesheets/components/supplier-record/_supplier-record.scss
@@ -67,7 +67,7 @@
 }
 
 .supplier-record__worker-cost,
-.supplier-record__supplier-fee
+.supplier-record__agency-fee
 {
   margin: 10px 0 0 0;
   font-size: 24px;

--- a/app/models/supply_teachers/branch_search_result.rb
+++ b/app/models/supply_teachers/branch_search_result.rb
@@ -10,7 +10,7 @@ module SupplyTeachers
     attr_accessor :distance
     attr_accessor :daily_rate
     attr_accessor :worker_cost
-    attr_accessor :supplier_fee
+    attr_accessor :agency_fee
 
     def initialize(id:, supplier_name:, name:, contact_name:,
                    telephone_number:, contact_email:)

--- a/app/models/supply_teachers/journey/results.rb
+++ b/app/models/supply_teachers/journey/results.rb
@@ -12,7 +12,7 @@ module SupplyTeachers
           result.distance = point.distance(branch.location)
           result.daily_rate = daily_rates.fetch(branch.id, nil)
           result.worker_cost = supplier_mark_up(result.daily_rate, result.rate)&.worker_cost
-          result.supplier_fee = supplier_mark_up(result.daily_rate, result.rate)&.supplier_fee
+          result.agency_fee = supplier_mark_up(result.daily_rate, result.rate)&.agency_fee
         end
       end
     end

--- a/app/models/supply_teachers/supplier_mark_up.rb
+++ b/app/models/supply_teachers/supplier_mark_up.rb
@@ -9,7 +9,7 @@ module SupplyTeachers
       daily_rate / (1 + markup_rate)
     end
 
-    def supplier_fee
+    def agency_fee
       daily_rate - worker_cost
     end
   end

--- a/app/views/supply_teachers/branches/_branch.html.erb
+++ b/app/views/supply_teachers/branches/_branch.html.erb
@@ -66,13 +66,13 @@
             <% end %>
           </p>
         </div>
-        <div class="govuk-grid-column-one-third <%= 'supplier-record__calculator--muted' unless branch.supplier_fee %>">
+        <div class="govuk-grid-column-one-third <%= 'supplier-record__calculator--muted' unless branch.agency_fee %>">
           <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">
-            <%= t('.calculator.supplier_fee') %>
+            <%= t('.calculator.agency_fee') %>
           </p>
-          <p class="govuk-body supplier-record__supplier-fee">
-            <% if branch.supplier_fee %>
-              <%= number_to_currency(branch.supplier_fee) %>
+          <p class="govuk-body supplier-record__agency-fee">
+            <% if branch.agency_fee %>
+              <%= number_to_currency(branch.agency_fee) %>
             <% end %>
           </p>
         </div>

--- a/app/views/supply_teachers/branches/index.html.erb
+++ b/app/views/supply_teachers/branches/index.html.erb
@@ -94,9 +94,9 @@
               <p class="govuk-body govuk-body-s supplier-record__print-option">
                 <%= link_to t('.download_with_calculator'), supply_teachers_branches_path(@journey.params.merge(format: :xlsx, calculations: 'yes')), { class: 'supplier-record__file-download ga-download-calculator', 'aria-label': t('.download_with_calculator_aria_label') } %>
               </p>
-              <h2 class="govuk-heading-s"><%= t('.calculate_markup') %></h2>
+              <h2 class="govuk-heading-s"><%= t('.calculate_markup_heading') %></h2>
               <p class="govuk-body govuk-body-s"><%= t('.calculate_markup_description') %></p>
-              <%= submit_tag t('.calculate_markup'), class: "govuk-button govuk-!-margin-0" %>
+              <%= submit_tag t('.calculate_markup_button_label'), class: "govuk-button govuk-!-margin-0" %>
             <% end %>
           </div>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -310,15 +310,16 @@ en:
       branch:
         branch: Branch
         calculator:
+          agency_fee: Agency fee
           daily_rate: Enter daily rate
-          heading: 'Enter the supplier’s quote to see how much the worker will get paid:'
-          supplier_fee: Supplier fee
+          heading: 'Enter the quote from this agency to see what their fee will be:'
           worker_cost: Cost of the worker
         markup: Mark-up
         miles: Miles
       index:
-        calculate_markup: Calculate mark-up
-        calculate_markup_description: 'See how much the worker makes and what fee the supplier will get using the figure they quoted you:'
+        calculate_markup_button_label: Calculate the fee
+        calculate_markup_description: 'See how much the worker makes and what fee the agency will get using the figure they quoted you:'
+        calculate_markup_heading: Calculate agency fee
         distance_aria_label_html: Set the radius to %{radius_setting}
         do_next:
           contact_supplier: contact the supplier of your choice from the list below to find a suitable, available worker and their daily rate

--- a/spec/features/supply_teachers/supplier_markup_calculator.features_spec.rb
+++ b/spec/features/supply_teachers/supplier_markup_calculator.features_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'Supplier mark-up calculator', type: :feature do
     Geocoder::Lookup::Test.reset
   end
 
-  scenario 'Buyer can calculate the supplier mark-up' do
+  scenario 'Buyer can calculate the agency mark-up' do
     visit_supply_teachers_start
 
     choose I18n.t('supply_teachers.journey.looking_for.answer_worker')
@@ -58,11 +58,11 @@ RSpec.feature 'Supplier mark-up calculator', type: :feature do
       fill_in 'Enter daily rate', with: '150'
     end
 
-    click_on 'Calculate mark-up'
+    click_on 'Calculate the fee'
 
     within page.find('.supplier-record:first') do
       expect(page).to have_css('.supplier-record__worker-cost', text: '£115.38')
-      expect(page).to have_css('.supplier-record__supplier-fee', text: '£34.62')
+      expect(page).to have_css('.supplier-record__agency-fee', text: '£34.62')
     end
   end
 end

--- a/spec/models/supply_teachers/supplier_mark_up_spec.rb
+++ b/spec/models/supply_teachers/supplier_mark_up_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe SupplyTeachers::SupplierMarkUp, type: :model do
     end
   end
 
-  describe '#supplier_fee' do
-    it 'calculates the supplier’s fee out of the daily rate' do
-      expect(supplier_mark_up.supplier_fee).to be_within(0.1).of(67.22)
+  describe '#agency_fee' do
+    it 'calculates the agency’s fee out of the daily rate' do
+      expect(supplier_mark_up.agency_fee).to be_within(0.1).of(67.22)
     end
   end
 end

--- a/spec/views/supply_teachers/branches/index.html.erb_spec.rb
+++ b/spec/views/supply_teachers/branches/index.html.erb_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'supply_teachers/branches/index.html.erb' do
   end
 
   it 'has a button to calculate the mark-up' do
-    expect(rendered).to have_button(I18n.t('supply_teachers.branches.index.calculate_markup'))
+    expect(rendered).to have_button(I18n.t('supply_teachers.branches.index.calculate_markup_button_label'))
   end
 
   context 'when shortlisting for teachers on school payroll' do
@@ -92,7 +92,7 @@ RSpec.describe 'supply_teachers/branches/index.html.erb' do
     end
 
     it 'does not have a button to calculate the mark-up' do
-      expect(rendered).not_to have_button(I18n.t('supply_teachers.branches.index.calculate_markup'))
+      expect(rendered).not_to have_button(I18n.t('supply_teachers.branches.index.calculate_markup_button_label'))
     end
   end
 


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/rEDidMZB/958-content-about-online-calculator

## Changes in this PR:
- Update online calculator heading
- Change `supplier fee` to `agency fee`
- Change the heading of the calculate mark-up section at the sidebar
- Change copy of the calculate mark-up section at the sidebar
- Change button label of the calculate mark-up section sidebar

## Screenshots of UI changes:

### Before
<img width="994" alt="screenshot 2019-01-29 at 17 58 48" src="https://user-images.githubusercontent.com/6421298/51900405-30d68880-23f0-11e9-8d71-da888fec5efb.png">


### After
<img width="993" alt="screenshot 2019-01-29 at 17 58 30" src="https://user-images.githubusercontent.com/6421298/51900418-3502a600-23f0-11e9-914f-8f13b108c019.png">

