### PR TITLE
Page now displays the correct content by making exception for fm

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,8 @@ module ApplicationHelper
   include LayoutHelper
 
   ADMIN_CONTROLLERS = ['supply_teachers/admin', 'management_consultancy/admin', 'legal_services/admin'].freeze
-  PLATFORM_LANDINGPAGES = ['', 'legal_services/home', 'supply_teachers/home', 'facilities_management/home', 'management_consultancy/home', 'apprenticeships/home'].freeze
+  PLATFORM_LANDINGPAGES = ['', 'legal_services/home', 'supply_teachers/home', 'management_consultancy/home', 'apprenticeships/home'].freeze
+  FACILITIES_MANAGEMENT_LANDINGPAGES = ['facilities_management/home', 'facilities_management/beta/home'].freeze
 
   def miles_to_metres(miles)
     DistanceConverter.miles_to_metres(miles)
@@ -263,6 +264,10 @@ module ApplicationHelper
 
   def landing_or_admin_page
     (PLATFORM_LANDINGPAGES.include?(controller.class.controller_path) && controller.action_name == 'index') || controller.action_name == 'landing_page' || ADMIN_CONTROLLERS.include?(controller.class.parent_name.try(:underscore))
+  end
+
+  def fm_landing_page
+    (FACILITIES_MANAGEMENT_LANDINGPAGES.include?(controller.class.controller_path) && controller.action_name == 'index')
   end
 
   def fm_buyer_landing_page

--- a/app/views/layouts/_header-banner.html.erb
+++ b/app/views/layouts/_header-banner.html.erb
@@ -18,7 +18,7 @@
     <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
     <nav>
       <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-        <% unless landing_or_admin_page || fm_buyer_landing_page || not_permitted_page %>
+        <% unless landing_or_admin_page || fm_buyer_landing_page || not_permitted_page || fm_landing_page %>
           <li class="govuk-header__navigation-item">
             <% if request.path_info == '/facilities-management/beta' %>
             <% elsif controller.controller_name == 'buildings_management'%>


### PR DESCRIPTION
Fixed formatting issues for rubocop
Renamed constant to make it more descriptive

The main fix for this solution was to add 'facilities_management/beta/home' to the 'PLATFORM_LANDINGPAGES'. This did remove back to start from the landing page but then resulted in other issues. Because the landing pages for FM now look different from the other landing pages (they say 'Find a facilities management supplier' rather than 'Crown Marketplace') exceptions needed to be added for the FM landing pages. This means that these pages require a different logic, so this needed to be added.

I created a new constant with the two landing pages path in them and created a new method `fm_landing_page`. This enabled me to use the correct logic and the right point so that the pages where consistent with the new design, without changing the other landing pages.