### PR TITLE
Bug/fm 333 back button creates duplicates building

### DIFF
--- a/app/assets/javascripts/facilities_management/beta/building_management/building.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building.js
@@ -56,17 +56,19 @@ $(function () {
     };
     
     $.restore_last_known_addr = function ( ) {
-        let addr = '' + pageUtils.getCachedData( 'lst_knwn_addr');
-        if ( addr != '' ){
-            $('#fm-find-address-results').empty();
-            $('#fm-find-address-results').append('<option value="' + addr + '">' + addr + '</option>');
-            showCantFindAddressLink();
-            let address = {};
-            if (extract_address_data(addr, address)) {
-                assign_building_address(address, address['building-ref']);
+        if ( location.href.indexOf('/beta/building') > 0 ) {
+            let addr = '' + pageUtils.getCachedData('lst_knwn_addr');
+            if (addr != '') {
+                $('#fm-find-address-results').empty();
+                $('#fm-find-address-results').append('<option value="' + addr + '">' + addr + '</option>');
+                showCantFindAddressLink();
+                let address = {};
+                if (extract_address_data(addr, address)) {
+                    assign_building_address(address, address['building-ref']);
+                }
             }
         }
-    } ;
+    };
 
     const extract_address_data = function (selectedAddress, new_address) {
         if (selectedAddress) {

--- a/app/assets/javascripts/facilities_management/beta/building_management/building.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building.js
@@ -125,7 +125,8 @@ $(function () {
         let msg;
         let bn = $('#fm-building-name-input').val();
         assign_building_name(bn);
-
+        FM.building.id = $('#building-id').val();
+        
         if (!bn) {
             id = 'fm-building-name-input';
             msg = 'A building name is required';

--- a/app/assets/javascripts/facilities_management/beta/building_management/building.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building.js
@@ -46,9 +46,27 @@ $(function () {
         //$('#fm-find-address-results').css("background", '#28a197');
         let address = {};
         if (extract_address_data(selectedAddress, address)) {
+            cache_address ( selectedAddress) ;
             assign_building_address(address, address['building-ref']);
         }
     });
+
+    const cache_address =function( addr )  {
+        pageUtils.setCachedData( 'lst_knwn_addr', addr );
+    };
+    
+    $.restore_last_known_addr = function ( ) {
+        let addr = '' + pageUtils.getCachedData( 'lst_knwn_addr');
+        if ( addr != '' ){
+            $('#fm-find-address-results').empty();
+            $('#fm-find-address-results').append('<option value="' + addr + '">' + addr + '</option>');
+            showCantFindAddressLink();
+            let address = {};
+            if (extract_address_data(addr, address)) {
+                assign_building_address(address, address['building-ref']);
+            }
+        }
+    } ;
 
     const extract_address_data = function (selectedAddress, new_address) {
         if (selectedAddress) {
@@ -184,5 +202,8 @@ $(function () {
 
         return bRet;
     };
+});
+$(window).on("load", function () {
+    $.restore_last_known_addr();
 });
 

--- a/app/assets/javascripts/facilities_management/beta/building_management/buildings_management.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/buildings_management.js
@@ -3,6 +3,10 @@ $(function () {
     /* namespace */
     window.FM = window.FM || {};
     FM.buildings_management = {};
+    if ( location.href.indexOf('/beta/buildings-management') > 0 ) {
+        pageUtils.clearCashedData('lst_knwn_addr');
+    }
+    
     $("a[role='details']").on('click', function (e) {
         let target = $(e.target);
         let url = target.attr('href');

--- a/app/assets/javascripts/facilities_management/beta/building_management/new_building_steps.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/new_building_steps.js
@@ -160,6 +160,7 @@ $(function () {
         }
         assign_building_name($('#fm-building-name-input').val());
         assign_building_description($('#fm-building-desc-input').val());
+        FM.building.id = $('#building-id').val();
     };
     const assign_building_name = function (new_name) {
         FM.building.name = new_name;

--- a/app/controllers/facilities_management/beta/buildings_management_controller.rb
+++ b/app/controllers/facilities_management/beta/buildings_management_controller.rb
@@ -18,6 +18,7 @@ module FacilitiesManagement
       Rails.logger.warn "Error: BuildingsController buildings_management(): #{e}"
     end
 
+    # rubocop:disable Metrics/AbcSize
     def building_details_summary
       @error_msg = ''
       update_building_data if params['detail-type'].present? && request.method == 'POST'
@@ -32,6 +33,7 @@ module FacilitiesManagement
     rescue StandardError => e
       Rails.logger.warn "Error: BuildingsController building_details_summary(): #{e}"
     end
+    # rubocop:enable Metrics/AbcSize
 
     def building
       @back_link_href = 'buildings-management'

--- a/app/controllers/facilities_management/beta/buildings_management_controller.rb
+++ b/app/controllers/facilities_management/beta/buildings_management_controller.rb
@@ -10,7 +10,7 @@ module FacilitiesManagement
     def buildings_management
       @error_msg = ''
       current_login_email = current_user.email.to_s
-
+      cookies.delete 'fm_building_id'
       @fm_building_data = FMBuildingData.new
       @building_count = @fm_building_data.get_count_of_buildings(current_login_email)
       @building_data = @fm_building_data.get_building_data(current_login_email)
@@ -22,6 +22,7 @@ module FacilitiesManagement
       @error_msg = ''
       update_building_data if params['detail-type'].present? && request.method == 'POST'
 
+      cookies.delete 'fm_building_id'
       @building_id = building_id_from_inputs
       @base_path = request.method.to_s == 'GET' ? '../' : './'
 
@@ -39,6 +40,8 @@ module FacilitiesManagement
       @page_title = 'Create single building'
 
       @building_id = building_id_from_inputs
+      @building_id = SecureRandom.uuid if @building_id.blank?
+
       if params['id'].present?
         building_record = FacilitiesManagement::Buildings.find_by("user_id = '" + Base64.encode64(current_user.email.to_s) + "' and id = '#{@building_id}'")
         @building = building_record&.building_json
@@ -162,12 +165,15 @@ module FacilitiesManagement
     # New building Save Methods
     def save_new_building
       new_building_json = request.raw_post
-      fm_building_data = FMBuildingData.new
-      building_id = fm_building_data.save_new_building current_user.email.to_s, new_building_json
-      cache_new_building_id building_id
       add = JSON.parse(new_building_json)
+      fm_building_data = FMBuildingData.new
+      building_id = fm_building_data.save_new_building current_user.email.to_s, add['id'], new_building_json
+      cache_new_building_id building_id
+      raise 'Building IDs do not match' unless building_id == add['id']
+
       postcode = add['address']['fm-address-postcode']
-      save_region(postcode)
+      save_region(postcode) if postcode.present?
+
       j = { 'status': 200, 'fm_building-id': building_id.to_s }
       render json: j, status: 200
     rescue StandardError => e

--- a/app/services/facilities_management/fm_buildings_data.rb
+++ b/app/services/facilities_management/fm_buildings_data.rb
@@ -88,7 +88,9 @@ class FMBuildingData
     # Beta code for step 1 saving a new building
     Rails.logger.info '==> FMBuildingData.save_new_building()'
     query = "insert into facilities_management_buildings (user_id, building_json, updated_at, status, id, updated_by)
-            values ('#{Base64.encode64(email_address)}', '#{building.gsub("'", "''")}', now(), 'Incomplete', '#{building_id}', '#{email_address}') ON CONFLICT DO NOTHING;"
+            values ('#{Base64.encode64(email_address)}', '#{building.gsub("'", "''")}', now(), 'Incomplete', '#{building_id}', '#{email_address}')
+            ON CONFLICT (id)
+            DO update set building_json = '#{building.gsub("'", "''")}';"
     ActiveRecord::Base.connection_pool.with_connection { |con| con.exec_query(query) }
     # update_building_id
     new_building_id(email_address)

--- a/app/services/facilities_management/fm_buildings_data.rb
+++ b/app/services/facilities_management/fm_buildings_data.rb
@@ -84,13 +84,13 @@ class FMBuildingData
     Rails.logger.warn "Couldn't get new building details: #{e}"
   end
 
-  def save_new_building(email_address, building)
+  def save_new_building(email_address, building_id, building)
     # Beta code for step 1 saving a new building
     Rails.logger.info '==> FMBuildingData.save_new_building()'
     query = "insert into facilities_management_buildings (user_id, building_json, updated_at, status, id, updated_by)
-            values ('#{Base64.encode64(email_address)}', '#{building.gsub("'", "''")}', now(), 'Incomplete', gen_random_uuid(), '#{email_address}');"
+            values ('#{Base64.encode64(email_address)}', '#{building.gsub("'", "''")}', now(), 'Incomplete', '#{building_id}', '#{email_address}') ON CONFLICT DO NOTHING;"
     ActiveRecord::Base.connection_pool.with_connection { |con| con.exec_query(query) }
-    update_building_id
+    # update_building_id
     new_building_id(email_address)
   rescue StandardError => e
     Rails.logger.warn "Couldn't save new building: #{e}"


### PR DESCRIPTION
New code that prevents creating multiple buildings upon using the browser back button and saving.
An upsert is performed.
Selected address are cached and restored on navigation to the building page.
The cache is cleared on entry to buildings-management.