### PR TITLE
Feature/fm 518 procurement dashboard button on manage buildings

### DIFF
--- a/app/views/facilities_management/beta/buildings_management/_buildings_management_controller.html.erb
+++ b/app/views/facilities_management/beta/buildings_management/_buildings_management_controller.html.erb
@@ -8,6 +8,11 @@
    role="button">
   <%= t('facilities_management.beta.index.create_new_button') %>
 </a>
+<a href="/facilities-management/beta/procurements"
+   class="govuk-button ccs-no-print govuk-button--secondary govuk-!-margin-left-3 govuk-!-margin-bottom-6"
+   role="button">
+  <%= t('facilities_management.beta.index.procurements_dashboard_button') %>
+</a>
 <p class="govuk-caption-l">
     <%= t('facilities_management.beta.index.start_paragraph')%>
 </p>

--- a/app/views/facilities_management/beta/buildings_management/_buildings_management_controller.html.erb
+++ b/app/views/facilities_management/beta/buildings_management/_buildings_management_controller.html.erb
@@ -13,11 +13,15 @@
    role="button">
   <%= t('facilities_management.beta.index.procurements_dashboard_button') %>
 </a>
-<p class="govuk-caption-l">
+<div class="govuk-body">
+<p class="govuk-body-l ">
     <%= t('facilities_management.beta.index.start_paragraph')%>
 </p>
-<p class="govuk-caption-l govuk-!-margin-top-6 govuk-margin-bottom-3">
+
+<p class="govuk-caption-m govuk-!-margin-top-6 govuk-margin-bottom-3">
   <%= t('facilities_management.beta.index.start_warning') %>
 </p>
+</div>
+
 <h2 class="govuk-heading-l govuk-!-margin-top-6"><%= t('facilities_management.beta.index.my_buildings_header') %></h2>
 <%= render partial: 'building_list'%>

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -277,7 +277,8 @@ en:
         column_lstup_header: Last updated
         column_name_header: Name
         column_status_header: Status
-        create_new_button: "+ Create Single Building"
+        create_new_button: Create Single Building
+        procurements_dashboard_button: Procurements dashboard
         link_to_building_summary: View details for building
         manage_building: Manage buildings
         manage_buildings_header: Manage buildings

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -278,14 +278,14 @@ en:
         column_name_header: Name
         column_status_header: Status
         create_new_button: Create Single Building
-        procurements_dashboard_button: Procurements dashboard
         link_to_building_summary: View details for building
         manage_building: Manage buildings
         manage_buildings_header: Manage buildings
         my_buildings_header: My buildings
         no_buildings_text: You have no saved buildings
+        procurements_dashboard_button: Procurements dashboard
         start_paragraph: You will use your buildings to inform suppliers where you want particular services to be delivered to. Once set up, your buildings can be reused in this system for other FM procurements.
-        start_warning: When creating your buildings, you are not restricted to creating just full buildings. For example, you may choose to set up just a floor within a building, or a specific area. Ultimately, your service pricing will be broken down to show a cost per service per 'building', allowing your to manage your contract effectively. You should therefore create buildings dependent on the level of detail you require. 
+        start_warning: When creating your buildings, you are not restricted to creating just full buildings. For example, you may choose to set up just a floor within a building, or a specific area. Ultimately, your service pricing will be broken down to show a cost per service per 'building', allowing your to manage your contract effectively. You should therefore create buildings dependent on the level of detail you require.
       passwords:
         edit:
           confirm_code: Confirm Code

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -284,8 +284,8 @@ en:
         manage_buildings_header: Manage buildings
         my_buildings_header: My buildings
         no_buildings_text: You have no saved buildings
-        start_paragraph: Buildings are used to tell suppliers where you want services provided. You can add buildings to the system and these will be available to use later in your requirements.
-        start_warning: Only buildings that are ready can be used in your procurement.
+        start_paragraph: You will use your buildings to inform suppliers where you want particular services to be delivered to. Once set up, your buildings can be reused in this system for other FM procurements.
+        start_warning: When creating your buildings, you are not restricted to creating just full buildings. For example, you may choose to set up just a floor within a building, or a specific area. Ultimately, your service pricing will be broken down to show a cost per service per 'building', allowing your to manage your contract effectively. You should therefore create buildings dependent on the level of detail you require. 
       passwords:
         edit:
           confirm_code: Confirm Code


### PR DESCRIPTION
As per the ticket, I have created a button on the manage building page which leads to the procurement dashboard. I changed the text in the manage building section and changed some colours of the text and the newly created button.