### PR TITLE
Bug/fm-573 direct award excel building bug

### DIFF
--- a/app/models/facilities_management/summary_report.rb
+++ b/app/models/facilities_management/summary_report.rb
@@ -120,6 +120,7 @@ module FacilitiesManagement
           result = uvals_for_public(building)
           all_building_uvals = result[0]
           building_data = result[1]
+          id = result[0][0][:building_id]
 
           # TBC filter out nil values for now
           building_uvals = all_building_uvals.reject { |v| v[:uom_value].nil? }

--- a/app/services/facilities_management/direct_award_spreadsheet.rb
+++ b/app/services/facilities_management/direct_award_spreadsheet.rb
@@ -142,7 +142,7 @@ class FacilitiesManagement::DirectAwardSpreadsheet
       end
       sheet.add_row new_row, style: header_row_style
 
-      sorted_building_keys = @data.keys.sort
+      sorted_building_keys = @data.keys
       sumsum = 0
       sum_building = {}
       sum_building_cafm = {}

--- a/spec/models/facilities_management/summary_report3_spec.rb
+++ b/spec/models/facilities_management/summary_report3_spec.rb
@@ -487,6 +487,42 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
     end
     # rubocop:enable RSpec/InstanceVariable
     # rubocop:enable RSpec/ExampleLength
+
+    # rubocop:disable RSpec/ExampleLength
+    # rubocop:disable RSpec/InstanceVariable
+    it 'create a direct-award report with contract length of 1 year and verify a report for each building' do
+      user_email = 'test@example.com'
+      start_date = DateTime.now.utc
+
+      uvals.map!(&:deep_symbolize_keys)
+
+      data[:'fm-contract-length'] = 1
+      report = described_class.new(start_date, user_email, data)
+
+      rates = CCS::FM::Rate.read_benchmark_rates
+      rate_card = CCS::FM::RateCard.latest
+
+      results = {}
+      report_results = {}
+
+      supplier_names = rate_card.data[:Prices].keys
+      supplier_names.each do |supplier_name|
+        report_results[supplier_name] = {}
+        report.calculate_services_for_buildings @selected_buildings2, uvals, rates, rate_card, supplier_name, report_results[supplier_name]
+        results[supplier_name] = report.direct_award_value
+      end
+
+      buildings_ids = uvals.collect { |u| u[:building_id] }.compact.uniq
+      supplier_names = rate_card.data[:Prices].keys
+      supplier_names.each do |supplier_name|
+        # verify a report is generated for each building
+        buildings_ids.each do |building_id|
+          expect(report_results[supplier_name][building_id].count).to be > 0
+        end
+      end
+    end
+    # rubocop:enable RSpec/InstanceVariable
+    # rubocop:enable RSpec/ExampleLength
   end
 
   # rubocop:disable RSpec/ExampleLength


### PR DESCRIPTION
In the direct_award_prices excel,  only one building was calculated for.  This fix will calculate for all the procurement selected buildings in the correct name order.