### PR TITLE
Feature/FM-459-fixes

### DIFF
--- a/app/models/facilities_management/procurement.rb
+++ b/app/models/facilities_management/procurement.rb
@@ -40,7 +40,15 @@ module FacilitiesManagement
     end
 
     def valid_on_continue?
-      valid?(:all) || procurement_buildings.active.map { |p| p.valid?(:procurement_building_services) }.include?(false)
+      valid?(:all) && valid_services?
+    end
+
+    def valid_services?
+      active_procurement_buildings.map(&:procurement_building_services).any? && active_procurement_buildings.all? { |p| p.valid?(:procurement_building_services) }
+    end
+
+    def active_procurement_buildings
+      procurement_buildings.active
     end
   end
 end

--- a/app/views/facilities_management/beta/procurements/_errors_on_show.html.erb
+++ b/app/views/facilities_management/beta/procurements/_errors_on_show.html.erb
@@ -11,7 +11,7 @@
         </li>
       <% end %>
       <% @active_procurement_buildings.each do |procurement_building| %>
-        <% if procurement_building.valid?(:procurement_building_service) && params[:validate] %>
+        <% if procurement_building.procurement_building_services.any? && procurement_building.valid?(:procurement_building_service) && params[:validate] %>
           <li>
             <%= link_to t('activerecord.errors.models.facilities_management/procurement.attributes.procurement_building_services.invalid_html', building_name: procurement_building.name), "##{procurement_building.id}" %>
           </li>

--- a/app/views/facilities_management/beta/procurements/contract_period/_contract_period_section.html.erb
+++ b/app/views/facilities_management/beta/procurements/contract_period/_contract_period_section.html.erb
@@ -1,4 +1,4 @@
-<tr class="govuk-table__row">
+<tr class="govuk-table__row" id="initial_call_off_period-error">
   <th scope="row" class="govuk-table__header govuk-!-font-size-24" width="30%">Contract period</th>
   <td class="govuk-table__cell">
     <%= link_to('Answer all questions', edit_facilities_management_beta_procurement_path(:step => 'contract_dates'), :class => "govuk-link") if @procurement.unanswered_contract_date_questions? %>
@@ -25,9 +25,6 @@
 </tr>
 <tr class="govuk-table__row">
   <th scope="row" class="govuk-table__header govuk-!-font-size-19" width="30%">Initial call-off period end date</th>
-  <td class="govuk-table__cell">
-    <%= initial_call_off_period_start_date %>
-  </td>
   <td class="govuk-table__cell">
     <% unless @procurement.initial_call_off_period.nil? %>
       <%= initial_call_off_period_end_date %>


### PR DESCRIPTION
Issue1- the error message(You must answer the questions about 'Contract period') is not clickable like other error messages
Issue 2- Initial call-off period end date field is displaying start date before end date
Issue 3- error message You have to answer one or more questions on "WV building". Service information status must be 'Complete' should appear on the header only when no  service has been assigned to the building.
Issue 4- when service is added to a building, click continue with the service information = incomplete, user is able to continue to summary page