### PR TITLE
Bug/migrations broken on cmpdev

### DIFF
--- a/db/migrate/20200113193447_change_fm_rates_attributes.rb
+++ b/db/migrate/20200113193447_change_fm_rates_attributes.rb
@@ -3,6 +3,7 @@ class ChangeFmRatesAttributes < ActiveRecord::Migration[5.2]
     add_column :fm_rates, :standard, :string, limit: 1
     add_column :fm_rates, :direct_award, :boolean
     change_column :fm_rates, :code, :string, unique: false, limit: 5
+    remove_foreign_key(:fm_rates, name: 'fm_rates_code_key') if foreign_key_exists?(:fm_rates, name: 'fm_rates_code_key')
     remove_index :fm_rates, ['code'] if index_exists?(:fm_rates, ['code'])
     remove_index :fm_rates, name: 'fm_rates_code_key' if index_exists?(:fm_rates, name: 'fm_rates_code_key')
     add_index :fm_rates, ['code'], unique: false
@@ -13,6 +14,6 @@ class ChangeFmRatesAttributes < ActiveRecord::Migration[5.2]
     remove_column :fm_rates, :direct_award, :boolean
     change_column :fm_rates, :code, :text
     remove_index :fm_rates, ['code']
-    add_index :fm_rates, ['code'], unique: true
+    add_index :fm_rates, ['code']
   end
 end

--- a/lib/tasks/facilities_management/fm_suppliers.rake
+++ b/lib/tasks/facilities_management/fm_suppliers.rake
@@ -9,7 +9,7 @@ module CCS
     # debug
     puts "CCS_DEFAULT_DB_HOST #{is_dev_db}"
     # nb reinstate || (is_dev_db.include? 'dev')
-    if is_dev_db.nil? || (is_dev_db.include? 'dev.') || (is_dev_db.include? 'cmpdefault.db.internal.fm-preview') || (is_dev_db.include? 'marketplace.preview')
+    if is_dev_db.nil? || (%w[dev. cmpdefault.db.internal.fm-preview marketplace.preview sandbox].any? { |env| is_dev_db.include?(env) })
       puts 'dummy supplier data'
       JSON File.read('data/' + 'facilities_management/dummy_supplier_data.json')
     elsif ENV['SECRET_KEY_BASE']


### PR DESCRIPTION
- Added option to remove fk key if present as cmpdev complains about a 'constraint fm_rates_code_key on table fm_rates' 
- Also updated fm_suppliers.rake to load fake suppliers rather than real ones on cmp-sandbox