### PR TITLE
JavaScripts changed for building char counts

### DIFF
--- a/app/assets/javascripts/facilities_management/beta/building_management/building.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building.js
@@ -43,7 +43,7 @@ $(function () {
     };
 
     $('#fm-building-desc-input').on('keyup', function (e) {
-        putCharsLeft($('#fm-building-desc-chars-left'), e.target.value, 50);
+        putCharsLeft($("#fm-building-desc-chars-left"), e.target.value, 50);
     });
 
     $('#fm-building-desc-input').on('change', function (e) {

--- a/app/assets/javascripts/facilities_management/beta/building_management/building.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building.js
@@ -9,6 +9,11 @@ $(function () {
     $('#fm-find-address-btn').text('Find address');
     $('fm-bm-postcode-lookup-container').removeClass('govuk-!-margin-top-3');
     
+    function putCharsLeft(messageLocation,  value, maxChars) {
+        let charsLeft = FM.calcCharsLeft(value, maxChars);
+        messageLocation.text("You have " + charsLeft + " characters remaining");
+    }
+    
     // Puts the 'characters remaining' count when the page loads
     if ($("#fm-building-name-input").length) {
         putCharsLeft($('#fm-building-name-chars-left'), document.getElementById("fm-building-name-input").value, 25);
@@ -18,10 +23,6 @@ $(function () {
         putCharsLeft($('#fm-building-desc-chars-left'), document.getElementById("fm-building-desc-input").value, 50);
     }
     
-    function putCharsLeft(messageLocation,  value, maxChars) {
-        let charsLeft = FM.calcCharsLeft(value, maxChars);
-        messageLocation.text("You have " + charsLeft + " characters remaining");
-    }
     
     $('#fm-building-name-input').on('keyup', function (e) {
         putCharsLeft($('#fm-building-name-chars-left'), e.target.value, 25);

--- a/app/assets/javascripts/facilities_management/beta/building_management/building.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building.js
@@ -8,11 +8,25 @@ $(function () {
     $('#fm-find-address-btn').addClass('govuk-button');
     $('#fm-find-address-btn').text('Find address');
     $('fm-bm-postcode-lookup-container').removeClass('govuk-!-margin-top-3');
-
+    
+    // Puts the 'characters remaining' count when the page loads
+    if ($("#fm-building-name-input").length) {
+        putCharsLeft($('#fm-building-name-chars-left'), document.getElementById("fm-building-name-input").value, 25);
+    }
+    
+    if ($("#fm-building-desc-chars-left").length) {
+        putCharsLeft($('#fm-building-desc-chars-left'), document.getElementById("fm-building-desc-input").value, 50);
+    }
+    
+    function putCharsLeft(messageLocation,  value, maxChars) {
+        let charsLeft = FM.calcCharsLeft(value, maxChars);
+        messageLocation.text("You have " + charsLeft + " characters remaining");
+    }
+    
     $('#fm-building-name-input').on('keyup', function (e) {
-        $('#fm-building-name-chars-left').text(FM.calcCharsLeft(e.target.value, 25));
+        putCharsLeft($('#fm-building-name-chars-left'), e.target.value, 25);
     });
-
+    
     $('#fm-building-name-input').on('change', function (e) {
         if (e.target.value) {
             assign_building_name(e.target.value);
@@ -28,7 +42,7 @@ $(function () {
     };
 
     $('#fm-building-desc-input').on('keyup', function (e) {
-        $('#fm-building-desc-chars-left').text(FM.calcCharsLeft(e.target.value, 50));
+        putCharsLeft($('#fm-building-desc-chars-left'), e.target.value, 50);
     });
 
     $('#fm-building-desc-input').on('change', function (e) {

--- a/app/assets/javascripts/facilities_management/beta/building_management/building.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building.js
@@ -16,11 +16,11 @@ $(function () {
     
     // Puts the 'characters remaining' count when the page loads
     if ($("#fm-building-name-input").length) {
-        putCharsLeft($('#fm-building-name-chars-left'), document.getElementById("fm-building-name-input").value, 25);
+        putCharsLeft($("#fm-building-name-chars-left"), document.getElementById("fm-building-name-input").value, 25);
     }
     
     if ($("#fm-building-desc-chars-left").length) {
-        putCharsLeft($('#fm-building-desc-chars-left'), document.getElementById("fm-building-desc-input").value, 50);
+        putCharsLeft($("#fm-building-desc-chars-left"), document.getElementById("fm-building-desc-input").value, 50);
     }
     
     

--- a/app/assets/javascripts/facilities_management/beta/building_management/building.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building.js
@@ -25,7 +25,7 @@ $(function () {
     
     
     $('#fm-building-name-input').on('keyup', function (e) {
-        putCharsLeft($('#fm-building-name-chars-left'), e.target.value, 25);
+        putCharsLeft($("#fm-building-name-chars-left"), e.target.value, 25);
     });
     
     $('#fm-building-name-input').on('change', function (e) {

--- a/app/assets/javascripts/facilities_management/beta/building_management/building_gross_internal_area.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building_gross_internal_area.js
@@ -11,12 +11,12 @@ $(function () {
     
     // Puts the 'characters remaining' count when the page loads
     if ($("#fm-bm-internal-square-area").length) {
-        putCharsLeft($('#fm-internal-square-area-chars-left'), document.getElementById("fm-bm-internal-square-area").value);
+        putCharsLeft($("#fm-internal-square-area-chars-left"), document.getElementById("fm-bm-internal-square-area").value);
     }
     
     // GIA
     $('#fm-bm-internal-square-area').on('keyup', function (e) {
-        putCharsLeft($('#fm-internal-square-area-chars-left'), e.target.value);
+        putCharsLeft($("#fm-internal-square-area-chars-left"), e.target.value);
     });
     
     $('#fm-bm-internal-square-area').on('keypress', function (event) {

--- a/app/assets/javascripts/facilities_management/beta/building_management/building_gross_internal_area.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building_gross_internal_area.js
@@ -4,14 +4,14 @@ $(function () {
     window.FM = window.FM || {};
     FM.building.GIA = {};
     
-    // Puts the 'characters remaining' count when the page loads
-    if ($("#fm-bm-internal-square-area").length) {
-        putCharsLeft($('#fm-internal-square-area-chars-left'), document.getElementById("fm-bm-internal-square-area").value);
-    }
-    
     function putCharsLeft(messageLocation,  value) {
         let charsLeft = FM.calcCharsLeft(value, 10);
         messageLocation.text("You have " + charsLeft + " characters remaining");
+    }
+    
+    // Puts the 'characters remaining' count when the page loads
+    if ($("#fm-bm-internal-square-area").length) {
+        putCharsLeft($('#fm-internal-square-area-chars-left'), document.getElementById("fm-bm-internal-square-area").value);
     }
     
     // GIA

--- a/app/assets/javascripts/facilities_management/beta/building_management/building_gross_internal_area.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building_gross_internal_area.js
@@ -3,10 +3,22 @@ $(function () {
     /* namespace */
     window.FM = window.FM || {};
     FM.building.GIA = {};
+    
+    // Puts the 'characters remaining' count when the page loads
+    if ($("#fm-bm-internal-square-area").length) {
+        putCharsLeft($('#fm-internal-square-area-chars-left'), document.getElementById("fm-bm-internal-square-area").value);
+    }
+    
+    function putCharsLeft(messageLocation,  value) {
+        let charsLeft = FM.calcCharsLeft(value, 10);
+        messageLocation.text("You have " + charsLeft + " characters remaining");
+    }
+    
     // GIA
     $('#fm-bm-internal-square-area').on('keyup', function (e) {
-        $('#fm-internal-square-area-chars-left').text(FM.calcCharsLeft(e.target.value, 10));
+        putCharsLeft($('#fm-internal-square-area-chars-left'), e.target.value);
     });
+    
     $('#fm-bm-internal-square-area').on('keypress', function (event) {
         if ((event.which < 48 || event.which > 57)) {
             event.preventDefault();

--- a/app/assets/javascripts/facilities_management/beta/building_management/building_security_type.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building_security_type.js
@@ -1,26 +1,20 @@
-function findCharsLeft(value) {
-    
-    if (value.length > 0) {
-        $('#fm-building-security-type-other').val(value);
-    } else {
-        $('#fm-building-security-type-other').val("other");
-    }
-
-    let charsLeft = FM.calcCharsLeft(value, 150);
-    $('#fm-bm-bs-char-count').text('You have ' + charsLeft + ' characters remaining');
-}
-    
 $(function () {
     
     // Puts the 'characters remaining' count when the page loads
-    let otherSecurityType = document.getElementById("fm-building-security-type-more-detail");
-    let value = 0;
-    
-    if (otherSecurityType != null) {
-        value = otherSecurityType.value;
+    if ($("#fm-building-security-type-more-detail").length){
+        putCharsLeft(document.getElementById("fm-building-security-type-more-detail").value);
     }
     
-    findCharsLeft(value);
+    function putCharsLeft(value) {
+        if (value.length > 0) {
+            $('#fm-building-security-type-other').val(value);
+        } else {
+            $('#fm-building-security-type-other').val("other");
+        }
+    
+        let charsLeft = FM.calcCharsLeft(value, 150);
+        $('#fm-bm-bs-char-count').text('You have ' + charsLeft + ' characters remaining');
+    }
     
     $("input:radio[name=fm-building-security-type-radio]").on('click', function (e) {
         $('#inline-error-message').addClass('govuk-visually-hidden');
@@ -38,7 +32,7 @@ $(function () {
 
     $('#fm-building-security-type-more-detail').on('keyup', function(e) {
         let value = e.target.value;
-        findCharsLeft(value);
+        putCharsLeft(value);
     });
 
     $('#fm-bm-security-type-footer #fm-bm-cancel-and-return').on('click', function (e) {

--- a/app/assets/javascripts/facilities_management/beta/building_management/building_security_type.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building_security_type.js
@@ -1,10 +1,5 @@
 $(function () {
     
-    // Puts the 'characters remaining' count when the page loads
-    if ($("#fm-building-security-type-more-detail").length){
-        putCharsLeft(document.getElementById("fm-building-security-type-more-detail").value);
-    }
-    
     function putCharsLeft(value) {
         if (value.length > 0) {
             $('#fm-building-security-type-other').val(value);
@@ -14,6 +9,11 @@ $(function () {
     
         let charsLeft = FM.calcCharsLeft(value, 150);
         $('#fm-bm-bs-char-count').text('You have ' + charsLeft + ' characters remaining');
+    }
+    
+    // Puts the 'characters remaining' count when the page loads
+    if ($("#fm-building-security-type-more-detail").length){
+        putCharsLeft(document.getElementById("fm-building-security-type-more-detail").value);
     }
     
     $("input:radio[name=fm-building-security-type-radio]").on('click', function (e) {

--- a/app/views/facilities_management/beta/buildings_management/building.html.erb
+++ b/app/views/facilities_management/beta/buildings_management/building.html.erb
@@ -16,7 +16,7 @@
 
     <input id="fm-building-name-input" class="govuk-input" type="text" maxlength="25" style="width:300px;"
            value="<%= @building['name'] %>" name="fm-building-name">
-    <span class="govuk-caption-m">You have <span id="fm-building-name-chars-left">25</span> characters remaining</span>
+    <span class="govuk-caption-m" id="fm-building-name-chars-left"></span>
     <!-- building description -->
     <span class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-margin-top-5">What's the description? - Optional</span>
     <span class="govuk-caption-m govuk-!-margin-top-0">
@@ -25,7 +25,7 @@
   </span>
     <input id="fm-building-desc-input" class="govuk-input" type="text" maxlength="50" style="width:300px;"
            value="<%= @building['description'] %>" name="fm-building-desc">
-    <span class="govuk-caption-m">You have <span id="fm-building-desc-chars-left">50</span> characters remaining</span>
+    <span class="govuk-caption-m" id="fm-building-desc-chars-left"></span>
     <!-- Address -->
     <span class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-margin-top-5">What's the address?</span>
     <span class="govuk-caption-m govuk-!-margin-top-0">

--- a/app/views/facilities_management/beta/buildings_management/building_gross_internal_area.html.erb
+++ b/app/views/facilities_management/beta/buildings_management/building_gross_internal_area.html.erb
@@ -15,7 +15,7 @@
              value="<%= @building['gia']%>"/>
       <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
       <label for="fm-bm-internal-square-area" class="govuk-label-wrapper govuk-!-margin-left-3"><%= t('facilities_management.beta.building-gross-internal-area.input_label') %></label>
-      <span class="govuk-caption-m">You have <span id="fm-internal-square-area-chars-left">10</span> characters remaining</span>
+      <span class="govuk-caption-m" id="fm-internal-square-area-chars-left"> </span>
     </p>
   </div>
 </form>


### PR DESCRIPTION
I have updated the char count JavaScript so that it works when the page is reloaded. This affected the building 'name' and 'description' in the building details, the building GIA input and the 'other' security text box. I also change the HTML so that didn't need hardcoded text so that only the JavaScript would put it in. I also refactored my previous solution to reduce the lines of code.