### PR TITLE
Bug/fm 574 building order in spreadsheet

### DIFF
--- a/app/controllers/facilities_management/beta/summary_controller.rb
+++ b/app/controllers/facilities_management/beta/summary_controller.rb
@@ -21,7 +21,6 @@ module FacilitiesManagement
         end
       end
 
-      # rubocop:disable Metrics/AbcSize
       def sorted_suppliers
         init
 
@@ -45,7 +44,7 @@ module FacilitiesManagement
 
         # create deliverable matrix spreadsheet
         # buildings_ids = building_uvals.collect { |u| u[:id] }.compact.uniq
-        building_ids_with_service_codes2 = buildings_ids.sort.collect do |b|
+        building_ids_with_service_codes2 = buildings_ids.collect do |b|
           services_per_building = uvals.select { |u| u[:building_id] == b }.collect { |u| u[:service_code] }
           { building_id: b.downcase, service_codes: services_per_building }
         end
@@ -60,7 +59,6 @@ module FacilitiesManagement
         ### render xlsx: spreadsheet2.to_stream.read, filename: 'deliverable_matrix'
         download_report 'fm_spreadsheets', [['direct_award_prices', spreadsheet1], ['deliverable_matrix', spreadsheet_builder]]
       end
-      # rubocop:enable Metrics/AbcSize
 
       private
 

--- a/spec/models/facilities_management/summary_report2_spec.rb
+++ b/spec/models/facilities_management/summary_report2_spec.rb
@@ -703,7 +703,7 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
       # create deliverable matrix spreadsheet
       buildings_ids = uvals.collect { |u| u['building_id'] }.compact.uniq
 
-      building_ids_with_service_codes2 = buildings_ids.sort.collect do |b|
+      building_ids_with_service_codes2 = buildings_ids.collect do |b|
         services_per_building = uvals.select { |u| u[:building_id] == b }.collect { |u| u[:service_code] }
         { building_id: b.downcase, service_codes: services_per_building }
       end

--- a/spec/models/facilities_management/summary_report3_spec.rb
+++ b/spec/models/facilities_management/summary_report3_spec.rb
@@ -424,7 +424,8 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
       # create deliverable matrix spreadsheet
       buildings_ids = uvals.collect { |u| u[:building_id] }.compact.uniq
 
-      building_ids_with_service_codes2 = buildings_ids.sort.collect do |b|
+      # building_ids_with_service_codes2 = buildings_ids.sort.collect do |b|
+      building_ids_with_service_codes2 = buildings_ids.collect do |b|
         services_per_building = uvals.select { |u| u[:building_id] == b }.collect { |u| u[:service_code] }
         { building_id: b.downcase, service_codes: services_per_building }
       end
@@ -475,7 +476,7 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
       # create deliverable matrix spreadsheet
       buildings_ids = uvals.collect { |u| u[:building_id] }.compact.uniq
 
-      building_ids_with_service_codes2 = buildings_ids.sort.collect do |b|
+      building_ids_with_service_codes2 = buildings_ids.collect do |b|
         services_per_building = uvals.select { |u| u[:building_id] == b }.collect { |u| u[:service_code] }
         { building_id: b.downcase, service_codes: services_per_building }
       end

--- a/spec/models/facilities_management/summary_report3_spec.rb
+++ b/spec/models/facilities_management/summary_report3_spec.rb
@@ -424,7 +424,6 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
       # create deliverable matrix spreadsheet
       buildings_ids = uvals.collect { |u| u[:building_id] }.compact.uniq
 
-      # building_ids_with_service_codes2 = buildings_ids.sort.collect do |b|
       building_ids_with_service_codes2 = buildings_ids.collect do |b|
         services_per_building = uvals.select { |u| u[:building_id] == b }.collect { |u| u[:service_code] }
         { building_id: b.downcase, service_codes: services_per_building }


### PR DESCRIPTION
The buildings were not order by the name in the deliverable_matrix.xlsx.
The SQL query does order by name already, so I just removed the sort by building id in the code.

_module FacilitiesManagement
  class ProcurementBuilding < ApplicationRecord
    default_scope { order(name: :asc) }_