### PR TITLE
removed numbering from services pages

### DIFF
--- a/app/views/facilities_management/beta/procurement_buildings/_building_standards.html.erb
+++ b/app/views/facilities_management/beta/procurement_buildings/_building_standards.html.erb
@@ -33,14 +33,12 @@
       <%= t('.fabric_standard_c_copy') %>
     </div>
   </details>
-  <% index = 0 %>
   <%= f.fields_for :procurement_building_services do |procurement_building_service| %>
     <% if procurement_building_service.object.requires_building_standards? %>
-      <% index += 1 %>
       <div class="govuk-form-group <%= "govuk-form-group--error" if procurement_building_service.object.errors.any? %>" id="<%= error_id("procurement_building_services.#{building_standard_question(procurement_building_service.object)}") %>">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-0 govuk-!-padding-bottom-0">
-            <p class="govuk-fieldset__heading"><strong><%= index %>. <%= procurement_building_service.object.name %></strong></p>
+            <p class="govuk-fieldset__heading"><strong><%= procurement_building_service.object.name %></strong></p>
           </legend>
           <%= display_error_nested_models(procurement_building_service.object, building_standard_question(procurement_building_service.object)) %>
           <%= procurement_building_service.collection_radio_buttons :service_standard, FacilitiesManagement::ProcurementBuildingService::SERVICE_STANDARDS, :first, :first do |b| %>

--- a/app/views/facilities_management/beta/procurement_buildings/_cleaning_standards.html.erb
+++ b/app/views/facilities_management/beta/procurement_buildings/_cleaning_standards.html.erb
@@ -33,14 +33,12 @@
       <%= t('.cleaning_standard_c_copy') %>
     </div>
   </details>
-  <% index = 0 %>
   <%= f.fields_for :procurement_building_services do |procurement_building_service| %>
     <% if procurement_building_service.object.requires_cleaning_standards? %>
-      <% index += 1 %>
       <div class="govuk-form-group <%= "govuk-form-group--error" if procurement_building_service.object.errors.any? %>" id="<%= error_id("procurement_building_services.#{cleaning_standard_question(procurement_building_service.object)}") %>">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-0 govuk-!-padding-bottom-0">
-            <span class="govuk-fieldset__heading"><strong><%= index %>. <%= procurement_building_service.object.name %></strong></span>
+            <span class="govuk-fieldset__heading"><strong><%= procurement_building_service.object.name %></strong></span>
           </legend>
           <%= display_error_nested_models(procurement_building_service.object, cleaning_standard_question(procurement_building_service.object)) %>
           <%= procurement_building_service.collection_radio_buttons :service_standard, FacilitiesManagement::ProcurementBuildingService::SERVICE_STANDARDS, :first, :first do |b| %>

--- a/app/views/facilities_management/beta/procurement_buildings/_ppm_standards.html.erb
+++ b/app/views/facilities_management/beta/procurement_buildings/_ppm_standards.html.erb
@@ -33,14 +33,12 @@
       <%= t('.standard_c_copy') %>
     </div>
   </details>
-  <% index = 0 %>
   <%= f.fields_for :procurement_building_services do |procurement_building_service| %>
     <% if procurement_building_service.object.requires_ppm_standards? %>
-      <% index += 1 %>
       <div class="govuk-form-group <%= "govuk-form-group--error" if procurement_building_service.object.errors.any? %>" id="<%= error_id("procurement_building_services.#{ppm_standard_question(procurement_building_service.object)}") %>">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-0 govuk-!-padding-bottom-0">
-            <span class="govuk-fieldset__heading"><strong><%= index %>. <%= procurement_building_service.object.name %></strong></span>
+            <span class="govuk-fieldset__heading"><strong><%= procurement_building_service.object.name %></strong></span>
           </legend>
           <%= display_error_nested_models(procurement_building_service.object, ppm_standard_question(procurement_building_service.object)) %>
           <%= procurement_building_service.collection_radio_buttons :service_standard, FacilitiesManagement::ProcurementBuildingService::SERVICE_STANDARDS, :first, :first do |b| %>


### PR DESCRIPTION
CSI-42 On the services information page, as selecting 'change' on different services led to different standard pages (PPM standards, Cleaning standards and building fabric standards) users may be confused by the inconsistency of numbering. I have removed the numbering from the standards pages so only the service title remains.