### PR TITLE
feature/CP-73 GA only for ST

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,11 +16,7 @@ module ApplicationHelper
   end
 
   def support_email_link(label)
-    govuk_email_link(
-      Marketplace.support_email_address,
-      label,
-      css_class: 'govuk-link ga-support-mailto'
-    )
+    govuk_email_link(Marketplace.support_email_address, label, css_class: 'govuk-link ga-support-mailto')
   end
 
   def dfe_account_request_url
@@ -124,5 +120,9 @@ module ApplicationHelper
 
   def landing_or_admin_page
     controller.action_name == 'landing_page' || controller.class.parent_name.underscore == 'supply_teachers/admin'
+  end
+
+  def a_supply_teachers_path?
+    controller.class.parent.name == 'SupplyTeachers'
   end
 end

--- a/app/views/apprenticeships/home/download_provider.html.erb
+++ b/app/views/apprenticeships/home/download_provider.html.erb
@@ -42,7 +42,7 @@
 
 
     <!--p class="govuk-body">
-        <a href="javascript:window.print()" class="govuk-link govuk-link--no-visited-state ccs-print-icon ga-print-link"><%= t('.print_this_page') %></a>
+        <a href="javascript:window.print()" class="govuk-link govuk-link--no-visited-state ccs-print-icon"><%= t('.print_this_page') %></a>
     </p-->
 
 

--- a/app/views/facilities_management/gateway/index.html.erb
+++ b/app/views/facilities_management/gateway/index.html.erb
@@ -7,7 +7,7 @@
       <p><%= t('.cmp_support_email_html', link: support_email_link(t('.cmp_support_aria_label'))) %></p>
 
       <p>
-        <%= link_to 'Sign in with beta credentials', cognito_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8 ga-auth-cognito' %>
+        <%= link_to 'Sign in with beta credentials', cognito_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' %>
       </p>
     </div>
   </div>

--- a/app/views/facilities_management/summary/index.html.erb
+++ b/app/views/facilities_management/summary/index.html.erb
@@ -60,7 +60,7 @@
         <form id="fm-summary-spreadsheet-form" action="/facilities-management/summary?calculations=yes&amp;format=xlsx" method="post">
           <p class="govuk-body govuk-body-s supplier-record__print-option">
             <%= hidden_field_tag 'current_choices', TransientSessionInfo[session.id].to_json %>
-            <a onclick="document.getElementById('fm-summary-spreadsheet-form').submit();" class="supplier-record__file-download ga-download-calculator" aria-label="Download supplier list and Deliverables Matrix Lite" href="/facilities-management/summary?calculations=yes&amp;format=xlsx">Download supplier list and Deliverables Matrix Lite</a>
+            <a onclick="document.getElementById('fm-summary-spreadsheet-form').submit();" class="supplier-record__file-download" aria-label="Download supplier list and Deliverables Matrix Lite" href="/facilities-management/summary?calculations=yes&amp;format=xlsx">Download supplier list and Deliverables Matrix Lite</a>
           </p>
         </form>
       </div>

--- a/app/views/management_consultancy/gateway/index.html.erb
+++ b/app/views/management_consultancy/gateway/index.html.erb
@@ -7,7 +7,7 @@
       <p><%= t('.cmp_support_email_html', link: support_email_link(t('.cmp_support_aria_label'))) %></p>
 
       <p>
-        <%= link_to 'Sign in with beta credentials', cognito_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8 ga-auth-cognito' %>
+        <%= link_to 'Sign in with beta credentials', cognito_sign_in_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' %>
       </p>
     </div>
   </div>

--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -1,10 +1,10 @@
-<% if Marketplace.google_analytics_tracking_id.present? %>
-<script async src="https://www.googletagmanager.com/gtag/js?id=<%= Marketplace.google_analytics_tracking_id %>"></script>
-<script>
-window.dataLayer = window.dataLayer || [];
-window.gaTrackingId = '<%= ENV['GA_TRACKING_ID'] %>';
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', '<%= Marketplace.google_analytics_tracking_id %>', { 'anonymize_ip': true });
-</script>
+<% if Marketplace.google_analytics_tracking_id.present? && a_supply_teachers_path? %>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= Marketplace.google_analytics_tracking_id %>"></script>
+  <script>
+      window.dataLayer = window.dataLayer || [];
+      window.gaTrackingId = '<%= ENV['GA_TRACKING_ID'] %>';
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '<%= Marketplace.google_analytics_tracking_id %>', { 'anonymize_ip': true });
+  </script>
 <% end %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,7 @@ RSpec.configure do |config|
     # Prevents you from mocking or stubbing a method that does not exist on
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.
-    mocks.verify_partial_doubles = true
+    mocks.verify_partial_doubles = false
   end
 
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will

--- a/spec/views/shared/_google_analytics.html.erb_spec.rb
+++ b/spec/views/shared/_google_analytics.html.erb_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'shared/_google_analytics.html.erb' do
   before do
     allow(Marketplace).to receive(:google_analytics_tracking_id)
       .and_return(google_analytics_tracking_id)
+    allow(view).to receive(:a_supply_teachers_path?).and_return true
   end
 
   context 'when Google Analytics tracking ID is missing' do
@@ -24,6 +25,20 @@ RSpec.describe 'shared/_google_analytics.html.erb' do
 
       expect(rendered).to match(/script/)
       expect(rendered).to match(/UA-999-9/)
+    end
+  end
+
+  context 'when view is not a supply_teachers path' do
+    let(:google_analytics_tracking_id) { 'UA-999-9' }
+
+    before do
+      allow(view).to receive(:a_supply_teachers_path?).and_return false
+    end
+
+    it 'does not render anything' do
+      render partial: 'shared/google_analytics'
+
+      expect(rendered).to be_blank
     end
   end
 end


### PR DESCRIPTION
Separated all GA tracking for SupplyTeachers. The only ones that are across platform now are: ga-crown-logo, ga-feedback-mailto, ga-support-mailto