### PR TITLE
(fix) Show entire OmniAuth hash

### DIFF
--- a/app/models/login/dfe_login.rb
+++ b/app/models/login/dfe_login.rb
@@ -1,7 +1,7 @@
 module Login
   class DfeLogin < Login::BaseLogin
     def self.from_omniauth(hash)
-      Rails.logger.info("Login attempt from dfe > OmniAuth hash extra #{hash.dig('extra').inspect}")
+      Rails.logger.info("Login attempt from dfe > OmniAuth hash #{hash.inspect}")
       school_type_id = hash.dig('extra', 'raw_info', 'organisation', 'type', 'id')
       organisation_category = hash.dig('extra', 'raw_info', 'organisation', 'category', 'id')
       new(


### PR DESCRIPTION
In a702f0509baf5fa071ac16c6e6c0ba557cc31761 I reduced the amount of the OmniAuth hash output in the logs, but this has resulted in the log line being quite useless:

`OmniAuth hash extra #<OmniAuth::AuthHash raw_info=#<OmniAuth::AuthHash email="laura.porter@digital.education.gov.uk" organisation=#<OmniAuth::AuthHash> sub="C4A26681-D338-4F3E-8A32-04283DDC731F">>`

So this change reverts it and inspects the whole hash, which I knew was working before.