### PR TITLE
Feature/ST-40 Start now button change

### DIFF
--- a/app/views/supply_teachers/home/index.html.erb
+++ b/app/views/supply_teachers/home/index.html.erb
@@ -25,9 +25,7 @@
         <%= t('.you_will_need_your_dfe_sign_in') %>
       </p>
 
-      <%= link_to t('.start_now'), journey_start_path(journey: SupplyTeachers::Journey.journey_name), role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', 'aria-label': t('.start_finding_supply_teachers') %>
-
-      <h2 class="govuk-heading-m"><%= t('.before_you_start') %></h2>
+      <h2 class="govuk-heading-m cmp-start-page__sub-heading"><%= t('.before_you_start') %></h2>
 
       <p class="govuk-body"><%= t('.you_will_need_to_have') %></p>
 
@@ -46,7 +44,9 @@
 
       <p class="govuk-body"><%= t('.all_suppliers_have_undergone') %></p>
 
-      <h2 class="govuk-heading-m cmp-start-page__sub-heading"><%= t('.buyers_obligations') %></h2>
+      <%= link_to t('.start_now'), journey_start_path(journey: SupplyTeachers::Journey.journey_name), role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', 'aria-label': t('.start_finding_supply_teachers') %>
+
+      <h2 class="govuk-heading-m"><%= t('.buyers_obligations') %></h2>
 
       <p class="govuk-body"><%= t('.this_service_contains_pricing_information_html', url: 'https://www.gov.uk/guidance/deal-for-schools-hiring-supply-teachers-and-agency-workers') %></p>
 


### PR DESCRIPTION
Problem: Currently, users aren't aware that there is more guidance content below the start button. This means they aren't aware what accreditation suppliers have, or what their obligations are for using the data contained in the service.

Solution: move start button to bottom of the page (below "before you start" and accreditation section)