### PR TITLE
(chore) update spreadsheet headings

### DIFF
--- a/app/models/supply_teachers/spreadsheet.rb
+++ b/app/models/supply_teachers/spreadsheet.rb
@@ -11,7 +11,7 @@ class SupplyTeachers::Spreadsheet
     end
 
     def headers
-      ['Supplier name', 'Branch name', 'Contact name', 'Contact email', 'Telephone number']
+      ['Agency name', 'Branch name', 'Contact name', 'Contact email', 'Telephone number']
     end
 
     def types
@@ -36,13 +36,13 @@ class SupplyTeachers::Spreadsheet
 
     def title
       extra_title =
-        ['', '', '', '', '', 'Enter the supplier’s quote to see how much the worker will get paid']
+        ['', '', '', '', '', 'Enter the quote from this agency to see what their fee will be']
       super + extra_title
     end
 
     def headers
       extra_headers =
-        ['Mark-up', 'Enter daily rate', 'Cost of the worker', 'Supplier fee']
+        ['Mark-up', 'Enter daily rate', 'Cost of the worker', 'Agency fee']
       super + extra_headers
     end
 

--- a/spec/models/supply_teachers/spreadsheet_spec.rb
+++ b/spec/models/supply_teachers/spreadsheet_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe SupplyTeachers::Spreadsheet do
 
     it 'has the correct header row 2' do
       expect(worksheet[1].cells.map(&:value)).to eq [
-        'Supplier name',
+        'Agency name',
         'Branch name',
         'Contact name',
         'Contact email',


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/OOEJNiMO/982-update-downloadable-calculator-content

## Changes in this PR:
- Change the content of instructions for spreadsheets
- Change `Supplier name` to `Agency name` for spreadsheets
- Change `Supplier fee` to `Agency fee` for spreadsheets

## Screenshots of UI changes:

### Before
<img width="1586" alt="screenshot 2019-01-29 at 23 18 45" src="https://user-images.githubusercontent.com/6421298/51920823-136de280-2421-11e9-96e2-821ebb9cf8b5.png">


### After
<img width="1564" alt="screenshot 2019-01-29 at 23 17 22" src="https://user-images.githubusercontent.com/6421298/51920828-179a0000-2421-11e9-9ec5-7118bcb30cde.png">
