### PR TITLE
Formatting fixes on offer declined page (HTML)

### DIFF
--- a/app/views/facilities_management/beta/supplier/offer/accepted.html.erb
+++ b/app/views/facilities_management/beta/supplier/offer/accepted.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_page_content(@page_description, @page_data[:model_object]) do |pd|  %>
+<%= govuk_page_content(@page_description, @page_data[:model_object], true) do |pd|  %>
 
   <div class="govuk-panel govuk-panel--confirmation">
     <h1 class="govuk-panel__title govuk-!-font-size-36">

--- a/app/views/facilities_management/beta/supplier/offer/declined.html.erb
+++ b/app/views/facilities_management/beta/supplier/offer/declined.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_page_content(@page_description, @page_data[:model_object]) do |pd|%>
+<%= govuk_page_content(@page_description, @page_data[:model_object], true) do |pd|%>
     <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-6">
         <h1 class="govuk-panel__title govuk-!-font-size-36">
             You have declined this contract offer
@@ -9,7 +9,7 @@
         </div>
     </div>
 
-    <div class="govuk-body govuk-!-width-three-quarters govuk-!-margin-bottom-9">
+    <div class="govuk-body govuk-!-margin-bottom-9">
         For reference, this contract offer will be viewable only in the closed section of your dashboard.
     </div>
 


### PR DESCRIPTION
- Removed the gap between the green banner and the back button
- Made the text stay on one line