### PR TITLE
Refactor Results page continuation to use CRUD routes

### DIFF
--- a/app/controllers/facilities_management/beta/procurements_controller.rb
+++ b/app/controllers/facilities_management/beta/procurements_controller.rb
@@ -46,7 +46,6 @@ module FacilitiesManagement
         end
       end
 
-      # rubocop:disable Metrics/AbcSize
       def update
         continue_to_results && return if params['continue_to_results'].present?
 
@@ -54,7 +53,6 @@ module FacilitiesManagement
 
         update_procurement if params['facilities_management_procurement'].present?
       end
-      # rubocop:enable Metrics/AbcSize
 
       # DELETE /procurements/1
       # DELETE /procurements/1.json
@@ -133,6 +131,7 @@ module FacilitiesManagement
           redirect_to facilities_management_beta_procurement_path(@procurement, validate: true)
         end
       end
+
       # sets the state of the procurement depending on the submission from the results view
       def set_route_to_market
         if params[:commit] == page_details(:results)[:secondary_text]

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -8,11 +8,12 @@ module LayoutHelper
 
   # Value Objects (Classes) to structure data for parameters to helper methods
   class NavigationDetail
-    attr_accessor(:primary_text, :return_url, :return_text, :secondary_url, :secondary_text, :secondary_name)
+    attr_accessor(:primary_text, :primary_name, :return_url, :return_text, :secondary_url, :secondary_text, :secondary_name)
 
     # rubocop:disable Metrics/ParameterLists
-    def initialize(primary_text, return_url, return_text, secondary_url, secondary_text, secondary_name = '')
+    def initialize(primary_text, return_url, return_text, secondary_url, secondary_text, primary_name = '', secondary_name = '')
       @primary_text = primary_text
+      @primary_name = primary_name
       @return_url = return_url
       @return_text = return_text
       @secondary_url = secondary_url
@@ -102,7 +103,7 @@ module LayoutHelper
 
   # rubocop:disable Metrics/AbcSize
   def govuk_continuation_buttons(page_description, form_builder, secondary_button = true, return_link = true, primary_button = true)
-    buttons = form_builder.submit(page_description.navigation_details.primary_text, class: 'govuk-button govuk-!-margin-right-4', data: { disable_with: false }, name: 'commit') if primary_button
+    buttons = form_builder.submit(page_description.navigation_details.primary_text, class: 'govuk-button govuk-!-margin-right-4', data: { disable_with: false }, name: [page_description.navigation_details.primary_name, 'commit'].find(&:present?)) if primary_button
     buttons = form_builder.submit(page_description.navigation_details.secondary_text, class: 'govuk-button govuk-button--secondary', data: { disable_with: false }, name: [page_description.navigation_details.secondary_name, 'commit'].find(&:present?)) unless primary_button
     buttons << form_builder.submit(page_description.navigation_details.secondary_text, class: 'govuk-button govuk-button--secondary', data: { disable_with: false }, name: [page_description.navigation_details.secondary_name, 'commit'].find(&:present?)) if secondary_button
     buttons << capture { tag.br }

--- a/app/views/facilities_management/beta/procurements/_continue_button_footer.html.erb
+++ b/app/views/facilities_management/beta/procurements/_continue_button_footer.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-!-margin-top-6">
   <% if @delete %>
-    <%= link_to 'Confirm delete', facilities_management_beta_procurement_path(@procurement), :method => 'delete', class: "govuk-button govuk-button--warning" %>
+    <%= link_to 'Confirm delete', facilities_management_beta_procurement_path(@procurement), method: 'delete', class: "govuk-button govuk-button--warning" %>
     <%= link_to 'Cancel',  facilities_management_beta_procurements_url, class: "govuk-button govuk-button--secondary govuk-!-margin-left-3" %>
   <% else %>
-    <%= link_to 'Continue', facilities_management_beta_procurement_continue_path(procurement_id: @procurement.id), method: :post, class: 'govuk-button' %>
+    <%= f.submit 'Continue', class: 'govuk-button', data: { disable_with: false }, name: 'continue_to_results'%>
     <%= link_to 'Return to procurements dashboard', facilities_management_beta_procurements_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3' %>
   <%end %>
 </div>

--- a/app/views/facilities_management/beta/procurements/direct_award_pricing.html.erb
+++ b/app/views/facilities_management/beta/procurements/direct_award_pricing.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_page_content(@page_description, @page_data[:model_object]) do |pd| %>
   <p class="govuk-body">Content here</p>
-  <%= form_for @page_data[:model_object], url: facilities_management_beta_procurement_set_route_to_market_path(@procurement.id), method: :put, html: { specialvalidation: false, novalidate: true, multipart: true } do |f| %>
+  <%= form_for @page_data[:model_object], url: facilities_management_beta_procurement_path(@procurement.id), method: :patch, html: { specialvalidation: false, novalidate: true, multipart: true } do |f| %>
       <%= govuk_continuation_buttons(pd, f) %>
   <% end %>
 <% end %>

--- a/app/views/facilities_management/beta/procurements/further_competition.html.erb
+++ b/app/views/facilities_management/beta/procurements/further_competition.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_page_content(@page_description, @page_data[:model_object]) do |pd| %>
   <p class="govuk-body">Content here</p>
-  <%= form_for @page_data[:model_object], url: facilities_management_beta_procurement_set_route_to_market_path(@procurement.id), method: :put, html: { specialvalidation: false, novalidate: true, multipart: true } do |f| %>
+  <%= form_for @page_data[:model_object], url: facilities_management_beta_procurement_path(@procurement.id), method: :patch, html: { specialvalidation: false, novalidate: true, multipart: true } do |f| %>
     <%= govuk_continuation_buttons(pd, f) %>
   <% end %>
 <% end %>

--- a/app/views/facilities_management/beta/procurements/results.html.erb
+++ b/app/views/facilities_management/beta/procurements/results.html.erb
@@ -38,7 +38,7 @@
     <% end %>
   <% end %>
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-width-two-thirds"/>
-  <%= form_for @page_data[:model_object], url: facilities_management_beta_procurement_set_route_to_market_path(@procurement.id), method: :put, html: { specialvalidation: false, novalidate: true, multipart: true } do |f| %>
+  <%= form_for @procurement, url: facilities_management_beta_procurement_path(@procurement.id), method: :patch, html: { specialvalidation: false, novalidate: true, multipart: true } do |f| %>
     <%= f.hidden_field :route_to_market %>
     <%= govuk_grouped_field(f, 'Available routes to market', :route_to_market) do |ff, attr| %>
       <%= govuk_start_individual_field(ff, attr, {}, false, false) do |a| %>

--- a/app/views/facilities_management/beta/procurements/show.html.erb
+++ b/app/views/facilities_management/beta/procurements/show.html.erb
@@ -21,7 +21,7 @@
         <p>
           Once you have answered all of the questions below, you will be provided with an estimated cost and shortlist of suppliers in the recommended sub-lot.
         </p>
-        <form>
+        <%= form_for @procurement, url: facilities_management_beta_procurement_path(@procurement.id), method: :patch, html: {novalidate: true, multipart: true} do |f| %>
           <dl class="govuk-summary-list">
             <%= render('about_the_contract') %>
           </dl>
@@ -32,7 +32,6 @@
                 <%= render partial: 'facilities_management/beta/procurements/contract_period/contract_period_section' %>
                 <%= render partial: 'facilities_management/beta/procurements/contract_period/mobilisation_section' %>
                 <%= render partial: 'facilities_management/beta/procurements/contract_period/contract_extension_section' %>
-              </tbody>
               </tbody>
               <% else %>
               <tbody class="govuk-table__body">
@@ -46,8 +45,8 @@
           <dl class="govuk-summary-list">
             <%= render 'about_the_work', procurement: @procurement %>
           </dl>
-        </form>
-        <%= render('continue_button_footer') %>
+          <%= render partial: 'continue_button_footer', locals: {f: f} %>
+        <%end %>
       <% end %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,12 +142,9 @@ Rails.application.routes.draw do
       get 'spreadsheet-test/dm-spreadsheet-download', to: 'spreadsheet_test#dm_spreadsheet_download', as: 'dm_spreadsheet_download'
       get '/direct-award/sending-the-contract', to: 'direct_award_contract#sending_the_contract'
       resources :procurements do
-        post 'continue'
-        get 'summary'
         get 'results'
         get 'direct_award_pricing'
         get 'further_competition'
-        put 'set_route_to_market'
       end
       resources :procurement_buildings, only: %i[show edit update]
       resources :procurement_buildings_services, only: %i[show update]

--- a/db/migrate/20200115160444_add_eligible_for_da_to_facilities_management_procurements.rb
+++ b/db/migrate/20200115160444_add_eligible_for_da_to_facilities_management_procurements.rb
@@ -1,0 +1,5 @@
+class AddEligibleForDaToFacilitiesManagementProcurements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :facilities_management_procurements, :eligible_for_da, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_03_131101) do
+ActiveRecord::Schema.define(version: 2020_01_15_160444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -121,6 +121,7 @@ ActiveRecord::Schema.define(version: 2020_01_03_131101) do
     t.string "security_policy_document_file"
     t.string "lot_number"
     t.money "assessed_value", scale: 2
+    t.boolean "eligible_for_da"
     t.index ["user_id"], name: "index_facilities_management_procurements_on_user_id"
   end
 


### PR DESCRIPTION
There are changes here in the layout helper
Also, procurements controller and the associated views
And a migration to run