### PR TITLE
https://pushback.atlassian.net/browse/ST-11

### DIFF
--- a/app/views/supply_teachers/home/_avoid_paying_fees.html.erb
+++ b/app/views/supply_teachers/home/_avoid_paying_fees.html.erb
@@ -8,12 +8,6 @@
   </ul>
 <% else %>
   <p>
-    You could give notice to the agency on <%= @calculator.ideal_notice_date.to_formatted_s(:long_with_day) %> and make the worker permanent on <%= @calculator.ideal_hire_date.to_formatted_s(:long_with_day) %>
-    <% if @calculator.hiring_after_12_weeks? %>
-      to
-    <% else %>
-      so they've been in post for over 12 working weeks and you
-    <% end %>
-    provide 4 working weeks’ notice.
+    If you give notice to the agency on <%= @calculator.ideal_notice_date.to_formatted_s(:long_with_day) %>, and make the worker permanent on <%= @calculator.ideal_hire_date.to_formatted_s(:long_with_day) %> you will be charged £0.00 and avoid paying any temp-to-perm fee.
   </p>
 <% end %>

--- a/spec/views/supply_teachers/home/_avoid_paying_fees.html.erb_spec.rb
+++ b/spec/views/supply_teachers/home/_avoid_paying_fees.html.erb_spec.rb
@@ -31,8 +31,9 @@ RSpec.describe 'supply_teachers/home/_avoid_paying_fees.html.erb' do
 
     it 'displays the ideal hire and notice dates' do
       expect(rendered).to have_content(
-        "You could give notice to the agency on #{ideal_notice_date.to_formatted_s(:long_with_day)} "\
-        "and make the worker permanent on #{ideal_hire_date.to_formatted_s(:long_with_day)}"
+        "If you give notice to the agency on #{ideal_notice_date.to_formatted_s(:long_with_day)}, "\
+        "and make the worker permanent on #{ideal_hire_date.to_formatted_s(:long_with_day)}"\
+        ' you will be charged £0.00 and avoid paying any temp-to-perm fee.'
       )
     end
   end


### PR DESCRIPTION
ST-11 Results page content change

[DfE's request]
I’ve also noticed that the last paragraph of the results page for the TTP calculator still needs to be changed. We would like the statement to make it clear that by taking particular actions the school can pay 0.00 for taking the agency worker on. The current statement of:
Give notice to the agency on Thursday 28 February 2019 and make the worker permanent on Thursday 28 March 2019 so they've been in post for over 12 weeks and you provide 4 weeks’ notice.

Should be changed to:

If you give notice to the agency on Thursday 28 February 2019, and make the worker permanent on Thursday 28 March 2019 you will be charged £0.00 and avoid paying any temp­ to ­perm fee.

The £0.00 is important as it is immediately noticeable by the user and self­ explanatory.