### PR TITLE
(chore) Correct wording in temp-to-perm calculator

### DIFF
--- a/app/views/supply_teachers/home/_avoid_paying_fees.html.erb
+++ b/app/views/supply_teachers/home/_avoid_paying_fees.html.erb
@@ -1,12 +1,4 @@
-<% if @calculator.ideal_notice_date.past? %>
-  <p>
-    To provide 4 working weeks’ notice:
-  </p>
-  <ul>
-    <li>give notice to the agency as soon as possible and</li>
-    <li>make the worker permanent 4 working weeks after that date</li>
-  </ul>
-<% else %>
+<% unless @calculator.ideal_notice_date.past? %>
   <p>
     You could give notice to the agency on <%= @calculator.ideal_notice_date.to_formatted_s(:long_with_day) %> and make the worker permanent on <%= @calculator.ideal_hire_date.to_formatted_s(:long_with_day) %>
     <% if @calculator.hiring_after_12_weeks? %>

--- a/spec/views/supply_teachers/home/_avoid_paying_fees.html.erb_spec.rb
+++ b/spec/views/supply_teachers/home/_avoid_paying_fees.html.erb_spec.rb
@@ -19,9 +19,8 @@ RSpec.describe 'supply_teachers/home/_avoid_paying_fees.html.erb' do
     let(:ideal_notice_date) { 5.months.ago }
     let(:ideal_hire_date) { 4.months.ago }
 
-    it 'displays a generic notice to notify the agency' do
-      expect(rendered).to have_content('give notice to the agency as soon as possible and')
-      expect(rendered).to have_content('make the worker permanent 4 working weeks after that date')
+    it 'does not display advice about notifying the agency' do
+      expect(rendered).not_to have_content('You could give notice to the agency')
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/WfFMLfun/991-correct-wording-for-scenario-4-5-6-and-7-for-temp-to-perm-calculator

The new wording for scenarios 4, 5, 6, and 7 (only when the recommended notice date is in the past) is incorrect as it tells the users how they can provide 4 weeks notice, when they have already provided more than 4 week's notice or where providing 4 weeks notice only will not avoid paying fees.