### PR TITLE
FM-275 Bug - Procurements editing problem

### DIFF
--- a/app/controllers/facilities_management/beta/procurements_controller.rb
+++ b/app/controllers/facilities_management/beta/procurements_controller.rb
@@ -42,8 +42,7 @@ module FacilitiesManagement
         else
           @back_link = FacilitiesManagement::ProcurementRouter.new(id: @procurement.id, procurement_state: @procurement.aasm_state, step: params[:step]).back_link
 
-          redirect_to facilities_management_beta_procurement_url(id: @procurement.id, delete: @delete) unless FacilitiesManagement::ProcurementRouter::STEPS.include?(params[:step]) && @delete
-          redirect_to facilities_management_beta_procurement_url(id: @procurement.id) unless FacilitiesManagement::ProcurementRouter::STEPS.include?(params[:step]) && !@delete
+          redirect_to facilities_management_beta_procurement_url(id: @procurement.id) unless FacilitiesManagement::ProcurementRouter::STEPS.include?(params[:step])
         end
       end
 

--- a/app/views/facilities_management/beta/procurements/edit.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit.html.erb
@@ -34,8 +34,6 @@
       <span class="govuk-caption-xl"><%= @procurement.detailed_search? ? t('.detailed_search') : t('.quick_search') %> - <%= @procurement.name %></span>
     </div>
 
-    <span class="govuk-caption-l govuk-!-padding-top-0"><%= @procurement.detailed_search? ? t('.detailed_search') : t('.quick_search') %></span>
-    <h1 class="govuk-heading-xl govuk-!-padding-top-0 govuk-!-margin-0"><%= @procurement.name %></h1>
     <div class="procurement govuk-grid-row">
       <div class="govuk-grid-column-full">
         <%= govuk_form_group_with_optional_error(@procurement, :name) do %>

--- a/app/views/facilities_management/beta/procurements/edit/_contract_name.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit/_contract_name.html.erb
@@ -1,3 +1,4 @@
+<h1 style="margin-left:-1rem !important;" class="govuk-heading-xl govuk-!-padding-top-0 govuk-!-margin-0">Contract Name</h1>
 <div class="govuk-grid-row govuk-!-margin-top-3">
   <div class="govuk-character-count" data-module="character-count" data-maxlength="100">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-font-weight-bold">

--- a/app/views/facilities_management/beta/procurements/edit/_estimated_annual_cost.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit/_estimated_annual_cost.html.erb
@@ -1,3 +1,4 @@
+<h1 style="margin-left:-1rem !important;" class="govuk-heading-xl govuk-!-padding-top-0 govuk-!-margin-0">Estimated Annual Cost</h1>
 <div class="govuk-grid-row govuk-!-margin-top-3">
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-font-weight-bold">
     <h1 class="govuk-fieldset__heading">

--- a/app/views/facilities_management/beta/procurements/edit/_tupe.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit/_tupe.html.erb
@@ -1,6 +1,4 @@
-<div class="govuk-grid-row">
-  <h1 class="govuk-heading-xl"><%= t('.tupe_title') %></h1>
-</div>
+<h1 style="margin-left:-1rem !important;" class="govuk-heading-xl govuk-!-padding-top-0 govuk-!-margin-0"><%= t('.tupe_title') %></h1>
 
 <div class="govuk-grid-row govuk-!-margin-top-3">
   <span class="govuk-heading-s govuk-!-margin-bottom-0">


### PR DESCRIPTION
Procurements controller edit action - removed the now redundant and error-causing redirect.

Also fixed-up the title banner and made consistent for the new edit pages....