### PR TITLE
Update View to ensure basket list is updated when navigating back or …

### DIFF
--- a/app/assets/javascripts/global/global.js
+++ b/app/assets/javascripts/global/global.js
@@ -222,6 +222,8 @@ function initDynamicAccordian(){
             updateList(govcheckboxes, id, basketheader);
         });
     });
+
+    updateList(govcheckboxes, id, basketheader);
 }
 
 


### PR DESCRIPTION
…refreshing page

The change is to ensure the updateList (which modifies the basket view for the page) is called on initialisation and not just on check-box change