### PR TITLE
Remove ProcurementBuildingServices with codes not in the procurement service_codes

### DIFF
--- a/app/models/facilities_management/procurement_building.rb
+++ b/app/models/facilities_management/procurement_building.rb
@@ -45,7 +45,7 @@ module FacilitiesManagement
         if service_codes.include?(service_code)
           procurement_building_services.create(code: service_code, name: Service.find_by(code: service_code).try(:name)) if procurement_building_services.find_by(code: service_code).blank?
         else
-          procurement_building_services.find_by(code: service_code).destroy
+          procurement_building_services.find_by(code: service_code)&.destroy
         end
       end
     end

--- a/spec/factories/facilities_management_procurement.rb
+++ b/spec/factories/facilities_management_procurement.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     estimated_cost_known { 12345 }
     tupe { false }
     initial_call_off_period { Time.zone.now + 6.months }
+    service_codes { ['C.1', 'C.2'] }
     association :user
     procurement_buildings { build_list :facilities_management_procurement_building, 1 }
   end

--- a/spec/factories/facilities_management_procurement_building_services.rb
+++ b/spec/factories/facilities_management_procurement_building_services.rb
@@ -1,6 +1,6 @@
 require 'facilities_management/services_and_questions'
 FactoryBot.define do
   factory :facilities_management_procurement_building_service, class: FacilitiesManagement::ProcurementBuildingService do
-    name { Faker::Company.unique.name }
+    name { Faker::Name.unique.name }
   end
 end

--- a/spec/models/facilities_management/procurement_spec.rb
+++ b/spec/models/facilities_management/procurement_spec.rb
@@ -331,4 +331,22 @@ RSpec.describe FacilitiesManagement::Procurement, type: :model do
       end
     end
   end
+
+  describe '#update_building_services' do
+    before do
+      procurement.procurement_buildings.first.procurement_building_services.destroy_all
+
+      procurement.procurement_buildings.first.update(service_codes: procurement.service_codes)
+
+      procurement.service_codes = ['C.3']
+    end
+
+    it 'will remove any procurement_building_services that have a service code not included in the procurement service_codes' do
+      expect { procurement.save }.to change { procurement.procurement_building_services.count }.by(-2)
+    end
+
+    it 'will remove service codes from the procurement_buildings service codes that are not selected for the procurement' do
+      expect { procurement.save }.to change { procurement.procurement_buildings.first.service_codes }.from(['C.1', 'C.2']).to([])
+    end
+  end
 end


### PR DESCRIPTION
@Chee-Ng's ticket, so he will pick up any changes that need to be made.