### PR TITLE
(chore) Tidy up login log lines

### DIFF
--- a/app/models/login/base_login.rb
+++ b/app/models/login/base_login.rb
@@ -27,11 +27,10 @@ module Login
       raise 'not implemented'
     end
 
-    def log_attempt(result)
+    def log_attempt(result, framework)
       success = result ? 'successful' : 'unsuccessful'
-      school_type_id = @extra.nil? ? nil : "school type id: #{@extra['school_type_id']}, "
       Rails.logger.info(
-        "Login attempt from #{auth_provider} > email: #{@email}, #{school_type_id}result: #{success}"
+        "Login attempt to #{framework} from #{auth_provider} > email: #{@email}, result: #{success}"
       )
     end
   end

--- a/app/models/login/cognito_login.rb
+++ b/app/models/login/cognito_login.rb
@@ -12,8 +12,8 @@ module Login
       ::Cognito.logout_url(routable.gateway_url)
     end
 
-    def permit?(_framework)
-      log_attempt(true)
+    def permit?(framework)
+      log_attempt(true, framework)
       true
     end
   end

--- a/app/models/login/dfe_login.rb
+++ b/app/models/login/dfe_login.rb
@@ -23,7 +23,7 @@ module Login
 
     def permit?(framework)
       result = framework == :supply_teachers && non_profit? && whitelisted?
-      log_attempt(result)
+      log_attempt(result, framework)
       result
     end
 

--- a/spec/models/login/cognito_login_spec.rb
+++ b/spec/models/login/cognito_login_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Login::CognitoLogin, type: :model do
     it 'logs the attempt' do
       login.permit?(:supply_teachers)
       expect(Rails.logger).to have_received(:info)
-        .with('Login attempt from cognito > email: user@example.com, result: successful')
+        .with('Login attempt to supply_teachers from cognito > email: user@example.com, result: successful')
     end
   end
 

--- a/spec/models/login/dfe_login_spec.rb
+++ b/spec/models/login/dfe_login_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Login::DfeLogin, type: :model do
         it 'logs the attempt' do
           login.permit?(:supply_teachers)
           expect(Rails.logger).to have_received(:info)
-            .with('Login attempt from dfe > email: user@example.com, school type id: 01, result: successful')
+            .with('Login attempt to supply_teachers from dfe > email: user@example.com, result: successful')
         end
       end
 
@@ -110,7 +110,7 @@ RSpec.describe Login::DfeLogin, type: :model do
         it 'logs the attempt' do
           login.permit?(:supply_teachers)
           expect(Rails.logger).to have_received(:info)
-            .with('Login attempt from dfe > email: user@example.com, school type id: 28, result: successful')
+            .with('Login attempt to supply_teachers from dfe > email: user@example.com, result: successful')
         end
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe Login::DfeLogin, type: :model do
       it 'logs the attempt' do
         login.permit?(:supply_teachers)
         expect(Rails.logger).to have_received(:info)
-          .with('Login attempt from dfe > email: user@example.com, school type id: 11, result: unsuccessful')
+          .with('Login attempt to supply_teachers from dfe > email: user@example.com, result: unsuccessful')
       end
     end
 
@@ -223,7 +223,7 @@ RSpec.describe Login::DfeLogin, type: :model do
     it 'logs the attempt' do
       login.permit?(:management_consultancy)
       expect(Rails.logger).to have_received(:info)
-        .with('Login attempt from dfe > email: user@example.com, school type id: 01, result: unsuccessful')
+        .with('Login attempt to management_consultancy from dfe > email: user@example.com, result: unsuccessful')
     end
   end
 end


### PR DESCRIPTION
As the school type ID is sometimes nil, the existing log lines didn't look great, e.g.

`I, [2019-01-28T16:21:54.802929 #10] INFO -- : [8539db90-4ebe-4481-af6d-51f15a010248] Login attempt from dfe > email: <email>@deferrerstrust.com, school type id: , result: successful`

This commit removes the logging on the school type ID. This information can be obtained for DfE logins at https://github.com/Crown-Commercial-Service/crown-marketplace/blob/master/app/models/login/dfe_login.rb#L4

I have also added the framework to the login log lines to make it obvious which framework the user is trying to log in to.