### PR TITLE
(chore) renaming the title of the supplier list page and title of spr…

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -327,11 +327,11 @@ en:
           header: What to do next
           sign_form_html: sign the <a href="%{form_url}">short order form</a> (also available in the documents section of the <a href="%{framework_url}">CCS framework</a> as ‘RM3826 Supply Teachers - Order Form Template (Short Form).docx’)
           sign_once: You only need to sign the form once to use this supplier for the duration of the framework (which runs until 29 August 2020).
-        download: Download shortlist of suppliers
+        download: Download shortlist of agencies
         download_aria_label: Download shortlist as Microsoft Excel file
         download_with_calculator: Download shortlist (with markup calculator)
         download_with_calculator_aria_label: Download shortlist (with markup calculator) as Microsoft Excel file
-        header: Supplier list
+        header: Agency list
         inputs:
           job_type: Job type
           looking_for: Looking for

--- a/spec/views/supply_teachers/branches/index.html.erb_spec.rb
+++ b/spec/views/supply_teachers/branches/index.html.erb_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'supply_teachers/branches/index.html.erb' do
   end
 
   it 'has a link to download a spreadsheet' do
-    expect(rendered).to have_link('Download shortlist of suppliers')
+    expect(rendered).to have_link('Download shortlist of agencies')
   end
 
   it 'has a link to download the calculator' do


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/pCqx9USj/974-the-words-supplier-and-agency-are-used-interchangeably-on-the-service

## Changes in this PR:
- Renamed the page title of supplier list
- Renamed the title of spreadsheets

## Screenshots of UI changes:

### Before
<img width="367" alt="screenshot 2019-02-01 at 00 29 18" src="https://user-images.githubusercontent.com/6421298/52069238-4f3bb000-25b9-11e9-8534-7f9094f853af.png">
<img width="433" alt="screenshot 2019-02-01 at 00 29 31" src="https://user-images.githubusercontent.com/6421298/52069239-4fd44680-25b9-11e9-979c-815ddf926e9a.png">


### After
<img width="366" alt="screenshot 2019-02-01 at 00 29 10" src="https://user-images.githubusercontent.com/6421298/52069247-5498fa80-25b9-11e9-975b-47cdcec5bfe9.png">
<img width="431" alt="screenshot 2019-02-01 at 00 29 38" src="https://user-images.githubusercontent.com/6421298/52069252-5498fa80-25b9-11e9-8b96-effc0b0d2fba.png">
