### PR TITLE
Feature/st 12 test temp to perm calculator

### DIFF
--- a/app/calculators/temp_to_perm_calculator/calculator.rb
+++ b/app/calculators/temp_to_perm_calculator/calculator.rb
@@ -155,20 +155,20 @@ module TempToPermCalculator
 
     def working_days_after(date, number_of_days)
       working_days_count = 0
-      until working_days_count == number_of_days
-        date += 1
+      while working_days_count <= number_of_days
         working_days_count += 1 if working_day?(date)
+        date += 1.day
       end
-      date
+      date - 1.day
     end
 
     def working_days_before(date, number_of_days)
       working_days_count = 0
-      until working_days_count == number_of_days
-        date -= 1
+      while working_days_count <= number_of_days
         working_days_count += 1 if working_day?(date)
+        date -= 1.day
       end
-      date
+      date + 1.day
     end
 
     def working_days_between(earlier_date, later_date)

--- a/app/calculators/temp_to_perm_calculator/calculator.rb
+++ b/app/calculators/temp_to_perm_calculator/calculator.rb
@@ -154,21 +154,21 @@ module TempToPermCalculator
     end
 
     def working_days_after(date, number_of_days)
-      working_days_count = 0
+      working_days_count = working_day?(date) ? 1 : 0
       while working_days_count <= number_of_days
-        working_days_count += 1 if working_day?(date)
         date += 1.day
+        working_days_count += 1 if working_day?(date)
       end
-      date - 1.day
+      date
     end
 
     def working_days_before(date, number_of_days)
-      working_days_count = 0
+      working_days_count = working_day?(date) ? 1 : 0
       while working_days_count <= number_of_days
-        working_days_count += 1 if working_day?(date)
         date -= 1.day
+        working_days_count += 1 if working_day?(date)
       end
-      date + 1.day
+      date
     end
 
     def working_days_between(earlier_date, later_date)

--- a/app/models/supply_teachers/journey/temp_to_perm_calculator.rb
+++ b/app/models/supply_teachers/journey/temp_to_perm_calculator.rb
@@ -189,7 +189,7 @@ module SupplyTeachers
 
     def ensure_hire_date_is_after_contract_start_date
       return if hire_date.blank? || contract_start_date.blank?
-      return if hire_date > contract_start_date
+      return if hire_date >= contract_start_date
 
       errors.add(:hire_date, :after_contract_start_date)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,7 +70,6 @@ en:
               less_than_or_equal_to: The number of days worked per week must be between 0 and 5
               not_a_number: The number of days worked per week must be a number
             hire_date:
-              after_contract_start_date: The date the worker will be hired must be after the date the contract started
               blank: Enter the date you want to hire the worker and include a day, month and year
             holiday_1_end_date:
               before_start_date: The end date of the first school holiday must be after the start date

--- a/spec/calculators/temp_to_perm_calculator/calculator_spec.rb
+++ b/spec/calculators/temp_to_perm_calculator/calculator_spec.rb
@@ -76,6 +76,38 @@ RSpec.describe TempToPermCalculator::Calculator do
       expect(calculator.maximum_fee_for_lack_of_notice).to be_within(1e-6).of(20 * 10)
     end
 
+    context 'when the contract starts on a bank holiday' do
+      let(:contract_start_date) { start_of_1st_week - 1.week }
+
+      it 'calculates the daily supplier fee based on day rate and markup rate' do
+        expect(calculator.daily_supplier_fee).to be_within(1e-6).of(10)
+      end
+
+      it 'calculates the ideal hire date as the start of the 13th week to avoid paying an early hire fee' do
+        expect(calculator.ideal_hire_date).to eq(start_of_13th_week - 1.week + 1.day)
+      end
+
+      it 'calculates the ideal notice date as the start of the 9th week to avoid paying a lack of notice fee' do
+        expect(calculator.ideal_notice_date).to eq(start_of_9th_week - 1.week + 1.day)
+      end
+    end
+
+    context 'when the contract start day is on a Saturday' do
+      let(:contract_start_date) { start_of_1st_week - 2.days }
+
+      it 'calculates the daily supplier fee based on day rate and markup rate' do
+        expect(calculator.daily_supplier_fee).to be_within(1e-6).of(10)
+      end
+
+      it 'calculates the ideal hire date as the start of the 13th week to avoid paying an early hire fee' do
+        expect(calculator.ideal_hire_date).to eq(start_of_13th_week)
+      end
+
+      it 'calculates the ideal notice date as the start of the 9th week to avoid paying a lack of notice fee' do
+        expect(calculator.ideal_notice_date).to eq(start_of_9th_week)
+      end
+    end
+
     context 'when the worker works fewer than 5 days per week' do
       let(:days_per_week) { 2 }
 
@@ -93,8 +125,8 @@ RSpec.describe TempToPermCalculator::Calculator do
 
       it 'returns the number of days notice required' do
         expect(calculator.days_notice_required).to eq(
-                                                     TempToPermCalculator::Calculator::WORKING_DAYS_NOTICE_PERIOD_REQUIRED_TO_AVOID_LATE_NOTICE_FEE
-                                                   )
+          TempToPermCalculator::Calculator::WORKING_DAYS_NOTICE_PERIOD_REQUIRED_TO_AVOID_LATE_NOTICE_FEE
+        )
       end
     end
   end

--- a/spec/calculators/temp_to_perm_calculator/calculator_spec.rb
+++ b/spec/calculators/temp_to_perm_calculator/calculator_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe TempToPermCalculator::Calculator do
     described_class.new(
       contract_start_date: contract_start_date,
       days_per_week: days_per_week,
-      day_rate: 110,
-      markup_rate: 0.10,
+      day_rate: day_rate,
+      markup_rate: markup_rate,
       hire_date: hire_date,
       notice_date: notice_date,
       holiday_1_start_date: holiday_1_start_date,
@@ -19,6 +19,8 @@ RSpec.describe TempToPermCalculator::Calculator do
   include_context 'with friendly dates'
 
   let(:contract_start_date) { start_of_1st_week }
+  let(:day_rate) { 110 }
+  let(:markup_rate) { 0.10 }
   let(:hire_date) { start_of_1st_week }
   let(:notice_date) { nil }
   let(:holiday_1_start_date) { nil }
@@ -74,6 +76,15 @@ RSpec.describe TempToPermCalculator::Calculator do
 
     it 'calculates the maximum fee for lack of notice as 20 days of the daily supplier fee' do
       expect(calculator.maximum_fee_for_lack_of_notice).to be_within(1e-6).of(20 * 10)
+    end
+
+    context 'when day rate is 116 and mark-up rate is 16%' do
+      let(:day_rate) { 116 }
+      let(:markup_rate) { 0.16 }
+
+      it 'calculates the maximum fee for lack of notice as 20 days of the daily supplier fee' do
+        expect(calculator.maximum_fee_for_lack_of_notice).to be_within(1e-6).of(20 * 16)
+      end
     end
 
     context 'when the contract starts on a bank holiday' do
@@ -151,6 +162,10 @@ RSpec.describe TempToPermCalculator::Calculator do
       expect(calculator.ideal_notice_date).to eq(start_of_11th_week)
     end
 
+    it 'calculates the maximum fee for lack of notice as 20 days of the daily supplier fee' do
+      expect(calculator.maximum_fee_for_lack_of_notice).to be_within(1e-6).of(20 * 10)
+    end
+
     context 'and when there is a holiday within four weeks of the ideal hire date' do
       let(:holiday_2_start_date) { start_of_14th_week }
       let(:holiday_2_end_date) { start_of_14th_week.end_of_week }
@@ -179,11 +194,19 @@ RSpec.describe TempToPermCalculator::Calculator do
       expect(calculator.ideal_notice_date).to eq(start_date + 8.weeks + 3.days)
     end
 
+    it 'calculates the maximum fee for lack of notice as 20 days of the daily supplier fee' do
+      expect(calculator.maximum_fee_for_lack_of_notice).to be_within(1e-6).of(20 * 10)
+    end
+
     context 'when worker works fewer than 5 days a week' do
       let(:days_per_week) { 3 }
 
       it 'calculates the ideal notice date as the start of the 11th week to avoid paying a lack of notice fee' do
         expect(calculator.ideal_notice_date).to eq(start_date + 12.weeks - 4.weeks + 3.days)
+      end
+
+      it 'calculates the maximum fee for lack of notice as 20 days of the daily supplier fee' do
+        expect(calculator.maximum_fee_for_lack_of_notice).to be_within(1e-6).of(20 * 6)
       end
     end
   end
@@ -281,6 +304,15 @@ RSpec.describe TempToPermCalculator::Calculator do
       expect(calculator.fee).to be_within(1e-6).of(5 * 10)
     end
 
+    context 'and when day rate is 116 and markup rate 16%' do
+      let(:day_rate) { 116 }
+      let(:markup_rate) { 0.16 }
+
+      it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+        expect(calculator.fee).to be_within(1e-6).of(5 * 16)
+      end
+    end
+
     context 'and they give 4 weeks notice' do
       let(:notice_date) { start_of_8th_week }
 
@@ -300,6 +332,15 @@ RSpec.describe TempToPermCalculator::Calculator do
 
       it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
         expect(calculator.fee).to be_within(1e-6).of(5 * 10)
+      end
+
+      context 'and when day rate is 116 and markup rate 16%' do
+        let(:day_rate) { 116 }
+        let(:markup_rate) { 0.16 }
+
+        it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+          expect(calculator.fee).to be_within(1e-6).of(5 * 16)
+        end
       end
     end
 
@@ -323,6 +364,15 @@ RSpec.describe TempToPermCalculator::Calculator do
       it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
         expect(calculator.fee).to be_within(1e-6).of(10 * 10)
       end
+
+      context 'and when day rate is 116 and markup rate 16%' do
+        let(:day_rate) { 116 }
+        let(:markup_rate) { 0.16 }
+
+        it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+          expect(calculator.fee).to be_within(1e-6).of(10 * 16)
+        end
+      end
     end
 
     context 'and they give 2 weeks notice' do
@@ -344,6 +394,15 @@ RSpec.describe TempToPermCalculator::Calculator do
 
       it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
         expect(calculator.fee).to be_within(1e-6).of(15 * 10)
+      end
+
+      context 'and when day rate is 116 and markup rate 16%' do
+        let(:day_rate) { 116 }
+        let(:markup_rate) { 0.16 }
+
+        it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+          expect(calculator.fee).to be_within(1e-6).of(15 * 16)
+        end
       end
     end
 
@@ -367,6 +426,15 @@ RSpec.describe TempToPermCalculator::Calculator do
       it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
         expect(calculator.fee).to be_within(1e-6).of(20 * 10)
       end
+
+      context 'and when day rate is 116 and markup rate 16%' do
+        let(:day_rate) { 116 }
+        let(:markup_rate) { 0.16 }
+
+        it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+          expect(calculator.fee).to be_within(1e-6).of(20 * 16)
+        end
+      end
     end
 
     context 'and they give no notice' do
@@ -388,6 +456,15 @@ RSpec.describe TempToPermCalculator::Calculator do
 
       it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
         expect(calculator.fee).to be_within(1e-6).of(20 * 10)
+      end
+
+      context 'and when day rate is 116 and markup rate 16%' do
+        let(:day_rate) { 116 }
+        let(:markup_rate) { 0.16 }
+
+        it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+          expect(calculator.fee).to be_within(1e-6).of(20 * 16)
+        end
       end
     end
   end
@@ -427,6 +504,15 @@ RSpec.describe TempToPermCalculator::Calculator do
       expect(calculator.fee).to be_within(1e-6).of(0)
     end
 
+    context 'and when day rate is 116 and markup rate 16%' do
+      let(:day_rate) { 116 }
+      let(:markup_rate) { 0.16 }
+
+      it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+        expect(calculator.fee).to be_within(1e-6).of(0)
+      end
+    end
+
     context 'and they give 4 weeks notice' do
       let(:notice_date) { start_of_9th_week }
 
@@ -442,6 +528,15 @@ RSpec.describe TempToPermCalculator::Calculator do
 
       it 'calculates the fee as zero' do
         expect(calculator.fee).to be_within(1e-6).of(0)
+      end
+
+      context 'and when day rate is 116 and markup rate 16%' do
+        let(:day_rate) { 116 }
+        let(:markup_rate) { 0.16 }
+
+        it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+          expect(calculator.fee).to be_within(1e-6).of(0)
+        end
       end
     end
 
@@ -461,6 +556,15 @@ RSpec.describe TempToPermCalculator::Calculator do
       it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
         expect(calculator.fee).to be_within(1e-6).of(5 * 10)
       end
+
+      context 'and when day rate is 116 and markup rate 16%' do
+        let(:day_rate) { 116 }
+        let(:markup_rate) { 0.16 }
+
+        it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+          expect(calculator.fee).to be_within(1e-6).of(5 * 16)
+        end
+      end
     end
 
     context 'and they give 2 weeks notice' do
@@ -478,6 +582,15 @@ RSpec.describe TempToPermCalculator::Calculator do
 
       it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
         expect(calculator.fee).to be_within(1e-6).of(10 * 10)
+      end
+
+      context 'and when day rate is 116 and markup rate 16%' do
+        let(:day_rate) { 116 }
+        let(:markup_rate) { 0.16 }
+
+        it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+          expect(calculator.fee).to be_within(1e-6).of(10 * 16)
+        end
       end
     end
 
@@ -497,6 +610,15 @@ RSpec.describe TempToPermCalculator::Calculator do
       it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
         expect(calculator.fee).to be_within(1e-6).of(15 * 10)
       end
+
+      context 'and when day rate is 116 and markup rate 16%' do
+        let(:day_rate) { 116 }
+        let(:markup_rate) { 0.16 }
+
+        it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+          expect(calculator.fee).to be_within(1e-6).of(15 * 16)
+        end
+      end
     end
 
     context 'and they give no notice' do
@@ -514,6 +636,15 @@ RSpec.describe TempToPermCalculator::Calculator do
 
       it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
         expect(calculator.fee).to be_within(1e-6).of(20 * 10)
+      end
+
+      context 'and when day rate is 116 and markup rate 16%' do
+        let(:day_rate) { 116 }
+        let(:markup_rate) { 0.16 }
+
+        it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+          expect(calculator.fee).to be_within(1e-6).of(20 * 16)
+        end
       end
     end
   end

--- a/spec/models/supply_teachers/journey/temp_to_perm_calculator_spec.rb
+++ b/spec/models/supply_teachers/journey/temp_to_perm_calculator_spec.rb
@@ -431,14 +431,7 @@ RSpec.describe SupplyTeachers::Journey::TempToPermCalculator, type: :model do
     let(:contract_start_date_month) { '1' }
     let(:contract_start_date_year) { '2018' }
 
-    it { is_expected.to be_invalid }
-
-    it 'obtains the error message from an I18n translation' do
-      step.valid?
-      expect(step.errors[:hire_date]).to include(
-        I18n.t("#{model_key}.attributes.hire_date.after_contract_start_date")
-      )
-    end
+    it { is_expected.to be_valid }
 
     context 'and hire_date is one day earlier' do
       let(:hire_date_day) { '9' }


### PR DESCRIPTION
Added more tests to the Temp-to-Perm calculator:
- validations
- using a different markup and day rate
- contract start date on a bank holiday or weekend
- bank holidays in the middle of the contract

Found two bugs for which fixes have been made:
- the page in the Journey where you have to input the details would not allow contract_start_date == hire_date but the calculator did
- the calculator was not checking if the first day of the contract is a working day or not