### PR TITLE
FM-682 add cafm, help to table 2 in contract rate card worksheet

### DIFF
--- a/app/controllers/facilities_management/beta/summary_controller.rb
+++ b/app/controllers/facilities_management/beta/summary_controller.rb
@@ -21,14 +21,16 @@ module FacilitiesManagement
         end
       end
 
+      # rubocop:disable Metrics/AbcSize
       def sorted_suppliers
         init
 
-        build_direct_award_report params[:'download-spreadsheet'] == 'yes'
+        cafm_help_used = { isCafmUsed: false, isHelpUsed: false }
+        build_direct_award_report(params[:'download-spreadsheet'] == 'yes', cafm_help_used)
 
         return if params[:'download-spreadsheet'] != 'yes'
 
-        spreadsheet1 = FacilitiesManagement::DirectAwardSpreadsheet.new @supplier_name, @report_results[@supplier_name], @rate_card
+        spreadsheet1 = FacilitiesManagement::DirectAwardSpreadsheet.new @supplier_name, @report_results[@supplier_name], @rate_card, cafm_help_used
 
         uvals = []
         buildings_ids = []
@@ -59,14 +61,15 @@ module FacilitiesManagement
         ### render xlsx: spreadsheet2.to_stream.read, filename: 'deliverable_matrix'
         download_report 'fm_spreadsheets', [['direct_award_prices', spreadsheet1], ['deliverable_matrix', spreadsheet_builder]]
       end
+      # rubocop:enable Metrics/AbcSize
 
       private
 
       # rubocop:disable Metrics/AbcSize
-      def build_direct_award_report(cache__calculation_values_for_spreadsheet_flag)
+      def build_direct_award_report(cache__calculation_values_for_spreadsheet_flag, cafm_help_used = {})
         user_email = current_user.email.to_s
 
-        @report = SummaryReport.new(@start_date, user_email, TransientSessionInfo[session.id], @procurement)
+        @report = SummaryReport.new(@start_date, user_email, TransientSessionInfo[session.id], @procurement, cafm_help_used)
 
         # @procurement.procurement_buildings.first.procurement_building_services
         if @procurement

--- a/app/models/facilities_management/summary_report.rb
+++ b/app/models/facilities_management/summary_report.rb
@@ -2,12 +2,13 @@ module FacilitiesManagement
   class SummaryReport
     include FacilitiesManagement::Beta::SummaryHelper
 
-    attr_reader :sum_uom, :sum_benchmark, :building_data, :contract_length_years, :start_date, :tupe_flag, :posted_services, :posted_locations, :subregions, :errors
+    attr_reader :sum_uom, :sum_benchmark, :building_data, :contract_length_years, :start_date, :tupe_flag, :posted_services, :posted_locations, :subregions, :errors, :cafm_help_used
 
-    def initialize(start_date, user_id, data, procurement = nil)
+    def initialize(start_date, user_id, data, procurement = nil, cafm_help_used = {})
       @errors = ''
       @start_date = start_date
       @user_id = user_id
+      @cafm_help_used = cafm_help_used
 
       @sum_uom = 0
       @sum_benchmark = 0
@@ -134,10 +135,16 @@ module FacilitiesManagement
         vals_per_building = services(building_data, building_uvals, rates, rate_card, supplier_name, results2)
         @sum_uom += vals_per_building[:sum_uom]
         @sum_benchmark += vals_per_building[:sum_benchmark] if supplier_name.nil?
+        set_cafm_help_used
       end
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/ParameterLists (with a s)
+
+    def set_cafm_help_used
+      @cafm_help_used[:isCafmUsed] = true if @cafm_flag == 'Y'
+      @cafm_help_used[:isHelpUsed] = true if @helpdesk_flag == 'Y'
+    end
 
     def with_pricing
       # CCS::FM::Rate.non_zero_rate

--- a/app/services/facilities_management/direct_award_spreadsheet.rb
+++ b/app/services/facilities_management/direct_award_spreadsheet.rb
@@ -1,8 +1,9 @@
 class FacilitiesManagement::DirectAwardSpreadsheet
-  def initialize(supplier_name, data, rate_card)
+  def initialize(supplier_name, data, rate_card, cafm_help_used = {})
     @supplier_name = supplier_name
     @data = data
     @rate_card_data = rate_card.data
+    @cafm_help_used = cafm_help_used
     create_spreadsheet
   end
 
@@ -119,10 +120,16 @@ class FacilitiesManagement::DirectAwardSpreadsheet
         sheet.add_row ['TUPE Risk Premium', 'percentage of deliverables value', rate_card_variances[:'TUPE Risk Premium (DA %)']], style: [standard_column_style, standard_column_style, percentage_style]
         sheet.add_row ['Mobilisation Cost', 'percentage of deliverables value', rate_card_variances[:'Mobilisation Cost (DA %)']], style: [standard_column_style, standard_column_style, percentage_style]
 
+        add_table2_cafm_help_rows sheet, standard_column_style, percentage_style
       end
     end
   end
   # rubocop:enable Metrics/AbcSize
+
+  def add_table2_cafm_help_rows(sheet, standard_column_style, percentage_style)
+    sheet.add_row ['CAFM System', 'Percentage of Year 1 Deliverables Value (excluding Management and Corporate Overhead, and Profit) at call-off.', @rate_card_data[:Prices][@supplier_name.to_sym][:'M.1'][:'General office - Customer Facing']], style: [standard_column_style, standard_column_style, percentage_style] if @cafm_help_used[:isCafmUsed]
+    sheet.add_row ['Helpdesk Services', 'Percentage of Year 1 Deliverables Value (excluding Management and Corporate Overhead, and Profit) at call-off.', @rate_card_data[:Prices][@supplier_name.to_sym][:'N.1'][:'General office - Customer Facing']], style: [standard_column_style, standard_column_style, percentage_style] if @cafm_help_used[:isHelpUsed]
+  end
 
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/BlockLength

--- a/spec/models/facilities_management/summary_report_spec.rb
+++ b/spec/models/facilities_management/summary_report_spec.rb
@@ -621,6 +621,27 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
     expect(report.assessed_value.round(2)).to be 8733916.62
   end
 
+  it 'creates summary report for buildings for N.1' do
+    dummy_supplier_name = 'Hickle-Schinner'
+    cafm_help_used = { isCafmUsed: false, isHelpUsed: false }
+    report_cafmhelp = FacilitiesManagement::SummaryReport.new(start_date, 'test@example.com', data, nil, cafm_help_used)
+    expect(report_cafmhelp.cafm_help_used).to include(isCafmUsed: false, isHelpUsed: false)
+
+    u = uvals.select { |s| s['service_code'] == 'N.1' && s[:building_id] == '5D0901B0-E8C1-C6A7-191D-4710C4514EE1' }
+    report_cafmhelp.calculate_services_for_buildings buildings, u, rates, rate_card, dummy_supplier_name
+    expect(report_cafmhelp.cafm_help_used).to include(isCafmUsed: false, isHelpUsed: true)
+  end
+
+  it 'creates summary report for buildings for M1' do
+    dummy_supplier_name = 'Hickle-Schinner'
+    cafm_help_used = { isCafmUsed: false, isHelpUsed: false }
+    report_cafmhelp = FacilitiesManagement::SummaryReport.new(start_date, 'test@example.com', data, nil, cafm_help_used)
+
+    u = uvals.select { |s| s['service_code'] == 'M.1' && s[:building_id] == '5D0901B0-E8C1-C6A7-191D-4710C4514EE1' }
+    report_cafmhelp.calculate_services_for_buildings buildings, u, rates, rate_card, dummy_supplier_name
+    expect(report_cafmhelp.cafm_help_used).to include(isCafmUsed: true, isHelpUsed: false)
+  end
+
   it 'price individual services E.4' do
     # data
     dummy_supplier_name = 'Hickle-Schinner'

--- a/spec/models/facilities_management/summary_report_spec.rb
+++ b/spec/models/facilities_management/summary_report_spec.rb
@@ -624,22 +624,22 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
   it 'creates summary report for buildings for N.1' do
     dummy_supplier_name = 'Hickle-Schinner'
     cafm_help_used = { isCafmUsed: false, isHelpUsed: false }
-    report_cafmhelp = FacilitiesManagement::SummaryReport.new(start_date, 'test@example.com', data, nil, cafm_help_used)
-    expect(report_cafmhelp.cafm_help_used).to include(isCafmUsed: false, isHelpUsed: false)
+    report_help = FacilitiesManagement::SummaryReport.new(start_date, 'test@example.com', data, nil, cafm_help_used)
+    expect(report_help.cafm_help_used).to include(isCafmUsed: false, isHelpUsed: false)
 
     u = uvals.select { |s| s['service_code'] == 'N.1' && s[:building_id] == '5D0901B0-E8C1-C6A7-191D-4710C4514EE1' }
-    report_cafmhelp.calculate_services_for_buildings buildings, u, rates, rate_card, dummy_supplier_name
-    expect(report_cafmhelp.cafm_help_used).to include(isCafmUsed: false, isHelpUsed: true)
+    report_help.calculate_services_for_buildings buildings, u, rates, rate_card, dummy_supplier_name
+    expect(report_help.cafm_help_used).to include(isCafmUsed: false, isHelpUsed: true)
   end
 
   it 'creates summary report for buildings for M1' do
     dummy_supplier_name = 'Hickle-Schinner'
     cafm_help_used = { isCafmUsed: false, isHelpUsed: false }
-    report_cafmhelp = FacilitiesManagement::SummaryReport.new(start_date, 'test@example.com', data, nil, cafm_help_used)
+    report_cafm = FacilitiesManagement::SummaryReport.new(start_date, 'test@example.com', data, nil, cafm_help_used)
 
     u = uvals.select { |s| s['service_code'] == 'M.1' && s[:building_id] == '5D0901B0-E8C1-C6A7-191D-4710C4514EE1' }
-    report_cafmhelp.calculate_services_for_buildings buildings, u, rates, rate_card, dummy_supplier_name
-    expect(report_cafmhelp.cafm_help_used).to include(isCafmUsed: true, isHelpUsed: false)
+    report_cafm.calculate_services_for_buildings buildings, u, rates, rate_card, dummy_supplier_name
+    expect(report_cafm.cafm_help_used).to include(isCafmUsed: true, isHelpUsed: false)
   end
 
   it 'price individual services E.4' do

--- a/spec/models/facilities_management/summary_report_spec.rb
+++ b/spec/models/facilities_management/summary_report_spec.rb
@@ -624,7 +624,7 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
   it 'creates summary report for buildings for N.1' do
     dummy_supplier_name = 'Hickle-Schinner'
     cafm_help_used = { isCafmUsed: false, isHelpUsed: false }
-    report_help = FacilitiesManagement::SummaryReport.new(start_date, 'test@example.com', data, nil, cafm_help_used)
+    report_help = described_class.new(start_date, 'test@example.com', data, nil, cafm_help_used)
     expect(report_help.cafm_help_used).to include(isCafmUsed: false, isHelpUsed: false)
 
     u = uvals.select { |s| s['service_code'] == 'N.1' && s[:building_id] == '5D0901B0-E8C1-C6A7-191D-4710C4514EE1' }
@@ -635,7 +635,7 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
   it 'creates summary report for buildings for M1' do
     dummy_supplier_name = 'Hickle-Schinner'
     cafm_help_used = { isCafmUsed: false, isHelpUsed: false }
-    report_cafm = FacilitiesManagement::SummaryReport.new(start_date, 'test@example.com', data, nil, cafm_help_used)
+    report_cafm = described_class.new(start_date, 'test@example.com', data, nil, cafm_help_used)
 
     u = uvals.select { |s| s['service_code'] == 'M.1' && s[:building_id] == '5D0901B0-E8C1-C6A7-191D-4710C4514EE1' }
     report_cafm.calculate_services_for_buildings buildings, u, rates, rate_card, dummy_supplier_name


### PR DESCRIPTION
Needed to add a row in the direct_award excel ,contract rate card worksheet, table 2 for cafm and help. a requirement was to not add a row for cafm if no service selected cafm, same for help ; this functionality took most of the code changes.