### PR TITLE
bullet points on detailed summary page now all lowercase.

### DIFF
--- a/app/views/facilities_management/beta/procurements/_procurement_building_services.html.erb
+++ b/app/views/facilities_management/beta/procurements/_procurement_building_services.html.erb
@@ -8,7 +8,7 @@
     <ul class="govuk-!-margin-0 govuk-!-padding-0 govuk-!-padding-left-7">
       <%if @services %>
         <% procurement_building.service_codes.each do |service_code| %>
-          <li class="govuk-!-margin-top-2 govuk-!-margin-bottom-2"><%= "#{@services.select{|s| s['code'] == service_code}.first&.name}" %></li>
+          <li class="govuk-!-margin-top-2 govuk-!-margin-bottom-2"><%= "#{@services.select{|s| s['code'] == service_code}.first&.name.downcase}" %></li>
         <% end %>
       <% end %>
     </ul>


### PR DESCRIPTION
Detailed summary page services for building should all now be lower case, as is in line with ticket CSI-53. 