### PR TITLE
Feature/cp31 update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,8 @@
-MIT License
+The Open Government Licence (OGL) Version 3
 
-Copyright (c) 2018 Crown Commercial Service
+Copyright (c) 2019 Cown Commercial Service
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+This source code is licensed under the Open Government Licence v3.0. To view this
+licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+or write to the Information Policy Team, The National Archives, Kew, Richmond,
+Surrey, TW9 4DU.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The Open Government Licence (OGL) Version 3
 
-Copyright (c) 2019 Cown Commercial Service
+Copyright (c) 2019 Crown Commercial Service
 
 This source code is licensed under the Open Government Licence v3.0. To view this
 licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3


### PR DESCRIPTION
The Open Government License is the correct license to use for gov.uk projects.

No code change, so this shouldn't require any QA work.