### PR TITLE
Adding a heading to 'start a new precurment'

### DIFF
--- a/app/views/facilities_management/journey/choose_services.html.erb
+++ b/app/views/facilities_management/journey/choose_services.html.erb
@@ -4,6 +4,9 @@
     <div id="ccs-dynamic-accordian" class="govuk-grid-row">
       <div>
         <fieldset class="govuk-fieldset" aria-describedby="">
+          <h1 class="govuk-heading-xl">
+            <%= t('.start_a_new_procurement_header') %>
+          </h1>
           <h2 class="govuk-heading-m">
             <%= t('.question') %>
           </h2>

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -570,6 +570,7 @@ en:
         remove_all: Remove all
         service_specification_doc: Read the service specification document
         services_selected: Services selected
+        start_a_new_procurement_header: Start a new procurement
         subtitle: Choose all facilities management services required within your estate, even if you want services in just one building.
     passwords:
       edit:


### PR DESCRIPTION
Added a header to the 'Start a new procurement page' to bring it in line with the other pages. I placed the text for the heading in the 'facilities_management.en.yml'.