### PR TITLE
Changed the autocomplete on password and email to off

### DIFF
--- a/app/views/apprenticeships/home/search_results.html.erb
+++ b/app/views/apprenticeships/home/search_results.html.erb
@@ -17,7 +17,7 @@
 
   <!-- ID #ccs-at-results-filters required -->
   <section id="ccs-at-results-filters" class="govuk-grid-column-one-third ccs-at-results-filters">
-    <%= form_tag apprenticeships_search_path, class: :'ccs-form', method: :get, id: 'search-results-form',  autocomplete: 'off' do %><!-- form inside section element-->
+    <%= form_tag apprenticeships_search_path, class: :'ccs-form', method: :get, id: 'search-results-form',  autocomplete: "off" do %><!-- form inside section element-->
 
       <!-- start Levels filters -->
       <div class="govuk-form-group ccs-at-results-filters__panel">

--- a/app/views/apprenticeships/passwords/edit.html.erb
+++ b/app/views/apprenticeships/passwords/edit.html.erb
@@ -55,7 +55,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_reset.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@response, :password) %>
-          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "new-password" %>
+          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:password_confirmation].any? %>">
@@ -72,7 +72,7 @@
                     </span>
 
           <%= display_error(@response, :password_confirmation) %>
-          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "new-password" %>
+          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:confirmation_code].any? %>">

--- a/app/views/apprenticeships/passwords/new.html.erb
+++ b/app/views/apprenticeships/passwords/new.html.erb
@@ -45,7 +45,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_request.attributes.please_enter_a_valid_email_address') %>
                 </span>
 
-        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="email" spellcheck="false">
+        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
       </div>
 
       <%= submit_tag t('common.send_reset_email'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>

--- a/app/views/apprenticeships/registrations/new.html.erb
+++ b/app/views/apprenticeships/registrations/new.html.erb
@@ -47,7 +47,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.email_format') %>
                     </span>
           <%= display_error(@result, :email) %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "off", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
         </div>
 
       </fieldset>
@@ -83,7 +83,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@result, :password) %>
-          <%= f.password_field :password, autocomplete: "new-password", id: "password01", class: "govuk-input govuk-!-width-three-quarters"  %>
+          <%= f.password_field :password, autocomplete: "off", id: "password01", class: "govuk-input govuk-!-width-three-quarters"  %>
         </div>
 
         <div class="govuk-form-group  <%= 'govuk-form-group--error' if @result.errors[:password_confirmation].any? %>">
@@ -99,7 +99,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.passwords_dont_match') %>
                     </span>
           <%= display_error(@result, :password_confirmation) %>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", id: "password02", class: "govuk-input govuk-!-width-three-quarters"  %>
+          <%= f.password_field :password_confirmation, autocomplete: "off", id: "password02", class: "govuk-input govuk-!-width-three-quarters"  %>
         </div>
 
       </fieldset>

--- a/app/views/apprenticeships/sessions/new.html.erb
+++ b/app/views/apprenticeships/sessions/new.html.erb
@@ -27,7 +27,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.please_enter_a_valid_email_address') %>
         </span>
         <%= display_error(@result, :email) %>
-        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete:'email', spellcheck:'false', aria: {describedby: "email-hint"}  %>
+        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete: "off", spellcheck:'false', aria: {describedby: "email-hint"}  %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @result.errors[:password].any? %>">
@@ -39,7 +39,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.enter_your_password') %>
                 </span>
         <%= display_error(@result, :password) %>
-        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "current-password" %>
+        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "off" %>
 
       </div>
 

--- a/app/views/apprenticeships/users/_new_password_required.html.erb
+++ b/app/views/apprenticeships/users/_new_password_required.html.erb
@@ -55,7 +55,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.passwords_uppper') %>
                 </span>
         <%= display_error(@challenge, :new_password) %>
-        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "off" %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7">
@@ -71,7 +71,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.password_must_match') %>
                 </span>
         <%= display_error(@challenge, :new_password_confirmation) %>
-        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "off" %>
       </div>
 
       <%= hidden_field_tag :session, params[:session] %>

--- a/app/views/apprenticeships/users/confirm_new.html.erb
+++ b/app/views/apprenticeships/users/confirm_new.html.erb
@@ -62,7 +62,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.email_format') %>
                     </span>
           <%= display_error(@result, :email) %>
-          <%= text_field_tag :email, nil, autofocus: true, autocomplete: "email", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
+          <%= text_field_tag :email, nil, autofocus: true, autocomplete: "off", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
         </div>
       <% end %>
 

--- a/app/views/ccs_patterns/home/cog_forgot_password_request.html.erb
+++ b/app/views/ccs_patterns/home/cog_forgot_password_request.html.erb
@@ -39,7 +39,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_request.attributes.please_enter_a_valid_email_address') %>
                 </span>
 
-                <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="email" spellcheck="false">
+                <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
             </div>
 
             <%= submit_tag t('common.send_reset_email'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>

--- a/app/views/ccs_patterns/home/cog_forgot_password_reset.html.erb
+++ b/app/views/ccs_patterns/home/cog_forgot_password_reset.html.erb
@@ -54,7 +54,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_reset.attributes.passwords_upper') %>
                     </span>
 
-                    <input class="govuk-input govuk-!-width-three-quarters" id="password01" name="password01" type="password" autocomplete="new-password">
+                    <input class="govuk-input govuk-!-width-three-quarters" id="password01" name="password01" type="password" autocomplete="off">
                 </div>
 
                 <div class="govuk-form-group">
@@ -70,7 +70,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_reset.attributes.passwords_dont_match') %>
                     </span>
 
-                    <input class="govuk-input govuk-!-width-three-quarters" id="password02" name="password02" type="password" autocomplete="new-password">
+                    <input class="govuk-input govuk-!-width-three-quarters" id="password02" name="password02" type="password" autocomplete="off">
                 </div>
 
             </fieldset>

--- a/app/views/ccs_patterns/home/cog_register.html.erb
+++ b/app/views/ccs_patterns/home/cog_register.html.erb
@@ -100,7 +100,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.email_format') %>
                     </span>
 
-                    <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="email" spellcheck="false">
+                    <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
                 </div>
 
             </fieldset>
@@ -136,7 +136,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.passwords_upper') %>
                     </span>
 
-                    <input class="govuk-input govuk-!-width-three-quarters" id="password01" name="password01" type="password" autocomplete="new-password">
+                    <input class="govuk-input govuk-!-width-three-quarters" id="password01" name="password01" type="password" autocomplete="off">
                 </div>
 
                 <div class="govuk-form-group">
@@ -152,7 +152,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.passwords_dont_match') %>
                     </span>
 
-                    <input class="govuk-input govuk-!-width-three-quarters" id="password02" name="password02" type="password" autocomplete="new-password">
+                    <input class="govuk-input govuk-!-width-three-quarters" id="password02" name="password02" type="password" autocomplete="off">
                 </div>
 
             </fieldset>

--- a/app/views/ccs_patterns/home/cog_sign_in.html.erb
+++ b/app/views/ccs_patterns/home/cog_sign_in.html.erb
@@ -34,7 +34,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.please_enter_a_valid_email_address') %>
                 </span>
 
-                <input class="govuk-input govuk-!-width-two-thirds" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="email" spellcheck="false">
+                <input class="govuk-input govuk-!-width-two-thirds" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
             </div>
 
             <div class="govuk-form-group govuk-!-margin-bottom-7">
@@ -46,7 +46,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.enter_your_password') %>
                 </span>
 
-                <input class="govuk-input govuk-!-width-two-thirds" id="password" name="password" type="password" autocomplete="new-password">
+                <input class="govuk-input govuk-!-width-two-thirds" id="password" name="password" type="password" autocomplete="off">
             </div>
 
             <%= submit_tag t('common.sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>

--- a/app/views/ccs_patterns/home/cog_sign_in_password_prompt_change.html.erb
+++ b/app/views/ccs_patterns/home/cog_sign_in_password_prompt_change.html.erb
@@ -49,7 +49,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.passwords_uppper') %>
                 </span>
 
-                <input class="govuk-input govuk-!-width-two-thirds" id="password01" name="password01" type="password" autocomplete="new-password">
+                <input class="govuk-input govuk-!-width-two-thirds" id="password01" name="password01" type="password" autocomplete="off">
             </div>
 
             <div class="govuk-form-group govuk-!-margin-bottom-7">
@@ -65,7 +65,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.password_must_match') %>
                 </span>
 
-                <input class="govuk-input govuk-!-width-two-thirds" id="password02" name="password02" type="password" autocomplete="new-password">
+                <input class="govuk-input govuk-!-width-two-thirds" id="password02" name="password02" type="password" autocomplete="off">
             </div>
 
             <%= submit_tag t('common.change_password_and_sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>

--- a/app/views/facilities_management/beta/passwords/edit.html.erb
+++ b/app/views/facilities_management/beta/passwords/edit.html.erb
@@ -55,7 +55,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_reset.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@response, :password) %>
-          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "new-password" %>
+          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:password_confirmation].any? %>">
@@ -72,7 +72,7 @@
                     </span>
 
           <%= display_error(@response, :password_confirmation) %>
-          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "new-password" %>
+          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:confirmation_code].any? %>">

--- a/app/views/facilities_management/beta/passwords/new.html.erb
+++ b/app/views/facilities_management/beta/passwords/new.html.erb
@@ -45,7 +45,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_request.attributes.please_enter_a_valid_email_address') %>
                 </span>
 
-        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="email" spellcheck="false">
+        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
       </div>
 
       <%= submit_tag t('common.send_reset_email'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>

--- a/app/views/facilities_management/beta/sessions/new.html.erb
+++ b/app/views/facilities_management/beta/sessions/new.html.erb
@@ -27,7 +27,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.please_enter_a_valid_email_address') %>
         </span>
         <%= display_error(@result, :email) %>
-        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete:'email', spellcheck:'false', aria: {describedby: "email-hint"}  %>
+        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete: "off", spellcheck:'false', aria: {describedby: "email-hint"}  %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @result.errors[:password].any? %>">
@@ -39,7 +39,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.enter_your_password') %>
                 </span>
         <%= display_error(@result, :password) %>
-        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "current-password" %>
+        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "off" %>
 
       </div>
 

--- a/app/views/facilities_management/beta/users/_new_password_required.html.erb
+++ b/app/views/facilities_management/beta/users/_new_password_required.html.erb
@@ -55,7 +55,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.passwords_uppper') %>
                 </span>
         <%= display_error(@challenge, :new_password) %>
-        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "off" %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @challenge.errors[:new_password_confirmation].any? %>">
@@ -71,7 +71,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.password_must_match') %>
                 </span>
         <%= display_error(@challenge, :new_password_confirmation) %>
-        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "off" %>
       </div>
 
       <%= hidden_field_tag :session, params[:session] %>

--- a/app/views/facilities_management/passwords/edit.html.erb
+++ b/app/views/facilities_management/passwords/edit.html.erb
@@ -55,7 +55,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_reset.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@response, :password) %>
-          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "new-password" %>
+          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:password_confirmation].any? %>">
@@ -72,7 +72,7 @@
                     </span>
 
           <%= display_error(@response, :password_confirmation) %>
-          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "new-password" %>
+          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:confirmation_code].any? %>">

--- a/app/views/facilities_management/passwords/new.html.erb
+++ b/app/views/facilities_management/passwords/new.html.erb
@@ -45,7 +45,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_request.attributes.please_enter_a_valid_email_address') %>
                 </span>
 
-        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="email" spellcheck="false">
+        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
       </div>
 
       <%= submit_tag t('common.send_reset_email'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>

--- a/app/views/facilities_management/registrations/new.html.erb
+++ b/app/views/facilities_management/registrations/new.html.erb
@@ -47,7 +47,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.email_format') %>
                     </span>
           <%= display_error(@result, :email) %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "off", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
         </div>
 
       </fieldset>
@@ -83,7 +83,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@result, :password) %>
-          <%= f.password_field :password, autocomplete: "new-password", id: "password01", class: "govuk-input govuk-!-width-three-quarters"  %>
+          <%= f.password_field :password, autocomplete: "off", id: "password01", class: "govuk-input govuk-!-width-three-quarters"  %>
         </div>
 
         <div class="govuk-form-group  <%= 'govuk-form-group--error' if @result.errors[:password_confirmation].any? %>">
@@ -99,7 +99,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.passwords_dont_match') %>
                     </span>
           <%= display_error(@result, :password_confirmation) %>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", id: "password02", class: "govuk-input govuk-!-width-three-quarters"  %>
+          <%= f.password_field :password_confirmation, autocomplete: "off", id: "password02", class: "govuk-input govuk-!-width-three-quarters"  %>
         </div>
 
       </fieldset>

--- a/app/views/facilities_management/sessions/new.html.erb
+++ b/app/views/facilities_management/sessions/new.html.erb
@@ -27,7 +27,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.please_enter_a_valid_email_address') %>
         </span>
         <%= display_error(@result, :email) %>
-        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete:'email', spellcheck:'false', aria: {describedby: "email-hint"}  %>
+        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete: "off", spellcheck:'false', aria: {describedby: "email-hint"}  %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @result.errors[:password].any? %>">
@@ -39,7 +39,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.enter_your_password') %>
                 </span>
         <%= display_error(@result, :password) %>
-        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "current-password" %>
+        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "off" %>
 
       </div>
 

--- a/app/views/facilities_management/users/_new_password_required.html.erb
+++ b/app/views/facilities_management/users/_new_password_required.html.erb
@@ -55,7 +55,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.passwords_uppper') %>
                 </span>
         <%= display_error(@challenge, :new_password) %>
-        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "off" %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @challenge.errors[:new_password_confirmation].any? %>">
@@ -71,7 +71,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.password_must_match') %>
                 </span>
         <%= display_error(@challenge, :new_password_confirmation) %>
-        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "off" %>
       </div>
 
       <%= hidden_field_tag :session, params[:session] %>

--- a/app/views/facilities_management/users/confirm_new.html.erb
+++ b/app/views/facilities_management/users/confirm_new.html.erb
@@ -59,7 +59,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.email_format') %>
                     </span>
           <%= display_error(@result, :email) %>
-          <%= text_field_tag :email, nil, autofocus: true, autocomplete: "email", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
+          <%= text_field_tag :email, nil, autofocus: true, autocomplete: "off", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
         </div>
       <% end %>
 

--- a/app/views/legal_services/passwords/edit.html.erb
+++ b/app/views/legal_services/passwords/edit.html.erb
@@ -55,7 +55,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_reset.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@response, :password) %>
-          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "new-password" %>
+          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:password_confirmation].any? %>">
@@ -72,7 +72,7 @@
                     </span>
 
           <%= display_error(@response, :password_confirmation) %>
-          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "new-password" %>
+          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:confirmation_code].any? %>">

--- a/app/views/legal_services/passwords/new.html.erb
+++ b/app/views/legal_services/passwords/new.html.erb
@@ -45,7 +45,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_request.attributes.please_enter_a_valid_email_address') %>
                 </span>
 
-        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="email" spellcheck="false">
+        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
       </div>
 
       <%= submit_tag t('common.send_reset_email'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>

--- a/app/views/legal_services/registrations/new.html.erb
+++ b/app/views/legal_services/registrations/new.html.erb
@@ -47,7 +47,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.email_format') %>
                     </span>
           <%= display_error(@result, :email) %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "off", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
         </div>
 
       </fieldset>
@@ -83,7 +83,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@result, :password) %>
-          <%= f.password_field :password, autocomplete: "new-password", id: "password01", class: "govuk-input govuk-!-width-three-quarters"  %>
+          <%= f.password_field :password, autocomplete: "off", id: "password01", class: "govuk-input govuk-!-width-three-quarters"  %>
         </div>
 
         <div class="govuk-form-group  <%= 'govuk-form-group--error' if @result.errors[:password_confirmation].any? %>">
@@ -99,7 +99,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.passwords_dont_match') %>
                     </span>
           <%= display_error(@result, :password_confirmation) %>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", id: "password02", class: "govuk-input govuk-!-width-three-quarters"  %>
+          <%= f.password_field :password_confirmation, autocomplete: "off", id: "password02", class: "govuk-input govuk-!-width-three-quarters"  %>
         </div>
 
       </fieldset>

--- a/app/views/legal_services/sessions/new.html.erb
+++ b/app/views/legal_services/sessions/new.html.erb
@@ -27,7 +27,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.please_enter_a_valid_email_address') %>
         </span>
         <%= display_error(@result, :email) %>
-        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete:'email', spellcheck:'false', aria: {describedby: "email-hint"}  %>
+        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete: "off", spellcheck:'false', aria: {describedby: "email-hint"}  %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @result.errors[:password].any? %>">
@@ -39,7 +39,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.enter_your_password') %>
                 </span>
         <%= display_error(@result, :password) %>
-        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "current-password" %>
+        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "off" %>
 
       </div>
 

--- a/app/views/legal_services/users/_new_password_required.html.erb
+++ b/app/views/legal_services/users/_new_password_required.html.erb
@@ -55,7 +55,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.passwords_uppper') %>
                 </span>
         <%= display_error(@challenge, :new_password) %>
-        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "off" %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7">
@@ -71,7 +71,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.password_must_match') %>
                 </span>
         <%= display_error(@challenge, :new_password_confirmation) %>
-        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "off" %>
       </div>
 
       <%= hidden_field_tag :session, params[:session] %>

--- a/app/views/legal_services/users/confirm_new.html.erb
+++ b/app/views/legal_services/users/confirm_new.html.erb
@@ -59,7 +59,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.email_format') %>
                     </span>
           <%= display_error(@result, :email) %>
-          <%= text_field_tag :email, nil, autofocus: true, autocomplete: "email", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
+          <%= text_field_tag :email, nil, autofocus: true, autocomplete: "off", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
         </div>
       <% end %>
 

--- a/app/views/management_consultancy/admin/passwords/edit.html.erb
+++ b/app/views/management_consultancy/admin/passwords/edit.html.erb
@@ -55,7 +55,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_reset.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@response, :password) %>
-          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "new-password" %>
+          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:password_confirmation].any? %>">
@@ -72,7 +72,7 @@
                     </span>
 
           <%= display_error(@response, :password_confirmation) %>
-          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "new-password" %>
+          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:confirmation_code].any? %>">

--- a/app/views/management_consultancy/admin/passwords/new.html.erb
+++ b/app/views/management_consultancy/admin/passwords/new.html.erb
@@ -45,7 +45,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_request.attributes.please_enter_a_valid_email_address') %>
                 </span>
 
-        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="email" spellcheck="false">
+        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
       </div>
 
       <%= submit_tag t('common.send_reset_email'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>

--- a/app/views/management_consultancy/admin/sessions/new.html.erb
+++ b/app/views/management_consultancy/admin/sessions/new.html.erb
@@ -27,7 +27,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.please_enter_a_valid_email_address') %>
         </span>
         <%= display_error(@result, :email) %>
-        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete:'email', spellcheck:'false', aria: {describedby: "email-hint"}  %>
+        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete: "off", spellcheck:'false', aria: {describedby: "email-hint"}  %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @result.errors[:password].any? %>">
@@ -39,7 +39,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.enter_your_password') %>
                 </span>
         <%= display_error(@result, :password) %>
-        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "current-password" %>
+        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "off" %>
 
       </div>
 

--- a/app/views/management_consultancy/admin/users/_new_password_required.html.erb
+++ b/app/views/management_consultancy/admin/users/_new_password_required.html.erb
@@ -55,7 +55,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.passwords_uppper') %>
                 </span>
         <%= display_error(@challenge, :new_password) %>
-        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "off" %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @challenge.errors[:new_password_confirmation].any? %>">
@@ -71,7 +71,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.password_must_match') %>
                 </span>
         <%= display_error(@challenge, :new_password_confirmation) %>
-        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "off" %>
       </div>
 
       <%= hidden_field_tag :session, params[:session] %>

--- a/app/views/management_consultancy/passwords/edit.html.erb
+++ b/app/views/management_consultancy/passwords/edit.html.erb
@@ -55,7 +55,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_reset.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@response, :password) %>
-          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "new-password" %>
+          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:password_confirmation].any? %>">
@@ -72,7 +72,7 @@
                     </span>
 
           <%= display_error(@response, :password_confirmation) %>
-          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "new-password" %>
+          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:confirmation_code].any? %>">

--- a/app/views/management_consultancy/passwords/new.html.erb
+++ b/app/views/management_consultancy/passwords/new.html.erb
@@ -45,7 +45,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_request.attributes.please_enter_a_valid_email_address') %>
                 </span>
 
-        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="email" spellcheck="false">
+        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
       </div>
 
       <%= submit_tag t('common.send_reset_email'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>

--- a/app/views/management_consultancy/registrations/new.html.erb
+++ b/app/views/management_consultancy/registrations/new.html.erb
@@ -47,7 +47,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.email_format') %>
                     </span>
           <%= display_error(@result, :email) %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "off", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
         </div>
 
       </fieldset>
@@ -83,7 +83,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@result, :password) %>
-          <%= f.password_field :password, autocomplete: "new-password", id: "password01", class: "govuk-input govuk-!-width-three-quarters"  %>
+          <%= f.password_field :password, autocomplete: "off", id: "password01", class: "govuk-input govuk-!-width-three-quarters"  %>
         </div>
 
         <div class="govuk-form-group  <%= 'govuk-form-group--error' if @result.errors[:password_confirmation].any? %>">
@@ -99,7 +99,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.passwords_dont_match') %>
                     </span>
           <%= display_error(@result, :password_confirmation) %>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", id: "password02", class: "govuk-input govuk-!-width-three-quarters"  %>
+          <%= f.password_field :password_confirmation, autocomplete: "off", id: "password02", class: "govuk-input govuk-!-width-three-quarters"  %>
         </div>
 
       </fieldset>

--- a/app/views/management_consultancy/sessions/new.html.erb
+++ b/app/views/management_consultancy/sessions/new.html.erb
@@ -27,7 +27,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.please_enter_a_valid_email_address') %>
         </span>
         <%= display_error(@result, :email) %>
-        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete:'email', spellcheck:'false', aria: {describedby: "email-hint"}  %>
+        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete: "off", spellcheck:'false', aria: {describedby: "email-hint"}  %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @result.errors[:password].any? %>">
@@ -39,7 +39,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.enter_your_password') %>
                 </span>
         <%= display_error(@result, :password) %>
-        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "current-password" %>
+        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "off" %>
 
       </div>
 

--- a/app/views/management_consultancy/users/_new_password_required.html.erb
+++ b/app/views/management_consultancy/users/_new_password_required.html.erb
@@ -55,7 +55,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.passwords_uppper') %>
                 </span>
         <%= display_error(@challenge, :new_password) %>
-        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "off" %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7">
@@ -71,7 +71,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.password_must_match') %>
                 </span>
         <%= display_error(@challenge, :new_password_confirmation) %>
-        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "off" %>
       </div>
 
       <%= hidden_field_tag :session, params[:session] %>

--- a/app/views/management_consultancy/users/confirm_new.html.erb
+++ b/app/views/management_consultancy/users/confirm_new.html.erb
@@ -59,7 +59,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_register.attributes.email_format') %>
                     </span>
           <%= display_error(@result, :email) %>
-          <%= text_field_tag :email, nil, autofocus: true, autocomplete: "email", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
+          <%= text_field_tag :email, nil, autofocus: true, autocomplete: "off", class:"govuk-input govuk-!-width-three-quarters", id: "email", spellcheck: false, aria: {describedby: "email-hint"} %>
         </div>
       <% end %>
 

--- a/app/views/supply_teachers/admin/passwords/edit.html.erb
+++ b/app/views/supply_teachers/admin/passwords/edit.html.erb
@@ -55,7 +55,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_reset.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@response, :password) %>
-          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "new-password" %>
+          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:password_confirmation].any? %>">
@@ -72,7 +72,7 @@
                     </span>
 
           <%= display_error(@response, :password_confirmation) %>
-          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "new-password" %>
+          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:confirmation_code].any? %>">

--- a/app/views/supply_teachers/admin/passwords/new.html.erb
+++ b/app/views/supply_teachers/admin/passwords/new.html.erb
@@ -45,7 +45,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_request.attributes.please_enter_a_valid_email_address') %>
                 </span>
 
-        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="email" spellcheck="false">
+        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
       </div>
 
       <%= submit_tag t('common.send_reset_email'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>

--- a/app/views/supply_teachers/admin/sessions/new.html.erb
+++ b/app/views/supply_teachers/admin/sessions/new.html.erb
@@ -27,7 +27,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.please_enter_a_valid_email_address') %>
         </span>
         <%= display_error(@result, :email) %>
-        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete:'email', spellcheck:'false', aria: {describedby: "email-hint"}  %>
+        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete: "off", spellcheck:'false', aria: {describedby: "email-hint"}  %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @result.errors[:password].any? %>">
@@ -39,7 +39,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.enter_your_password') %>
                 </span>
         <%= display_error(@result, :password) %>
-        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "current-password" %>
+        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "off" %>
 
       </div>
 

--- a/app/views/supply_teachers/admin/users/_new_password_required.html.erb
+++ b/app/views/supply_teachers/admin/users/_new_password_required.html.erb
@@ -55,7 +55,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.passwords_uppper') %>
                 </span>
         <%= display_error(@challenge, :new_password) %>
-        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "off" %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @challenge.errors[:new_password_confirmation].any? %>">
@@ -71,7 +71,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.password_must_match') %>
                 </span>
         <%= display_error(@challenge, :new_password_confirmation) %>
-        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "off" %>
       </div>
 
       <%= hidden_field_tag :session, params[:session] %>

--- a/app/views/supply_teachers/passwords/edit.html.erb
+++ b/app/views/supply_teachers/passwords/edit.html.erb
@@ -55,7 +55,7 @@
                         <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_reset.attributes.passwords_upper') %>
                     </span>
           <%= display_error(@response, :password) %>
-          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "new-password" %>
+          <%= password_field_tag :password, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password01", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:password_confirmation].any? %>">
@@ -72,7 +72,7 @@
                     </span>
 
           <%= display_error(@response, :password_confirmation) %>
-          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "new-password" %>
+          <%= password_field_tag :password_confirmation, nil, class: "govuk-input govuk-!-width-three-quarters", id: "password02", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @response.errors[:confirmation_code].any? %>">

--- a/app/views/supply_teachers/passwords/new.html.erb
+++ b/app/views/supply_teachers/passwords/new.html.erb
@@ -45,7 +45,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_forgot_password_request.attributes.please_enter_a_valid_email_address') %>
                 </span>
 
-        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="email" spellcheck="false">
+        <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
       </div>
 
       <%= submit_tag t('common.send_reset_email'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>

--- a/app/views/supply_teachers/sessions/new.html.erb
+++ b/app/views/supply_teachers/sessions/new.html.erb
@@ -27,7 +27,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.please_enter_a_valid_email_address') %>
         </span>
         <%= display_error(@result, :email) %>
-        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete:'email', spellcheck:'false', aria: {describedby: "email-hint"}  %>
+        <%=  f.email_field :email, class:"govuk-input govuk-!-width-two-thirds", id:"email", autocomplete: "off", spellcheck:'false', aria: {describedby: "email-hint"}  %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7 <%= 'govuk-form-group--error' if @result.errors[:password].any? %>">
@@ -39,7 +39,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in.attributes.cog_sign_in.enter_your_password') %>
                 </span>
         <%= display_error(@result, :password) %>
-        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "current-password" %>
+        <%= f.password_field :password, class: "govuk-input govuk-!-width-two-thirds", id: "password", autocomplete: "off" %>
 
       </div>
 

--- a/app/views/supply_teachers/users/_new_password_required.html.erb
+++ b/app/views/supply_teachers/users/_new_password_required.html.erb
@@ -55,7 +55,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.passwords_uppper') %>
                 </span>
         <%= display_error(@challenge, :new_password) %>
-        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password01", autocomplete: "off" %>
       </div>
 
       <div class="govuk-form-group govuk-!-margin-bottom-7">
@@ -71,7 +71,7 @@
                     <%= t('activemodel.errors.models.ccs_patterns/home/cog_sign_in_password_prompt_change.attributes.password_must_match') %>
                 </span>
         <%= display_error(@challenge, :new_password_confirmation) %>
-        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "new-password" %>
+        <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "off" %>
       </div>
 
       <%= hidden_field_tag :session, params[:session] %>


### PR DESCRIPTION
On every form with 
`autocomplete: "some-text"`
I've set to:
`autocomplete: "off"`
This change only applies to forms with emails and passwords (so far).