### PR TITLE
MC & LS & ST & FM ITHC Remediation - User Account Enumeration changes

### DIFF
--- a/app/services/cognito/forgot_password.rb
+++ b/app/services/cognito/forgot_password.rb
@@ -9,6 +9,8 @@ module Cognito
 
     def call
       forgot_password
+    rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
+      @error = nil
     rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
       @error = e.message
     end

--- a/app/services/cognito/sign_in_user.rb
+++ b/app/services/cognito/sign_in_user.rb
@@ -17,6 +17,9 @@ module Cognito
 
     def call
       initiate_auth if valid?
+    rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
+      @error = I18n.t('activemodel.errors.models.user.incorrect_username_or_password')
+      errors.add(:base, @error)
     rescue Aws::CognitoIdentityProvider::Errors::PasswordResetRequiredException => e
       @error = e.message
       errors.add(:base, e.message)

--- a/app/views/ccs_patterns/home/cog_forgot_password_reset.html.erb
+++ b/app/views/ccs_patterns/home/cog_forgot_password_reset.html.erb
@@ -20,6 +20,19 @@
             <%= t('.heading') %>
         </h1>
 
+
+        <p class="govuk-body-l">
+          <%= t('.heading1') %>
+        </p>
+
+        <p class="govuk-body-l">
+          <%= t('.lead1') %>
+        </p>
+
+        <p class="govuk-body govuk-!-margin-bottom-7">
+          <%= t('.text01') %>
+        </p>
+
         <p class="govuk-body-l">
             <%= t('.lead') %> <span class="ccs-email-example">name.surname@domain.gov.uk</span>
         </p>

--- a/app/views/facilities_management/passwords/edit.html.erb
+++ b/app/views/facilities_management/passwords/edit.html.erb
@@ -22,6 +22,17 @@
     </h1>
 
     <p class="govuk-body-l">
+      <%= t('.heading1') %>
+    </p>
+
+    <p class="govuk-body-l">
+      <%= t('.lead1') %>
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <%= t('.text01') %>
+    </p>
+    <p class="govuk-body-l">
       <%= t('.lead') %> <span class="ccs-email-example"><%= @response.email %></span>
     </p>
 

--- a/app/views/legal_services/passwords/edit.html.erb
+++ b/app/views/legal_services/passwords/edit.html.erb
@@ -22,6 +22,18 @@
     </h1>
 
     <p class="govuk-body-l">
+      <%= t('.heading1') %>
+    </p>
+
+    <p class="govuk-body-l">
+      <%= t('.lead1') %>
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <%= t('.text01') %>
+    </p>
+
+    <p class="govuk-body-l">
       <%= t('.lead') %> <span class="ccs-email-example"><%= @response.email %></span>
     </p>
 

--- a/app/views/management_consultancy/admin/passwords/edit.html.erb
+++ b/app/views/management_consultancy/admin/passwords/edit.html.erb
@@ -22,6 +22,18 @@
     </h1>
 
     <p class="govuk-body-l">
+      <%= t('.heading1') %>
+    </p>
+
+    <p class="govuk-body-l">
+      <%= t('.lead1') %>
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <%= t('.text01') %>
+    </p>
+
+    <p class="govuk-body-l">
       <%= t('.lead') %> <span class="ccs-email-example"><%= @response.email %></span>
     </p>
 

--- a/app/views/management_consultancy/passwords/edit.html.erb
+++ b/app/views/management_consultancy/passwords/edit.html.erb
@@ -22,6 +22,18 @@
     </h1>
 
     <p class="govuk-body-l">
+      <%= t('.heading1') %>
+    </p>
+
+    <p class="govuk-body-l">
+      <%= t('.lead1') %>
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <%= t('.text01') %>
+    </p>
+
+    <p class="govuk-body-l">
       <%= t('.lead') %> <span class="ccs-email-example"><%= @response.email %></span>
     </p>
 

--- a/app/views/supply_teachers/admin/passwords/edit.html.erb
+++ b/app/views/supply_teachers/admin/passwords/edit.html.erb
@@ -22,6 +22,18 @@
     </h1>
 
     <p class="govuk-body-l">
+      <%= t('.heading1') %>
+    </p>
+
+    <p class="govuk-body-l">
+      <%= t('.lead1') %>
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <%= t('.text01') %>
+    </p>
+
+    <p class="govuk-body-l">
       <%= t('.lead') %> <span class="ccs-email-example"><%= @response.email %></span>
     </p>
 

--- a/app/views/supply_teachers/passwords/edit.html.erb
+++ b/app/views/supply_teachers/passwords/edit.html.erb
@@ -22,6 +22,18 @@
     </h1>
 
     <p class="govuk-body-l">
+      <%= t('.heading1') %>
+    </p>
+
+    <p class="govuk-body-l">
+      <%= t('.lead1') %>
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <%= t('.text01') %>
+    </p>
+
+    <p class="govuk-body-l">
       <%= t('.lead') %> <span class="ccs-email-example"><%= @response.email %></span>
     </p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -554,9 +554,12 @@ en:
       cog_forgot_password_reset:
         confirm_new_password: Confirm new password
         heading: Reset your password
+        heading1: A reset email has been sent
         lead: Reset password for
+        lead1: If the email address you've entered belongs to a Crown Commercial Service account, we'll send instructions to reset the password.
         new_password: New password
         password: Your password must have
+        text01: If you don't receive this, contact CCS customer services team.
       cog_forgot_password_reset2:
         heading: You have successfully changed your password
         lead: You can now sign in to your Crown Commercial Service account
@@ -871,9 +874,12 @@ en:
         confirm_code: Confirm Code
         confirm_new_password: Confirm new password
         heading: Reset your password
+        heading1: A reset email has been sent
         lead: Reset password for
+        lead1: If the email address you've entered belongs to a Crown Commercial Service account, we'll send instructions to reset the password.
         new_password: New password
         password: Your password must have
+        text01: If you don't receive this, contact CCS customer services team.
       forgot_password_confirmation:
         heading: A reset email has been sent
         lead: If the email address you've entered belongs to a Crown Commercial Service account, we'll send a link to reset the password.
@@ -975,9 +981,12 @@ en:
           confirm_code: Confirm Code
           confirm_new_password: Confirm new password
           heading: Reset your password
+          heading1: A reset email has been sent
           lead: Reset password for
+          lead1: If the email address you've entered belongs to a Crown Commercial Service account, we'll send instructions to reset the password.
           new_password: New password
           password: Your password must have
+          text01: If you don't receive this, contact CCS customer services team.
         forgot_password_confirmation:
           heading: A reset email has been sent
           lead: If the email address you've entered belongs to a Crown Commercial Service account, we'll send a link to reset the password.
@@ -1210,9 +1219,12 @@ en:
         confirm_code: Confirm Code
         confirm_new_password: Confirm new password
         heading: Reset your password
+        heading1: A reset email has been sent
         lead: Reset password for
+        lead1: If the email address you've entered belongs to a Crown Commercial Service account, we'll send instructions to reset the password.
         new_password: New password
         password: Your password must have
+        text01: If you don't receive this, contact CCS customer services team.
       forgot_password_confirmation:
         heading: A reset email has been sent
         lead: If the email address you've entered belongs to a Crown Commercial Service account, we'll send a link to reset the password.
@@ -1387,9 +1399,12 @@ en:
           confirm_code: Confirm Code
           confirm_new_password: Confirm new password
           heading: Reset your password
+          heading1: A reset email has been sent
           lead: Reset password for
+          lead1: If the email address you've entered belongs to a Crown Commercial Service account, we'll send instructions to reset the password.
           new_password: New password
           password: Your password must have
+          text01: If you don't receive this, contact CCS customer services team.
         forgot_password_confirmation:
           heading: A reset email has been sent
           lead: If the email address you've entered belongs to a Crown Commercial Service account, we'll send a link to reset the password.
@@ -1722,9 +1737,12 @@ en:
         confirm_code: Confirm Code
         confirm_new_password: Confirm new password
         heading: Reset your password
+        heading1: A reset email has been sent
         lead: Reset password for
+        lead1: If the email address you've entered belongs to a Crown Commercial Service account, we'll send instructions to reset the password.
         new_password: New password
         password: Your password must have
+        text01: If you don't receive this, contact CCS customer services team.
       forgot_password_confirmation:
         heading: A reset email has been sent
         lead: If the email address you've entered belongs to a Crown Commercial Service account, we'll send a link to reset the password.

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -40,6 +40,8 @@ en:
             wednesday:
               invalid: Select not required if you don't need the service on Wednesday
               not_a_date: Enter a real start time or end time for Wednesday
+        user:
+          incorrect_username_or_password: Incorrect username or password
   activerecord:
     errors:
       models:
@@ -661,9 +663,12 @@ en:
         confirm_code: Confirm Code
         confirm_new_password: Confirm new password
         heading: Reset your password
+        heading1: A reset email has been sent
         lead: Reset password for
+        lead1: If the email address you've entered belongs to a Crown Commercial Service account, we'll send instructions to reset the password.
         new_password: New password
         password: Your password must have
+        text01: If you don't receive this, contact CCS customer services team.
       forgot_password_confirmation:
         heading: A reset email has been sent
         lead: If the email address you've entered belongs to a Crown Commercial Service account, we'll send a link to reset the password.

--- a/spec/services/cognito/forgot_password_spec.rb
+++ b/spec/services/cognito/forgot_password_spec.rb
@@ -38,5 +38,22 @@ RSpec.describe Cognito::ForgotPassword do
         expect(response.error).to eq 'Oops'
       end
     end
+
+    context 'when cognito error is UserNotFoundException' do
+      before do
+        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+        allow(aws_client).to receive(:forgot_password).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('oops', 'Oops'))
+      end
+
+      it 'does not return success' do
+        response = described_class.call(email)
+        expect(response.success?).to eq true
+      end
+
+      it 'does returns cognito error' do
+        response = described_class.call(email)
+        expect(response.error).to eq nil
+      end
+    end
   end
 end


### PR DESCRIPTION
User Account Enumeration - The application was found to present error messages that facilitated the enumeration of valid user accounts.

Recommendation: BSI recommends that the application be configured to return generic error messages to ensure that they do not indicate whether a valid user account has been provided or not.

Current validation messages display the following: -

When password is wrong: Incorrect username or password.
When user email is wrong: User does not exist.
When resetting password and putting the wrong email in: Username/client id combination not found.

First two have been amended to always say 'Incorrect username or password'
The second one has been amended so it does not show an error message, but it now redirects to the password reset page where you see a message that if you have an account, you will receive instructions.