### PR TITLE
Switched bundler back

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,4 +435,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.2
+   1.16.6


### PR DESCRIPTION
If we update bundler version it brakes the AWS build