### PR TITLE
Bug/fm 681 volume tab

### DIFF
--- a/app/helpers/facilities_management/beta/summary_helper.rb
+++ b/app/helpers/facilities_management/beta/summary_helper.rb
@@ -11,6 +11,7 @@ module FacilitiesManagement::Beta::SummaryHelper
       uom_value = 0
       Date::DAYNAMES.each { |day| uom_value += val[:uom_value][day.downcase.to_sym][:uom] }
       uom_value *= 52 # for each week in the year
+      uom_value = uom_value.round(2)
     end
     uom_value
   end

--- a/app/helpers/facilities_management/beta/summary_helper.rb
+++ b/app/helpers/facilities_management/beta/summary_helper.rb
@@ -10,8 +10,7 @@ module FacilitiesManagement::Beta::SummaryHelper
     elsif val[:uom_value][:monday][:uom].is_a? Numeric
       uom_value = 0
       Date::DAYNAMES.each { |day| uom_value += val[:uom_value][day.downcase.to_sym][:uom] }
-      uom_value *= 52 # for each week in the year
-      uom_value = uom_value.round(2)
+      uom_value = (uom_value * 52).round(2) # for each week in the year
     end
     uom_value
   end

--- a/app/models/facilities_management/service_hour_choice.rb
+++ b/app/models/facilities_management/service_hour_choice.rb
@@ -16,7 +16,7 @@ module FacilitiesManagement
     attribute :end_hour, Integer, default: nil
     attribute :end_minute, Integer, default: nil
     attribute :end_ampm, String, default: nil
-    attribute :uom, Integer, default: nil
+    attribute :uom, Float, default: nil
 
     # these are used to capture validation messages for the time input-groups
     attr_accessor :start_time

--- a/spec/helpers/facilities_management/beta/summary_helper_spec.rb
+++ b/spec/helpers/facilities_management/beta/summary_helper_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe FacilitiesManagement::Beta::SummaryHelper, type: :helper do
           val[:uom_value][day.downcase.to_sym][:uom] = value
           value += 1
         end
-        result_value = ((1 + 2 + 3 + 4 + 5 + 6 + 7) * 52)
+        result_value = (1 + 2 + 3 + 4 + 5 + 6 + 7) * 52
         expect(calculate_uom_value(val)).to eq result_value
       end
 

--- a/spec/helpers/facilities_management/beta/summary_helper_spec.rb
+++ b/spec/helpers/facilities_management/beta/summary_helper_spec.rb
@@ -26,8 +26,21 @@ RSpec.describe FacilitiesManagement::Beta::SummaryHelper, type: :helper do
           val[:uom_value][day.downcase.to_sym][:uom] = value
           value += 1
         end
-        result_value = (1 + 2 + 3 + 4 + 5 + 6 + 7) * 52
+        result_value = ((1 + 2 + 3 + 4 + 5 + 6 + 7) * 52)
         expect(calculate_uom_value(val)).to eq result_value
+      end
+
+      it 'will round value to 2 digits' do
+        val = {}
+        val[:uom_value] = {}
+        value = 1
+        Date::DAYNAMES.each do |day|
+          val[:uom_value][day.downcase.to_sym] = {}
+          val[:uom_value][day.downcase.to_sym][:uom] = value
+          value += 1
+        end
+        val[:uom_value][:sunday][:uom] = 2.56789
+        expect(calculate_uom_value(val)).to eq(((2.56789 + 2 + 3 + 4 + 5 + 6 + 7) * 52).round(2))
       end
     end
   end

--- a/spec/models/facilities_management/service_hours_spec.rb
+++ b/spec/models/facilities_management/service_hours_spec.rb
@@ -65,6 +65,11 @@ RSpec.describe FacilitiesManagement::ServiceHours, type: :model do
         expect(target[:tuesday][:service_choice]).to eq 'all_day'
       end
 
+      it 'validate uom when serializing to a hash' do
+        target = described_class.dump(service_hours)
+        expect(target[:saturday][:uom]).to eq 4.5
+      end
+
       it 'succeeds when serializing from a json' do
         target = described_class.load(source)
         expect(target[:saturday][:service_choice]).to eq 'hourly'


### PR DESCRIPTION
The bug was for service volumes in the excel; if the time difference from start to end was not an exact integer like 2 hours the volume calculation in the procurement excel was not done correctly. The fix was to make it a decimal and to limit the precision in the volume worksheet output to 2 decimal places are requested by Akin.