### PR TITLE
Adjusted the javascript and added error message for no description (FM-624)

### DIFF
--- a/app/assets/javascripts/facilities_management/beta/building_management/building_security_type.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building_security_type.js
@@ -68,7 +68,7 @@ $(function () {
         } else {
             bRet = true;
         }
-        
+
         return bRet;
     };
 });

--- a/app/assets/javascripts/facilities_management/beta/building_management/building_security_type.js
+++ b/app/assets/javascripts/facilities_management/beta/building_management/building_security_type.js
@@ -4,7 +4,7 @@ $(function () {
         if (value.length > 0) {
             $('#fm-building-security-type-other').val(value);
         } else {
-            $('#fm-building-security-type-other').val("other");
+            $('#fm-building-security-type-other').val("");
         }
     
         let charsLeft = FM.calcCharsLeft(value, 150);
@@ -20,6 +20,10 @@ $(function () {
         $('#inline-error-message').addClass('govuk-visually-hidden');
         if (e.target.id !== 'fm-building-security-type-other') {
             $('#fm-bm-sec-other-container').addClass('govuk-visually-hidden');
+            $('#inline-no-description-error-message').addClass('govuk-visually-hidden');
+            $('#no-dexcription-error-text').addClass('govuk-visually-hidden');
+            $('#no-dexcription-error-details').removeClass('govuk-form-group--error');
+            $('#fm-building-security-type-more-detail').removeClass('govuk-textarea--error');
         }
     });
 
@@ -51,14 +55,20 @@ $(function () {
         let bRet = false;
 
         let radioValue = $("input[name='fm-building-security-type-radio']:checked").val();
-
-        if (!radioValue) {
+        
+        if (radioValue === "") {
+            $('#inline-no-description-error-message').removeClass('govuk-visually-hidden');
+            $('#no-dexcription-error-text').removeClass('govuk-visually-hidden');
+            $('#no-dexcription-error-details').addClass('govuk-form-group--error');
+            $('#fm-building-security-type-more-detail').addClass('govuk-textarea--error');
+            $('html, body').animate({scrollTop: 0}, 500);
+        } else if (!radioValue) {
             $('#inline-error-message').removeClass('govuk-visually-hidden');
             $('html, body').animate({scrollTop: 0}, 500);
         } else {
             bRet = true;
         }
-
+        
         return bRet;
     };
 });

--- a/app/controllers/facilities_management/beta/buildings_management_controller.rb
+++ b/app/controllers/facilities_management/beta/buildings_management_controller.rb
@@ -104,7 +104,7 @@ module FacilitiesManagement
         @building_name = @building['name']
         @building_sec_type = @building['security-type']
         @other_is_used = false
-        @other_value = 'other'
+        @other_value = ''
         @building_id = local_building_id
         @security_types = fm_building_data.security_types
         @page_title = 'Change Security Type' if @editing

--- a/app/views/facilities_management/beta/buildings_management/_buildings_steps_header.html.erb
+++ b/app/views/facilities_management/beta/buildings_management/_buildings_steps_header.html.erb
@@ -1,5 +1,18 @@
 <a class="govuk-back-link" href="<%= @back_link_href %>">Back</a>
 <%= render('errors/inline_error_summary') %>
+<div id="inline-no-description-error-message" name="inline-no-description-error-message" class="govuk-error-summary govuk-visually-hidden"
+     aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    There is a problem
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <li>
+        <a id="error-summary-link" href="#fm-building-security-type-other">You must describe your security level</a>
+      </li>
+    </ul>
+  </div>
+</div>
 <%if @step.present? %><span class="govuk-caption-m govuk-!-padding-bottom-0">Step <%= @step.floor() %> of 4</span><%end %>
 <span class="govuk-caption-l govuk-!-padding-top-0">Manage buildings <%= unless @building_name.blank? then
                                                                            ': ' + @building_name

--- a/app/views/facilities_management/beta/buildings_management/building_security_type.html.erb
+++ b/app/views/facilities_management/beta/buildings_management/building_security_type.html.erb
@@ -19,18 +19,21 @@
           </label>
         </div>
       <% end %>
-      <div class="govuk-radios__item">
-        <input class="govuk-radios__input" id="fm-building-security-type-other"
-               name="fm-building-security-type-radio" type="radio" value="<%= @other_value%>" <%= 'checked' if @other_is_used %>>
-        <label class="govuk-label govuk-radios__label" for="fm-building-security-type-other">
-          Other<br>
-        </label>
-      </div>
-      <div id="fm-bm-sec-other-container" class="govuk-details__text govuk-!-margin-left-3 govuk-!-width-two-thirds govuk-!-margin-top-1 <%= 'govuk-visually-hidden' unless @other_is_used%>">
-        <span class="govuk-caption-m govuk-!-margin-bottom-1">Describe security level</span>
-        <textarea maxlength="150" class="govuk-textarea govuk-!-margin-bottom-1 govuk-!-margin-top-1" id="fm-building-security-type-more-detail"
-                  name="fm-building-security-type-more-detail" rows="4"><%= @other_value unless @other_value == 'other'%></textarea>
-        <span id="fm-bm-bs-char-count" class="govuk-caption-m govuk-!-margin-top-1 fm-security-type-text"></span>
+      <div id="no-dexcription-error-details">
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="fm-building-security-type-other"
+                 name="fm-building-security-type-radio" type="radio" value="<%= @other_value%>" <%= 'checked' if @other_is_used %>>
+          <label class="govuk-label govuk-radios__label" for="fm-building-security-type-other">
+            Other<br>
+          </label>
+        </div>
+        <div id="fm-bm-sec-other-container" class="govuk-details__text govuk-!-margin-left-3 govuk-!-width-two-thirds govuk-!-margin-top-1 <%= 'govuk-visually-hidden' unless @other_is_used%>">
+          <span class="govuk-caption-m govuk-!-margin-bottom-1">Describe security level</span>
+          <span class="govuk-caption-m govuk-!-margin-bottom-1 govuk-visually-hidden govuk-error-message" id="no-dexcription-error-text" >You must describe your security level</span>
+          <textarea maxlength="150" class="govuk-textarea govuk-!-margin-bottom-1 govuk-!-margin-top-1" id="fm-building-security-type-more-detail"
+                    name="fm-building-security-type-more-detail" rows="4"><%= @other_value unless @other_value == ''%></textarea>
+          <span id="fm-bm-bs-char-count" class="govuk-caption-m govuk-!-margin-top-1 fm-security-type-text"></span>
+        </div>
       </div>
     </div>
   </form>


### PR DESCRIPTION
Updated the Javascript to prevent the user from leaving the 'other' security description blank, which originally made the description say other. This also needed an additional error message for when the was no description so this was also added. Finally I changed the other message in the controller to be blank ("") by default as the JS would immediately change it being so on the page loading anyway.