### PR TITLE
Added method to remove excess spaces from name and refactored regex

### DIFF
--- a/app/controllers/facilities_management/beta/procurements_controller.rb
+++ b/app/controllers/facilities_management/beta/procurements_controller.rb
@@ -25,6 +25,7 @@ module FacilitiesManagement
 
       def create
         @procurement = current_user.procurements.build(procurement_params)
+        @procurement.name = remove_excess_spaces(@procurement.name)
 
         if @procurement.save(context: :name)
           redirect_to edit_facilities_management_beta_procurement_url(id: @procurement.id)
@@ -204,6 +205,10 @@ module FacilitiesManagement
 
       def procurement_valid?
         @procurement.valid_on_continue?
+      end
+
+      def remove_excess_spaces(name)
+        name.split.join(' ')
       end
     end
   end

--- a/app/controllers/facilities_management/beta/procurements_controller.rb
+++ b/app/controllers/facilities_management/beta/procurements_controller.rb
@@ -208,7 +208,7 @@ module FacilitiesManagement
       end
 
       def remove_excess_spaces(name)
-        name.split.join(' ')
+        name&.split&.join(' ')
       end
     end
   end

--- a/app/controllers/facilities_management/beta/procurements_controller.rb
+++ b/app/controllers/facilities_management/beta/procurements_controller.rb
@@ -25,7 +25,6 @@ module FacilitiesManagement
 
       def create
         @procurement = current_user.procurements.build(procurement_params)
-        @procurement.name = remove_excess_spaces(@procurement.name)
 
         if @procurement.save(context: :name)
           redirect_to edit_facilities_management_beta_procurement_url(id: @procurement.id)
@@ -205,10 +204,6 @@ module FacilitiesManagement
 
       def procurement_valid?
         @procurement.valid_on_continue?
-      end
-
-      def remove_excess_spaces(name)
-        name&.split&.join(' ')
       end
     end
   end

--- a/app/models/concerns/procurement_validator.rb
+++ b/app/models/concerns/procurement_validator.rb
@@ -7,7 +7,7 @@ module ProcurementValidator
     validates :name, presence: true, on: :name
     validates :name, uniqueness: { scope: :user }, on: :name
     validates :name, length: 1..100, on: :name
-    validates :name, format: { with: /\A([a-zA-Z(0-9)_\''\-])([a-zA-Z(0-9) _\''\-]*)([a-zA-Z(0-9)_\''\-])\z/ }, on: :name
+    validates :name, format: { with: /\A([a-zA-Z(0-9) _\''\-]*)\z/ }, on: :name
 
     # validations on :contract_name step
     validates :contract_name, presence: true, on: %i[contract_name]

--- a/app/models/concerns/procurement_validator.rb
+++ b/app/models/concerns/procurement_validator.rb
@@ -4,6 +4,7 @@ module ProcurementValidator
   # rubocop:disable Metrics/BlockLength
   included do
     # validations on :name step
+    before_validation :remove_excess_whitespace_from_name, on: :name
     validates :name, presence: true, on: :name
     validates :name, uniqueness: { scope: :user }, on: :name
     validates :name, length: 1..100, on: :name
@@ -69,6 +70,13 @@ module ProcurementValidator
     validate :validate_mobilisation_and_tupe, on: :all
 
     private
+
+    #############################################
+    # Start of validation methods for contract-dates
+
+    def remove_excess_whitespace_from_name
+      self.name = name&.split&.join(' ')
+    end
 
     #############################################
     # Start of validation methods for contract-dates

--- a/app/views/facilities_management/beta/procurements/_quick_search_form.html.erb
+++ b/app/views/facilities_management/beta/procurements/_quick_search_form.html.erb
@@ -30,7 +30,7 @@
               <%= govuk_form_group_with_optional_error @procurement, :name do %>
                 <%= display_potential_errors @procurement, :name, f.object_name %>
                 <%= f.label :name, t('.new_name_label'), class: 'govuk-label' %>
-                <%= f.text_field :name, maxlength: 110, required: true, class: 'govuk-input govuk-input--width-20 js-character-count', pattern: '^([a-zA-Z(0-9)_\'\-])([a-zA-Z(0-9) _\'\-]*)([a-zA-Z(0-9)_\'\-])$' %>
+                <%= f.text_field :name, maxlength: 110, required: true, class: 'govuk-input govuk-input--width-20 js-character-count', pattern: '^([a-zA-Z(0-9) _\'\-]*)$' %>
               <% end %>
             </div>
           </div>

--- a/spec/models/facilities_management/procurement_spec.rb
+++ b/spec/models/facilities_management/procurement_spec.rb
@@ -17,10 +17,38 @@ RSpec.describe FacilitiesManagement::Procurement, type: :model do
     end
 
     context 'when the name is not unique' do
-      let(:second_procurement) {  create(:facilities_management_procurement, name: procurement.name, user: user) }
+      let(:second_procurement) { create(:facilities_management_procurement, name: procurement.name, user: user) }
 
       it 'expected to not be valid' do
         expect(second_procurement.valid?(:name)).to eq false
+      end
+    end
+
+    context 'when the name has trailing and preceeding whitespace' do
+      let(:third_procurement) { create(:facilities_management_procurement, name: "  #{procurement.name}  ", user: user) }
+
+      it 'expected to remove trailing and preceeding whitespace' do
+        expect(third_procurement.send(:remove_excess_whitespace_from_name)).to eq procurement.name
+      end
+
+      it 'expected not to be valid if the same name is in database without additional whitespace' do
+        expect(third_procurement.valid?(:name)).to eq false
+      end
+    end
+
+    context 'when the name has multiple space in the middle' do
+      let(:forth_procurement) { create(:facilities_management_procurement, name: 'This   is a  test     name', user: user) }
+
+      it 'expected to remove excess spaces' do
+        expect(forth_procurement.send(:remove_excess_whitespace_from_name)).to eq 'This is a test name'
+      end
+    end
+
+    context 'when the name uses invalid characters' do
+      let(:fith_procurement) { create(:facilities_management_procurement, name: '!@£ $%^&* ()+=|<>,?', user: user) }
+
+      it 'expected to be invalid' do
+        expect(fith_procurement.valid?(:name)).to eq false
       end
     end
 


### PR DESCRIPTION
I created a simple method that takes the quick search name and gets rid of the excess spaces. This prevents a user from creating basically identical search names (like "Test 1" and "Test    1"). 

This also meant that I could update the regex for the name pattern as the splitting of the name automatically removes leading and trailing spaces.

Overall, this solution prevents the user from putting in names that would appear identical when viewed on the page.