### PR TITLE
Feature/fm 462 eligibility for da

### DIFF
--- a/app/controllers/facilities_management/beta/procurements_controller.rb
+++ b/app/controllers/facilities_management/beta/procurements_controller.rb
@@ -87,6 +87,7 @@ module FacilitiesManagement
 
       def continue
         if procurement_valid?
+          @procurement.save_eligible_suppliers
           redirect_to facilities_management_beta_procurement_results_path(@procurement)
         else
           redirect_to facilities_management_beta_procurement_path(@procurement, validate: true)
@@ -148,13 +149,13 @@ module FacilitiesManagement
       def set_results_page_data
         @page_data = {}
         @page_data[:model_object] = @procurement
-        @page_data[:no_suppliers] = @suppliers_lot1a.length
-        @page_data[:supplier_collection] = @suppliers_lot1a.map { |s| s['name'] }
-        @page_data[:estimated_cost] = estimated_cost
-        @page_data[:selected_sublot] = '1a'
+        @page_data[:no_suppliers] = @procurement.procurement_suppliers.count
+        @page_data[:supplier_collection] = @procurement.procurement_suppliers.map { |s| s.supplier.data['supplier_name'] }
+        @page_data[:estimated_cost] = @procurement.assessed_value
+        @page_data[:selected_sublot] = @procurement.lot_number
         @page_data[:buildings] = @active_procurement_buildings.map { |b| b[:name] }
-        @page_data[:services] = @services.map { |s| s[:name] }
-        @page_data[:supplier_prices] = [estimated_cost]
+        @page_data[:services] = @procurement.procurement_building_services.map { |s| s[:name] }
+        @page_data[:supplier_prices] = @procurement.procurement_suppliers.map(&:direct_award_value)
       end
 
       def procurement_route_params

--- a/app/models/ccs/fm/building.rb
+++ b/app/models/ccs/fm/building.rb
@@ -5,10 +5,18 @@ module CCS
     class Building < ApplicationRecord
       self.table_name = 'facilities_management_buildings'
 
+      STANDARD_BUILDING_TYPES = ['General office - Customer Facing', 'General office - Non Customer Facing', 'Call Centre Operations',
+                                 'Warehouses', 'Restaurant and Catering Facilities', 'Pre-School', 'Primary School', 'Secondary School', 'Special Schools',
+                                 'Universities and Colleges', 'Doctors, Dentists and Health Clinics', 'Nursery and Care Homes'].freeze
+
       # CCS::FM::Building.all
       #
       def self.buildings_for_user(user_id)
         where("user_id = '" + Base64.encode64(user_id) + "'")
+      end
+
+      def building_standard
+        STANDARD_BUILDING_TYPES.include?(building_json['building-type']) ? 'STANDARD' : 'NON-STANDARD'
       end
     end
   end

--- a/app/models/ccs/fm/supplier.rb
+++ b/app/models/ccs/fm/supplier.rb
@@ -8,11 +8,9 @@ module CCS
 
     class Supplier < ApplicationRecord
       # usage:
-      # CCS::FM::Supplier.where("data->'supplier_name' = 'Shields, Ratke and Parisian'")
       # CCS::FM::Supplier.supplier_name('Shields, Ratke and Parisian')
       def self.supplier_name(name)
-        # p "data->'supplier_name' = '#{name}'"
-        where("data->>'supplier_name' = '#{name}'")
+        select { |s| s['data']['supplier_name'] == name }.first
       end
 
       # usage:

--- a/app/models/facilities_management/procurement.rb
+++ b/app/models/facilities_management/procurement.rb
@@ -1,3 +1,4 @@
+require 'fm_calculator/fm_direct_award_calculator.rb'
 module FacilitiesManagement
   class Procurement < ApplicationRecord
     include AASM
@@ -12,6 +13,9 @@ module FacilitiesManagement
     has_many :procurement_buildings, foreign_key: :facilities_management_procurement_id, inverse_of: :procurement, dependent: :destroy
     has_many :procurement_building_services, through: :procurement_buildings
     accepts_nested_attributes_for :procurement_buildings, allow_destroy: true
+
+    has_many :procurement_suppliers, foreign_key: :facilities_management_procurement_id, inverse_of: :procurement, dependent: :destroy
+
     acts_as_gov_uk_date :initial_call_off_start_date, :security_policy_document_date, error_clash_behaviour: :omit_gov_uk_date_field_error
     mount_uploader :security_policy_document_file, FacilitiesManagementSecurityPolicyDocumentUploader
     # needed to move this validation here as it was being called incorrectly in the validator, ie when a file with the wrong
@@ -69,7 +73,33 @@ module FacilitiesManagement
       procurement_buildings.active
     end
 
+    def save_eligible_suppliers
+      sorted_list = FacilitiesManagement::DirectAwardEligibleSuppliers.new(id).sorted_list
+
+      # if any procurement_suppliers present, they need to be removed
+      procurement_suppliers.destroy_all
+      sorted_list.each do |supplier_data|
+        procurement_suppliers.create(supplier_id: CCS::FM::Supplier.supplier_name(supplier_data[0].to_s).id, direct_award_value: supplier_data[1]) if DirectAward.new(buildings_standard, services_standard, priced_at_framework, supplier_data[1]).calculate
+      end
+    end
+
     private
+
+    def buildings_standard
+      active_procurement_buildings.map { |pb| pb.building.building_standard }.include?('NON-STANDARD') ? 'NON-STANDARD' : 'STANDARD'
+    end
+
+    def services_standard
+      # 'A' if A or N/A, 'B' if 'B' or 'C' standards are present
+      (procurement_building_services.map(&:service_standard).uniq.flatten - ['A']).none? ? 'A' : 'B'
+    end
+
+    def priced_at_framework
+      # [procurement_building_services.map(&:code) - CCS::FM::Service.direct_award_services].none?
+      # this is not the right list, still need to import this data
+      # for now this always returns true
+      true
+    end
 
     def update_procurement_building_services
       procurement_buildings.each do |building|

--- a/app/models/facilities_management/procurement_building.rb
+++ b/app/models/facilities_management/procurement_building.rb
@@ -22,6 +22,10 @@ module FacilitiesManagement
       #{postcode}"
     end
 
+    def building
+      CCS::FM::Building.find_by(id: building_id)
+    end
+
     private
 
     def service_codes_not_empty

--- a/app/models/facilities_management/procurement_supplier.rb
+++ b/app/models/facilities_management/procurement_supplier.rb
@@ -1,0 +1,10 @@
+module FacilitiesManagement
+  class ProcurementSupplier < ApplicationRecord
+    default_scope { order(direct_award_value: :asc) }
+    belongs_to :procurement, class_name: 'FacilitiesManagement::Procurement', foreign_key: :facilities_management_procurement_id, inverse_of: :procurement_suppliers
+
+    def supplier
+      CCS::FM::Supplier.find(supplier_id)
+    end
+  end
+end

--- a/app/services/facilities_management/direct_award_eligible_suppliers.rb
+++ b/app/services/facilities_management/direct_award_eligible_suppliers.rb
@@ -1,0 +1,21 @@
+class FacilitiesManagement::DirectAwardEligibleSuppliers
+  def initialize(procurement_id)
+    @procurement = FacilitiesManagement::Procurement.find(procurement_id)
+  end
+
+  def sorted_list
+    @report = FacilitiesManagement::SummaryReport.new(@procurement.initial_call_off_start_date, @procurement.user.email, nil, @procurement)
+
+    @selected_buildings = @procurement.active_procurement_buildings
+    rates = CCS::FM::Rate.read_benchmark_rates
+    @rate_card = CCS::FM::RateCard.latest
+    @results = {}
+    supplier_names = @rate_card.data[:Prices].keys
+    supplier_names.each do |supplier_name|
+      @report.calculate_services_for_buildings @selected_buildings, nil, rates, @rate_card, supplier_name, nil
+      @results[supplier_name] = @report.direct_award_value
+    end
+    @procurement.update(lot_number: @report.current_lot, assessed_value: @report.assessed_value)
+    @results.sort_by { |_k, v| v }
+  end
+end

--- a/db/migrate/20191223113007_add_facilities_management_procurement_supplier.rb
+++ b/db/migrate/20191223113007_add_facilities_management_procurement_supplier.rb
@@ -1,0 +1,12 @@
+class AddFacilitiesManagementProcurementSupplier < ActiveRecord::Migration[5.2]
+  def change
+    create_table :facilities_management_procurement_suppliers, id: :uuid do |t|
+      t.references :facilities_management_procurement,
+                   foreign_key: true, type: :uuid, null: false,
+                   index: { name: 'index_fm_procurement_supplier_on_fm_procurement_id' }
+      t.uuid :supplier_id
+      t.money :direct_award_value, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200103131101_add_lot_number_and_assessed_value_to_facilities_management_procurement.rb
+++ b/db/migrate/20200103131101_add_lot_number_and_assessed_value_to_facilities_management_procurement.rb
@@ -1,0 +1,6 @@
+class AddLotNumberAndAssessedValueToFacilitiesManagementProcurement < ActiveRecord::Migration[5.2]
+  def change
+    add_column :facilities_management_procurements, :lot_number, :string
+    add_column :facilities_management_procurements, :assessed_value, :money
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2019_12_30_124912) do
+ActiveRecord::Schema.define(version: 2020_01_03_131101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -83,6 +82,15 @@ ActiveRecord::Schema.define(version: 2019_12_30_124912) do
     t.index ["facilities_management_procurement_id"], name: "index_fm_procurements_on_fm_procurement_id"
   end
 
+  create_table "facilities_management_procurement_suppliers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "facilities_management_procurement_id", null: false
+    t.uuid "supplier_id"
+    t.money "direct_award_value", scale: 2, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["facilities_management_procurement_id"], name: "index_fm_procurement_supplier_on_fm_procurement_id"
+  end
+
   create_table "facilities_management_procurements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
     t.string "name", limit: 100
@@ -111,6 +119,8 @@ ActiveRecord::Schema.define(version: 2019_12_30_124912) do
     t.string "security_policy_document_version_number"
     t.date "security_policy_document_date"
     t.string "security_policy_document_file"
+    t.string "lot_number"
+    t.money "assessed_value", scale: 2
     t.index ["user_id"], name: "index_facilities_management_procurements_on_user_id"
   end
 
@@ -555,6 +565,7 @@ ActiveRecord::Schema.define(version: 2019_12_30_124912) do
   add_foreign_key "facilities_management_buyer_details", "users"
   add_foreign_key "facilities_management_procurement_building_services", "facilities_management_procurement_buildings"
   add_foreign_key "facilities_management_procurement_buildings", "facilities_management_procurements"
+  add_foreign_key "facilities_management_procurement_suppliers", "facilities_management_procurements"
   add_foreign_key "facilities_management_procurements", "users"
   add_foreign_key "facilities_management_regional_availabilities", "facilities_management_suppliers"
   add_foreign_key "facilities_management_service_offerings", "facilities_management_suppliers"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,7 @@ RSpec.configure do |config|
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = false
+    mocks.allow_message_expectations_on_nil = true
   end
 
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will


### PR DESCRIPTION
- Added procurement supplier model 
- Creating procurement suppliers when calculating eligibility (on continue button)
- Updated results page to show the real values
- Added some unit tests for the procurement method

Note: The calculator does not currently take into account 'priced at framework' option as it needs to be done as part of a different ticket: https://pushback.atlassian.net/browse/FM-483