### PR TITLE
Feature/Admin tool fix

### DIFF
--- a/app/models/supply_teachers/admin/upload.rb
+++ b/app/models/supply_teachers/admin/upload.rb
@@ -100,13 +100,13 @@ module SupplyTeachers
 
       # rubocop:disable Metrics/AbcSize
       def copy_files_to_input_folder
-        cp_file_to_input(current_accredited_suppliers.file.try(:path), CURRENT_ACCREDITED_PATH, current_accredited_suppliers_changed?)
-        cp_file_to_input(geographical_data_all_suppliers.file.try(:path), GEOGRAPHICAL_DATA_PATH, geographical_data_all_suppliers_changed?)
-        cp_file_to_input(lot_1_and_lot_2_comparisons.file.try(:path), LOT_1_AND_LOT2_PATH, lot_1_and_lot_2_comparisons_changed?)
-        cp_file_to_input(master_vendor_contacts.file.try(:path), MASTER_VENDOR_PATH, master_vendor_contacts_changed?)
-        cp_file_to_input(neutral_vendor_contacts.file.try(:path), NEUTRAL_VENDOR_PATH, neutral_vendor_contacts_changed?)
-        cp_file_to_input(pricing_for_tool.file.try(:path), PRICING_TOOL_PATH, pricing_for_tool_changed?)
-        cp_file_to_input(supplier_lookup.file.try(:path), SUPPLIER_LOOKUP_PATH, supplier_lookup_changed?)
+        cp_file_to_input(current_accredited_suppliers_url, CURRENT_ACCREDITED_PATH, current_accredited_suppliers_changed?)
+        cp_file_to_input(geographical_data_all_suppliers_url, GEOGRAPHICAL_DATA_PATH, geographical_data_all_suppliers_changed?)
+        cp_file_to_input(lot_1_and_lot_2_comparisons_url, LOT_1_AND_LOT2_PATH, lot_1_and_lot_2_comparisons_changed?)
+        cp_file_to_input(master_vendor_contacts_url, MASTER_VENDOR_PATH, master_vendor_contacts_changed?)
+        cp_file_to_input(neutral_vendor_contacts_url, NEUTRAL_VENDOR_PATH, neutral_vendor_contacts_changed?)
+        cp_file_to_input(pricing_for_tool_url, PRICING_TOOL_PATH, pricing_for_tool_changed?)
+        cp_file_to_input(supplier_lookup_url, SUPPLIER_LOOKUP_PATH, supplier_lookup_changed?)
       end
       # rubocop:enable Metrics/AbcSize
 

--- a/app/models/supply_teachers/admin/upload.rb
+++ b/app/models/supply_teachers/admin/upload.rb
@@ -98,7 +98,6 @@ module SupplyTeachers
         errors.add(:base, 'There is an error with your files. Please try again: ' + e.message)
       end
 
-      # rubocop:disable Metrics/AbcSize
       def copy_files_to_input_folder
         cp_file_to_input(current_accredited_suppliers_url, CURRENT_ACCREDITED_PATH, current_accredited_suppliers_changed?)
         cp_file_to_input(geographical_data_all_suppliers_url, GEOGRAPHICAL_DATA_PATH, geographical_data_all_suppliers_changed?)
@@ -108,7 +107,6 @@ module SupplyTeachers
         cp_file_to_input(pricing_for_tool_url, PRICING_TOOL_PATH, pricing_for_tool_changed?)
         cp_file_to_input(supplier_lookup_url, SUPPLIER_LOOKUP_PATH, supplier_lookup_changed?)
       end
-      # rubocop:enable Metrics/AbcSize
 
       def cp_file_to_input(file_path, new_path, condition)
         FileUtils.cp(file_path, new_path) if condition

--- a/app/uploaders/supply_teachers_file_uploader.rb
+++ b/app/uploaders/supply_teachers_file_uploader.rb
@@ -15,4 +15,8 @@ class SupplyTeachersFileUploader < CarrierWave::Uploader::Base
   def extension_whitelist
     %w[xls xlsx csv]
   end
+
+  def cache_dir
+    Rails.root.join('storage', 'supply_teachers', 'tmp', 'uploads')
+  end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -9,3 +9,10 @@ if Rails.env.production?
     }
   end
 end
+
+if Rails.env.test? or Rails.env.cucumber?
+  CarrierWave.configure do |config|
+    config.storage = :file
+    config.enable_processing = false
+  end
+end


### PR DESCRIPTION
- small change to ST admin upload.rb model: now using _url instead of file.path to get the file path from S3 as at the moment it is causing admin tool to crash.
- added cache_dir to uploader
- added config for test env in the carrierwave initializer