### PR TITLE
(chore) Correct wording in temp-to-perm calculator

### DIFF
--- a/app/views/supply_teachers/home/_between_9_and_12_weeks_and_enough_notice.html.erb
+++ b/app/views/supply_teachers/home/_between_9_and_12_weeks_and_enough_notice.html.erb
@@ -5,8 +5,6 @@
   <%= t('supply_teachers.home.temp_to_perm_fee.fees_are_negotiable') %>
 </p>
 
-<%= render partial: 'avoid_paying_fees', locals: { calculator: calculator } %>
-
 <h2>Calculation</h2>
 
 <ul>

--- a/app/views/supply_teachers/home/_between_9_and_12_weeks_and_no_notice_date.html.erb
+++ b/app/views/supply_teachers/home/_between_9_and_12_weeks_and_no_notice_date.html.erb
@@ -5,8 +5,6 @@
   <%= t('supply_teachers.home.temp_to_perm_fee.fees_are_negotiable') %>
 </p>
 
-<%= render partial: 'avoid_paying_fees', locals: { calculator: calculator } %>
-
 <h2>Calculation</h2>
 
 <ul>

--- a/app/views/supply_teachers/home/_between_9_and_12_weeks_and_not_enough_notice.html.erb
+++ b/app/views/supply_teachers/home/_between_9_and_12_weeks_and_not_enough_notice.html.erb
@@ -5,8 +5,6 @@
   <%= t('supply_teachers.home.temp_to_perm_fee.fees_are_negotiable') %>
 </p>
 
-<%= render partial: 'avoid_paying_fees', locals: { calculator: calculator } %>
-
 <h2>Calculation</h2>
 
 <ul>

--- a/app/views/supply_teachers/home/_within_first_8_weeks.html.erb
+++ b/app/views/supply_teachers/home/_within_first_8_weeks.html.erb
@@ -5,8 +5,6 @@
   <%= t('supply_teachers.home.temp_to_perm_fee.fees_are_negotiable') %>
 </p>
 
-<%= render partial: 'avoid_paying_fees', locals: { calculator: calculator } %>
-
 <h2>Calculation</h2>
 
 <ul>

--- a/spec/views/supply_teachers/home/temp_to_perm_fee.html.erb_spec.rb
+++ b/spec/views/supply_teachers/home/temp_to_perm_fee.html.erb_spec.rb
@@ -240,10 +240,6 @@ RSpec.describe 'supply_teachers/home/temp_to_perm_fee.html.erb' do
         )
       end
 
-      it 'explains how to avoid paying fees' do
-        expect(rendered).to render_template('_avoid_paying_fees')
-      end
-
       context 'and the worker works fewer than 5 days a week' do
         let(:days_per_week) { 2 }
 
@@ -331,10 +327,6 @@ RSpec.describe 'supply_teachers/home/temp_to_perm_fee.html.erb' do
         )
       end
 
-      it 'explains how to avoid paying fees' do
-        expect(rendered).to render_template('_avoid_paying_fees')
-      end
-
       context 'and the worker works fewer than 5 days a week' do
         let(:days_per_week) { 2 }
 
@@ -404,10 +396,6 @@ RSpec.describe 'supply_teachers/home/temp_to_perm_fee.html.erb' do
                  max_fee: '£200.00',
                  latest_notice_date: 'Monday 15 October 2018')
         )
-      end
-
-      it 'explains how to avoid paying fees' do
-        expect(rendered).to render_template('_avoid_paying_fees')
       end
 
       context 'and the worker works fewer than 5 days a week' do
@@ -484,10 +472,6 @@ RSpec.describe 'supply_teachers/home/temp_to_perm_fee.html.erb' do
       expect(rendered).to have_text(
         I18n.t("#{i18n_key}.total_fee", fee: '£250.00')
       )
-    end
-
-    it 'explains how to avoid paying fees' do
-      expect(rendered).to render_template('_avoid_paying_fees')
     end
 
     context 'and the worker works fewer than 5 days a week' do


### PR DESCRIPTION
Trello: https://trello.com/c/WfFMLfun/991-correct-wording-for-scenario-4-5-6-and-7-for-temp-to-perm-calculator

Do not show the wording which advises how to avoid fees if the user is hiring the worker after 12 weeks.