### PR TITLE
Added a regex pattern in view and added validation in the model

### DIFF
--- a/app/assets/javascripts/facilities_management/beta/procurement/FormValidationComponent.js
+++ b/app/assets/javascripts/facilities_management/beta/procurement/FormValidationComponent.js
@@ -81,7 +81,7 @@ function FormValidationComponent(formDOMObject, validationCallback, thisisspecia
                             if (jElem.prop("pattern") !== undefined && jElem.prop("pattern") !== "" && submitForm) {
                                 submitForm = submitForm && this.testError(
                                     this.validationFunctions["regex"],
-                                    jElem, "pattern");
+                                    jElem, "invalid");
                             }
                             if (jElem.prop("min") !== undefined && jElem.prop("min") !== "" && submitForm) {
                                 submitForm = submitForm && this.testError(

--- a/app/models/concerns/procurement_validator.rb
+++ b/app/models/concerns/procurement_validator.rb
@@ -7,7 +7,7 @@ module ProcurementValidator
     validates :name, presence: true, on: :name
     validates :name, uniqueness: { scope: :user }, on: :name
     validates :name, length: 1..100, on: :name
-    validates :name, format: { with: /\A[^\s]([a-zA-Z(0-9) _\-]*)[^\s]\z/ }, on: :name
+    validates :name, format: { with: /\A([a-zA-Z(0-9)_\''\-])([a-zA-Z(0-9) _\''\-]*)([a-zA-Z(0-9)_\''\-])\z/ }, on: :name
 
     # validations on :contract_name step
     validates :contract_name, presence: true, on: %i[contract_name]

--- a/app/models/concerns/procurement_validator.rb
+++ b/app/models/concerns/procurement_validator.rb
@@ -7,6 +7,7 @@ module ProcurementValidator
     validates :name, presence: true, on: :name
     validates :name, uniqueness: { scope: :user }, on: :name
     validates :name, length: 1..100, on: :name
+    validates :name, format: { with: /\A[^\s]([a-zA-Z(0-9) _\-]*)[^\s]\z/ }, on: :name
 
     # validations on :contract_name step
     validates :contract_name, presence: true, on: %i[contract_name]

--- a/app/views/facilities_management/beta/procurements/_quick_search_form.html.erb
+++ b/app/views/facilities_management/beta/procurements/_quick_search_form.html.erb
@@ -30,8 +30,8 @@
               <%= govuk_form_group_with_optional_error @procurement, :name do %>
                 <%= display_potential_errors @procurement, :name, f.object_name %>
                 <%= f.label :name, t('.new_name_label'), class: 'govuk-label' %>
-                <%= f.text_field :name, maxlength: 110, required: true, class: 'govuk-input govuk-input--width-20 js-character-count' %>
-              <%end %>
+                <%= f.text_field :name, maxlength: 110, required: true, class: 'govuk-input govuk-input--width-20 js-character-count', pattern: '^[^\s]([a-zA-Z(0-9) _\-]*)[^\s]$' %>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/facilities_management/beta/procurements/_quick_search_form.html.erb
+++ b/app/views/facilities_management/beta/procurements/_quick_search_form.html.erb
@@ -26,7 +26,7 @@
         </div>
         <div class="govuk-grid-row">
           <div class="govuk-caption-m govuk-!-margin-top-3" data-module="character-count" data-maxlength="100">
-            <div class="govuk-form-group <%= 'govuk-form-group--error' if @procurement.errors[:name].any? %>" data-propertyname="Name">
+            <div class="govuk-form-group <%= 'govuk-form-group--error' if @procurement.errors[:name].any? %>" data-propertyname="name">
               <%= govuk_form_group_with_optional_error @procurement, :name do %>
                 <%= display_potential_errors @procurement, :name, f.object_name %>
                 <%= f.label :name, t('.new_name_label'), class: 'govuk-label' %>

--- a/app/views/facilities_management/beta/procurements/_quick_search_form.html.erb
+++ b/app/views/facilities_management/beta/procurements/_quick_search_form.html.erb
@@ -30,7 +30,7 @@
               <%= govuk_form_group_with_optional_error @procurement, :name do %>
                 <%= display_potential_errors @procurement, :name, f.object_name %>
                 <%= f.label :name, t('.new_name_label'), class: 'govuk-label' %>
-                <%= f.text_field :name, maxlength: 110, required: true, class: 'govuk-input govuk-input--width-20 js-character-count', pattern: '^[^\s]([a-zA-Z(0-9) _\-]*)[^\s]$' %>
+                <%= f.text_field :name, maxlength: 110, required: true, class: 'govuk-input govuk-input--width-20 js-character-count', pattern: '^([a-zA-Z(0-9)_\'\-])([a-zA-Z(0-9) _\'\-]*)([a-zA-Z(0-9)_\'\-])$' %>
               <% end %>
             </div>
           </div>

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -105,10 +105,10 @@ en:
               not_valid_with_tupe: Mobilisation length must be a minimum of 4 weeks when TUPE is selected
             name:
               blank: Enter the name for the search
+              invalid: Name is not valid
               taken: This name is already in use
               too_long: Your search name must be 100 characters or fewer
               too_short: Enter the name for the search
-              invalid: Name is not valid
             optional_call_off_extensions_1:
               too_long: Call-off period and extensions must be 10 years or less
             procurement_building_services:

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -105,9 +105,9 @@ en:
               not_valid_with_tupe: Mobilisation length must be a minimum of 4 weeks when TUPE is selected
             name:
               blank: Enter the name for the search
-              invalid: Name is not valid
+              invalid: Search name must only include letters a to z, numbers, hyphens, spaces and apostrophes
               taken: This name is already in use
-              too_long: Your search name must be 100 characters or fewer
+              too_long: Search name must be 100 characters or less
               too_short: Enter the name for the search
             optional_call_off_extensions_1:
               too_long: Call-off period and extensions must be 10 years or less

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -108,6 +108,7 @@ en:
               taken: This name is already in use
               too_long: Your search name must be 100 characters or fewer
               too_short: Enter the name for the search
+              invalid: Name is not valid
             optional_call_off_extensions_1:
               too_long: Call-off period and extensions must be 10 years or less
             procurement_building_services:


### PR DESCRIPTION
As part of this ticket I also completed the work on CSI-48 as it was related to the validation of the quick search name.

I added the regex pattern to the view so that it would only allow alphanumeric characters, spaces and these characters: '-_'. For the part on CSI-48 I added the same regex but removed the space character so that only the permitted characters  can be used at the start and end to prevent the quick search name from having preceding or trailing spaces. This prevents the issue of someone being able to save the same quick search name twice by putting a space at the start or end of the name.

I added a validation to the model so that both the front and back end are secure from a user putting in invalid characters. I also added an invalid message into the `.yml` file.