### PR TITLE
Remove brackets from feedback links - also remove <IE9 specific JS

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,8 +17,6 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <!--[if lt IE 9]><%= javascript_include_tag 'html5shiv/dist/html5shiv' %><![endif]-->
-
     <% if params[:controller].present? && params[:controller].start_with?('apprenticeships') %>
       <%= stylesheet_link_tag 'apprenticeships', media: 'all' %>
     <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -685,7 +685,7 @@ en:
       crown_copyright: "© Crown copyright"
       error_prefix: Error
       feedback: feedback
-      feedback_aria_label: Email your feedback on this service
+      feedback_aria_label: Email your feedback on this service.
       feedback_html: This is a new service – your %{link} will help us to improve it.
       having_problems: To ask a question or report a problem,
       privacy_link: Privacy policy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -686,7 +686,7 @@ en:
       error_prefix: Error
       feedback: feedback
       feedback_aria_label: Email your feedback on this service
-      feedback_html: This is a new service – your (%{link}) will help us to improve it.
+      feedback_html: This is a new service – your %{link} will help us to improve it.
       having_problems: To ask a question or report a problem,
       privacy_link: Privacy policy
       privacy_link_aria_label: View our privacy policy

--- a/public/404.html
+++ b/public/404.html
@@ -6656,7 +6656,7 @@ strong {
                 beta
               </strong>
               <span class="govuk-phase-banner__text">
-                This is a new service – your feedback (<a class="govuk-link" aria-label="Email your feedback on this service" href="mailto:info@crowncommercial.gov.uk">info@crowncommercial.gov.uk</a>) will help us to improve it.
+                This is a new service – your <a class="govuk-link" aria-label="Email your feedback on this service" href="mailto:info@crowncommercial.gov.uk">feedback</a> will help us to improve it.
               </span>
             </p>
           </div>

--- a/public/422.html
+++ b/public/422.html
@@ -6656,7 +6656,7 @@ strong {
                 beta
               </strong>
               <span class="govuk-phase-banner__text">
-                This is a new service – your feedback (<a class="govuk-link" aria-label="Email your feedback on this service" href="mailto:info@crowncommercial.gov.uk">info@crowncommercial.gov.uk</a>) will help us to improve it.
+                This is a new service – your <a class="govuk-link" aria-label="Email your feedback on this service" href="mailto:info@crowncommercial.gov.uk">feedback</a> will help us to improve it.
               </span>
             </p>
           </div>

--- a/public/500.html
+++ b/public/500.html
@@ -6656,7 +6656,7 @@ strong {
                 beta
               </strong>
               <span class="govuk-phase-banner__text">
-                This is a new service – your feedback (<a class="govuk-link" aria-label="Email your feedback on this service" href="mailto:info@crowncommercial.gov.uk">info@crowncommercial.gov.uk</a>) will help us to improve it.
+                This is a new service – your <a class="govuk-link" aria-label="Email your feedback on this service" href="mailto:info@crowncommercial.gov.uk">feedback</a> will help us to improve it.
               </span>
             </p>
           </div>

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -6656,7 +6656,7 @@ strong {
                 beta
               </strong>
               <span class="govuk-phase-banner__text">
-                This is a new service – your feedback (<a class="govuk-link" aria-label="Email your feedback on this service" href="mailto:info@crowncommercial.gov.uk">info@crowncommercial.gov.uk</a>) will help us to improve it.
+                This is a new service – your <a class="govuk-link" aria-label="Email your feedback on this service" href="mailto:info@crowncommercial.gov.uk">feedback</a> will help us to improve it.
               </span>
             </p>
           </div>


### PR DESCRIPTION
en,yml had brackets around the feedback link.
Also, code for IE versions less than 9 is now breaking - so that has been removed... 