### PR TITLE
Dfe Sign in fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,9 +40,10 @@ gem 'virtus'
 gem 'jquery-rails', '~> 4.3.5'
 
 # for cognito authentication
-gem 'omniauth'
-gem 'omniauth-oauth2'
-gem 'omniauth_openid_connect'
+gem 'omniauth', '~> 1.9.0'
+gem 'omniauth-oauth2', '~> 1.6.0'
+# updating to the latest gem version causes an error when response_type is :code. A fix is coming but has not been merged in yet so will be using this branch until then
+gem 'omniauth_openid_connect', git: 'https://github.com/m0n9oose/omniauth_openid_connect.git', branch: 'fix_redundant_token_verification'
 gem 'json-jwt'
 
 # for authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/m0n9oose/omniauth_openid_connect.git
+  revision: a6779ddb035dd1b1d0e006e9f5a8318f747fbe1c
+  branch: fix_redundant_token_verification
+  specs:
+    omniauth_openid_connect (0.3.2)
+      addressable (~> 2.5)
+      omniauth (~> 1.9)
+      openid_connect (~> 1.1)
+
+GIT
   remote: https://github.com/randym/axlsx.git
   revision: 73d9477fc33706f4a186e92794134248fb389183
   branch: release-3.0.0
@@ -58,8 +68,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.0.1)
     arel (9.0.0)
     ast (2.4.0)
@@ -163,7 +173,7 @@ GEM
     holidays (7.1.0)
     htmlentities (4.3.4)
     httpclient (2.8.3)
-    i18n (1.6.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.29)
       activesupport (>= 4.0.2)
@@ -224,7 +234,7 @@ GEM
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.12.2)
     msgpack (1.2.10)
     msgpack (1.2.10-x64-mingw32)
     multi_json (1.13.1)
@@ -248,10 +258,6 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
-    omniauth_openid_connect (0.3.2)
-      addressable (~> 2.5)
-      omniauth (~> 1.9)
-      openid_connect (~> 1.1)
     openid_connect (1.1.8)
       activemodel
       attr_required (>= 1.0.0)
@@ -278,7 +284,7 @@ GEM
       method_source (~> 0.9.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (3.1.1)
+    public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
     rack-oauth2 (1.10.0)
@@ -495,9 +501,9 @@ DEPENDENCIES
   kaminari (~> 1.1.1)
   launchy
   listen (>= 3.0.5, < 3.2)
-  omniauth
-  omniauth-oauth2
-  omniauth_openid_connect
+  omniauth (~> 1.9.0)
+  omniauth-oauth2 (~> 1.6.0)
+  omniauth_openid_connect!
   pg (>= 0.18, < 2.0)
   phonejack
   poltergeist


### PR DESCRIPTION
The latest version of omniauth_openid_connect tries to decode id_token even if `response_type: :code`

Updating Gemfile to use the fix: https://github.com/m0n9oose/omniauth_openid_connect/issues/40