### PR TITLE
(feature) Add notice to agency mark-up results page

### DIFF
--- a/app/controllers/supply_teachers/branches_controller.rb
+++ b/app/controllers/supply_teachers/branches_controller.rb
@@ -24,6 +24,7 @@ module SupplyTeachers
       @radius_in_miles = step.radius
       @alternative_radiuses = SEARCH_RADIUSES - [@radius_in_miles]
       @branches = step.branches daily_rates
+      flash[:notice] = 'Calculated mark-up updated' unless daily_rates.empty?
 
       respond_to do |format|
         format.js { render json: @branches.find { |branch| params[:daily_rate][branch.id].present? } }

--- a/app/views/supply_teachers/branches/index.html.erb
+++ b/app/views/supply_teachers/branches/index.html.erb
@@ -5,6 +5,12 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl cmp-page-heading"><%= t('.header') %></h1>
 
+    <% if flash[:notice] %>
+      <div class="govuk-inset-text cmp-inset-text--success">
+        <p class="govuk-body govuk-body-s"><%= flash[:notice] %></p>
+      </div>
+    <% end %>
+
     <div class="govuk-inset-text cmp-inset-text--success">
       <h2 class="govuk-heading-s"><%= t('.inputs_header') %></h2>
       <ul class="govuk-list govuk-list--bullet">

--- a/spec/features/supply_teachers/supplier_markup_calculator.features_spec.rb
+++ b/spec/features/supply_teachers/supplier_markup_calculator.features_spec.rb
@@ -64,6 +64,7 @@ RSpec.feature 'Supplier mark-up calculator', type: :feature do
       expect(page).to have_css('.supplier-record__worker-cost', text: '£115.38')
       expect(page).to have_css('.supplier-record__agency-fee', text: '£34.62')
     end
+    expect(page).to have_content('Calculated mark-up updated')
   end
 
   scenario 'Buyer can calculate the agency mark-up via AJAX', js: true do


### PR DESCRIPTION
Only show notice when the rates are updated by the user.

Because the form is submitted via GET request if a user sends the URL to someone else, the other person will also see the notice. I think this ok though, because the goal of the notice is just to let the submitting user know that the content has changed.