### PR TITLE
Hotfix migrations

### DIFF
--- a/db/migrate/20190724080344_change_timestamp_defaults_fm_regions.rb
+++ b/db/migrate/20190724080344_change_timestamp_defaults_fm_regions.rb
@@ -1,5 +1,11 @@
 class ChangeTimestampDefaultsFmRegions < ActiveRecord::Migration[5.2]
   def change
+    unless column_exists?(:fm_regions, :created_at)
+      add_column :fm_regions, :created_at, :datetime, null: false
+    end
+    unless column_exists?(:fm_regions, :updated_at)
+      add_column :fm_regions, :updated_at, :datetime, null: false
+    end
     change_column_null :fm_regions, :created_at, true
     change_column_null :fm_regions, :updated_at, true
 

--- a/db/migrate/20190724080344_change_timestamp_defaults_fm_regions.rb
+++ b/db/migrate/20190724080344_change_timestamp_defaults_fm_regions.rb
@@ -1,15 +1,17 @@
 class ChangeTimestampDefaultsFmRegions < ActiveRecord::Migration[5.2]
   def change
-    unless column_exists?(:fm_regions, :created_at)
-      add_column :fm_regions, :created_at, :datetime, null: false
+    if column_exists?(:fm_regions, :created_at)
+      change_column_null :fm_regions, :created_at, true
+      change_column_default :fm_regions, :created_at, from: '', to: 'now()'
+    else
+      add_column :fm_regions, :created_at, :datetime, from: '', to: 'now()', default: true
     end
-    unless column_exists?(:fm_regions, :updated_at)
-      add_column :fm_regions, :updated_at, :datetime, null: false
-    end
-    change_column_null :fm_regions, :created_at, true
-    change_column_null :fm_regions, :updated_at, true
 
-    change_column_default :fm_regions, :created_at, from: '', to: 'now()'
-    change_column_default :fm_regions, :updated_at, from: '', to: 'now()'
+    if column_exists?(:fm_regions, :updated_at)
+      change_column_null :fm_regions, :updated_at, true
+      change_column_default :fm_regions, :updated_at, from: '', to: 'now()'
+    else
+      add_column :fm_regions, :updated_at, :datetime, from: '', to: 'now()', default: true
+    end
   end
 end

--- a/db/migrate/20190724080344_change_timestamp_defaults_fm_regions.rb
+++ b/db/migrate/20190724080344_change_timestamp_defaults_fm_regions.rb
@@ -4,14 +4,14 @@ class ChangeTimestampDefaultsFmRegions < ActiveRecord::Migration[5.2]
       change_column_null :fm_regions, :created_at, true
       change_column_default :fm_regions, :created_at, from: '', to: 'now()'
     else
-      add_column :fm_regions, :created_at, :datetime, from: '', to: 'now()', default: true
+      add_column :fm_regions, :created_at, :datetime, from: '', to: 'now()', null: true
     end
 
     if column_exists?(:fm_regions, :updated_at)
       change_column_null :fm_regions, :updated_at, true
       change_column_default :fm_regions, :updated_at, from: '', to: 'now()'
     else
-      add_column :fm_regions, :updated_at, :datetime, from: '', to: 'now()', default: true
+      add_column :fm_regions, :updated_at, :datetime, from: '', to: 'now()', null: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,6 @@
 
 ActiveRecord::Schema.define(version: 2019_10_31_165100) do
 
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -65,8 +64,8 @@ ActiveRecord::Schema.define(version: 2019_10_31_165100) do
     t.integer "no_of_consoles_to_be_serviced"
     t.integer "tones_to_be_collected_and_removed"
     t.integer "no_of_units_to_be_serviced"
-    t.string "lift_data", default: [], array: true
     t.string "service_standard", limit: 1
+    t.string "lift_data", default: [], array: true
     t.index ["facilities_management_procurement_building_id"], name: "index_fm_procurements_on_fm_procurement_building_id"
   end
 


### PR DESCRIPTION
On cmp-dev some migrations have been edited after being run so we are missing timestamps on fm_regions. Attempting to fix this by checking if the timestamps exist and adding them to the table if they don't