### PR TITLE
Bug/Fix Update User Service

### DIFF
--- a/app/services/cognito/update_user.rb
+++ b/app/services/cognito/update_user.rb
@@ -8,7 +8,7 @@ module Cognito
     end
 
     def call
-      @cognito_user_groups = client.admin_list_groups_for_user(user_pool_id: ENV['COGNITO_USER_POOL_ID'], username: user.cognito_uuid)
+      @cognito_user_groups = client.admin_list_groups_for_user(user_pool_id: ENV['COGNITO_USER_POOL_ID'], username: user.email)
       update_user
     rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
       @error = e.message


### PR DESCRIPTION
Fixed update user service to use user.email instead of user.cognito_uuid when calling admin_list_groups_for_user