### PR TITLE
Results page content change

### DIFF
--- a/app/calculators/temp_to_perm_calculator/calculator.rb
+++ b/app/calculators/temp_to_perm_calculator/calculator.rb
@@ -96,7 +96,8 @@ module TempToPermCalculator
     end
 
     def chargeable_working_days_based_on_early_hire
-      WORKING_DAYS_BEFORE_WHICH_EARLY_HIRE_FEE_CAN_BE_CHARGED - working_days
+      chargeable_working_days = WORKING_DAYS_BEFORE_WHICH_EARLY_HIRE_FEE_CAN_BE_CHARGED - working_days
+      chargeable_working_days.negative? ? 0 : chargeable_working_days
     end
 
     def chargeable_working_days_based_on_lack_of_notice

--- a/app/controllers/supply_teachers/suppliers_controller.rb
+++ b/app/controllers/supply_teachers/suppliers_controller.rb
@@ -13,7 +13,7 @@ module SupplyTeachers
     end
 
     def all_suppliers
-      @back_path = source_journey.current_step_path
+      @back_path = source_journey.previous_step_path
       all_branches = Branch.all
       @branches_count = all_branches.count
       @branches = all_branches.page params[:page]

--- a/app/views/supply_teachers/home/_avoid_paying_fees.html.erb
+++ b/app/views/supply_teachers/home/_avoid_paying_fees.html.erb
@@ -8,12 +8,6 @@
   </ul>
 <% else %>
   <p>
-    You could give notice to the agency on <%= @calculator.ideal_notice_date.to_formatted_s(:long_with_day) %> and make the worker permanent on <%= @calculator.ideal_hire_date.to_formatted_s(:long_with_day) %>
-    <% if @calculator.hiring_after_12_weeks? %>
-      to
-    <% else %>
-      so they've been in post for over 12 working weeks and you
-    <% end %>
-    provide 4 working weeks’ notice.
+    If you give notice to the agency on <%= @calculator.ideal_notice_date.to_formatted_s(:long_with_day) %>, and make the worker permanent on <%= @calculator.ideal_hire_date.to_formatted_s(:long_with_day) %> you will be charged £0.00 and avoid paying any temp-to-perm fee.
   </p>
 <% end %>

--- a/spec/calculators/temp_to_perm_calculator/calculator_spec.rb
+++ b/spec/calculators/temp_to_perm_calculator/calculator_spec.rb
@@ -649,6 +649,42 @@ RSpec.describe TempToPermCalculator::Calculator do
     end
   end
 
+  context 'when hire date is more than 12 weeks after contract start date' do
+    let(:hire_date) { start_of_14th_week }
+
+    it 'returns 0 if number of charchable days is < 0' do
+      expect(calculator.chargeable_working_days_based_on_early_hire).to eq(0)
+    end
+
+    it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+      expect(calculator.fee).to be_within(1e-6).of(0)
+    end
+
+    context 'and notice date is less than 4 weeks' do
+      let(:notice_date) { start_of_14th_week - 4.weeks + 2.days }
+
+      it 'returns 0 if number of chargeable days is < 0' do
+        expect(calculator.chargeable_working_days_based_on_lack_of_notice).to eq(2)
+      end
+
+      it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+        expect(calculator.fee).to be_within(1e-6).of(2 * 10)
+      end
+    end
+
+    context 'and notice date is more than 4 weeks' do
+      let(:notice_date) { start_of_14th_week - 5.weeks }
+
+      it 'returns 0 if number of chargeable days is < 0' do
+        expect(calculator.chargeable_working_days_based_on_lack_of_notice).to eq(0)
+      end
+
+      it 'calculates the fee as the number of chargeable working days multiplied by the daily supplier fee' do
+        expect(calculator.fee).to be_within(1e-6).of(0)
+      end
+    end
+  end
+
   describe '#working_days' do
     context 'when the working period includes a bank holiday in England' do
       let(:august_bank_holiday) { Date.parse('Monday, 27th August 2018') }

--- a/spec/controllers/supply_teachers/suppliers_controller_spec.rb
+++ b/spec/controllers/supply_teachers/suppliers_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe SupplyTeachers::SuppliersController, type: :controller, auth: tru
     it 'sets the back path to the managed-service-provider question' do
       expected_path = journey_question_path(
         journey: 'supply-teachers',
-        slug: 'all-suppliers',
+        slug: 'looking-for',
         looking_for: 'all_suppliers'
       )
       expect(assigns(:back_path)).to eq(expected_path)

--- a/spec/views/supply_teachers/home/_avoid_paying_fees.html.erb_spec.rb
+++ b/spec/views/supply_teachers/home/_avoid_paying_fees.html.erb_spec.rb
@@ -31,8 +31,9 @@ RSpec.describe 'supply_teachers/home/_avoid_paying_fees.html.erb' do
 
     it 'displays the ideal hire and notice dates' do
       expect(rendered).to have_content(
-        "You could give notice to the agency on #{ideal_notice_date.to_formatted_s(:long_with_day)} "\
-        "and make the worker permanent on #{ideal_hire_date.to_formatted_s(:long_with_day)}"
+        "If you give notice to the agency on #{ideal_notice_date.to_formatted_s(:long_with_day)}"\
+        ", and make the worker permanent on #{ideal_hire_date.to_formatted_s(:long_with_day)}"\
+        ' you will be charged £0.00 and avoid paying any temp-to-perm fee.'
       )
     end
   end


### PR DESCRIPTION
On the Results page of the calculator:

Give notice to the agency on Thursday 28 February 2019 and make the worker permanent on Thursday 28 March 2019 so they've been in post for over 12 weeks and you provide 4 weeks’ notice.

Changed to:

 If you give notice to the agency on Thursday 28 February 2019, and make the worker permanent on Thursday 28 March 2019 you will be charged £0.00 and avoid paying any temp-to-perm fee.

Also found a couple of bugs:
- number of chargeable days based on hire date would be < 0 if there are more than 60 days between contract start date and hire date
This was fixed and new tests were added.
- back button on all suppliers didn't redirect back
