### PR TITLE
Feature/fm 659 assessed value fix

### DIFF
--- a/app/calculators/fm_calculator/calculator.rb
+++ b/app/calculators/fm_calculator/calculator.rb
@@ -179,7 +179,7 @@ module FMCalculator
 
     # cleaning consumables using benchmark rate
     def benchclean
-      @benchclean = @occupants * @framework_rates['M146']
+      @benchclean = @occupants * @benchmark_rates['M146']
     end
 
     # benchmark variation if london_flag set
@@ -194,7 +194,7 @@ module FMCalculator
     # benchmark cafm if flag set
     def benchcafm(benchsubtotal2)
       if @cafm_flag == 'Y'
-        @framework_rates['M136'] * benchsubtotal2
+        @benchmark_rates['M136'] * benchsubtotal2
       else
         0
       end
@@ -203,7 +203,7 @@ module FMCalculator
     # benchmark helpsdesk costs if helpdesk_flag set
     def benchhelpdesk(benchsubtotal2)
       if @helpdesk_flag == 'Y'
-        @benchhelpdesk = benchsubtotal2 * @framework_rates['N138']
+        @benchhelpdesk = benchsubtotal2 * @benchmark_rates['N138']
       else
         0
       end
@@ -211,13 +211,13 @@ module FMCalculator
 
     # benchmark mobilisation costs
     def benchmobilisation(benchsubtotal3)
-      benchsubtotal3 * @framework_rates['B1']
+      benchsubtotal3 * @benchmark_rates['B1']
     end
 
     # benchmark tupe costs if flag set
     def benchtupe(benchsubtotal3)
       if @tupe_flag == 'Y'
-        benchsubtotal3 * @framework_rates['M148']
+        benchsubtotal3 * @benchmark_rates['M148']
       else
         0
       end
@@ -225,22 +225,22 @@ module FMCalculator
 
     # benchmark mananagement overhead costs
     def benchmanage(benchyear1)
-      benchyear1 * @framework_rates['M140']
+      benchyear1 * @benchmark_rates['M140']
     end
 
     # bench mark corporate overhead cost
     def benchcorporate(benchyear1)
-      benchyear1 * @framework_rates['M141']
+      benchyear1 * @benchmark_rates['M141']
     end
 
     # bench mark profit
     def benchprofit(benchyear1)
-      benchyear1 * @framework_rates['M142']
+      benchyear1 * @benchmark_rates['M142']
     end
 
     # bench mark subsequent year(s) total charges
     def benchsubyearstotal(benchyear1totalcharges, benchmobilisation)
-      @subsequent_length_years * (benchyear1totalcharges - (((benchmobilisation + (benchmobilisation * @framework_rates['M140']) + (benchmobilisation * @framework_rates['M141'])) * (@framework_rates['M142'] + 1))))
+      @subsequent_length_years * (benchyear1totalcharges - (((benchmobilisation + (benchmobilisation * @benchmark_rates['M140']) + (benchmobilisation * @benchmark_rates['M141'])) * (@benchmark_rates['M142'] + 1))))
     end
 
     # entry point to calculate sum of the unit of measure
@@ -271,7 +271,6 @@ module FMCalculator
         results[:contract_length_years] = @contract_length_years
         results[:subsequent_length_years] = @subsequent_length_years
       end
-
       year1totalcharges + subyearstotal(year1totalcharges, mobilisation)
     end
     # rubocop:enable Metrics/AbcSize

--- a/app/services/facilities_management/direct_award_eligible_suppliers.rb
+++ b/app/services/facilities_management/direct_award_eligible_suppliers.rb
@@ -10,12 +10,16 @@ class FacilitiesManagement::DirectAwardEligibleSuppliers
     rates = CCS::FM::Rate.read_benchmark_rates
     @rate_card = CCS::FM::RateCard.latest
     @results = {}
+
+    @report.calculate_services_for_buildings @selected_buildings, nil, rates, @rate_card, nil, nil
+    @procurement.update(lot_number: @report.current_lot, assessed_value: @report.assessed_value)
+
     supplier_names = @rate_card.data[:Prices].keys
     supplier_names.each do |supplier_name|
       @report.calculate_services_for_buildings @selected_buildings, nil, rates, @rate_card, supplier_name, nil
       @results[supplier_name] = @report.direct_award_value
     end
-    @procurement.update(lot_number: @report.current_lot, assessed_value: @report.assessed_value)
+
     @results.sort_by { |_k, v| v }
   end
 end

--- a/spec/calculators/fm_calculator/calculators_routine_cleaning_spec.rb
+++ b/spec/calculators/fm_calculator/calculators_routine_cleaning_spec.rb
@@ -81,17 +81,17 @@ RSpec.describe FMCalculator::Calculator do
       benchmanage = calc.benchmanage(benchyear1)
       expect(benchmanage.round(0)).to eq(17404)
       benchcorporate = calc.benchcorporate(benchyear1)
-      expect(benchcorporate.round(0)).to eq(7244)
+      expect(benchcorporate.round(0)).to eq(8594)
       benchyear1total = benchyear1 + benchmanage + benchcorporate
-      expect(benchyear1total.round(0)).to eq(197126)
+      expect(benchyear1total.round(0)).to eq(198476)
       benchprofit = calc.benchprofit(benchyear1)
-      expect(benchprofit.round(0)).to eq(5347)
+      expect(benchprofit.round(0)).to eq(9362)
       benchyear1totalcharges = benchyear1total + benchprofit
-      expect(benchyear1totalcharges.round(0)).to eq(202473)
+      expect(benchyear1totalcharges.round(0)).to eq(207838)
       benchsubyearstotal = calc.benchsubyearstotal(benchyear1totalcharges, benchmobilisation)
-      expect(benchsubyearstotal.round(0)).to eq(382342)
+      expect(benchsubyearstotal.round(0)).to eq(392403)
       benchtotalcharges = benchyear1totalcharges + benchsubyearstotal
-      expect(benchtotalcharges.round(0)).to eq(584815)
+      expect(benchtotalcharges.round(0)).to eq(600241)
     end
     # rubocop:enable RSpec/MultipleExpectations:
     # rubocop:enable RSpec/ExampleLength:

--- a/spec/calculators/fm_calculator/fm_calculators_spec.rb
+++ b/spec/calculators/fm_calculator/fm_calculators_spec.rb
@@ -42,37 +42,37 @@ RSpec.describe FMCalculator::Calculator do
       expect(X9.round(0)).to eq(63546)
 
       Y1 = FMCalculator::Calculator.new(3, 'G1', 23000, 125, 'Y', 'Y', 'Y', 'N', rates).benchmarkedcostssum
-      expect(Y1.round(0)).to eq(584815)
+      expect(Y1.round(0)).to eq(600241)
 
       Y2 = FMCalculator::Calculator.new(3, 'C5', 54, 0, 'Y', 'Y', 'Y', 'N', rates).benchmarkedcostssum
-      expect(Y2.round(0)).to eq(54280)
+      expect(Y2.round(0)).to eq(55712)
 
       Y3 = FMCalculator::Calculator.new(3, 'C19', 0, 0, 'Y', 'Y', 'Y', 'N', rates).benchmarkedcostssum
       expect(Y3.round(0)).to eq(0)
 
       Y4 = FMCalculator::Calculator.new(3, 'E4', 450, 0, 'N', 'N', 'M', 'Y', rates).benchmarkedcostssum
-      expect(Y4.round(0)).to eq(1340)
+      expect(Y4.round(0)).to eq(1376)
 
       Y5 = FMCalculator::Calculator.new(3, 'K1', 75, 0, 'N', 'N', 'N', 'Y', rates).benchmarkedcostssum
-      expect(Y5.round(0)).to eq(26360)
+      expect(Y5.round(0)).to eq(27055)
 
       Y6 = FMCalculator::Calculator.new(3, 'H4', 2350, 0, 'N', 'N', 'N', 'Y', rates).benchmarkedcostssum
-      expect(Y6.round(0)).to eq(173929)
+      expect(Y6.round(0)).to eq(178515)
 
       Y7 = FMCalculator::Calculator.new(3, 'G5', 56757, 0, 'N', 'N', 'N', 'N', rates).benchmarkedcostssum
-      expect(Y7.round(0)).to eq(536629)
+      expect(Y7.round(0)).to eq(550777)
 
       Y8 = FMCalculator::Calculator.new(3, 'K2', 125, 0, 'N', 'N', 'N', 'N', rates).benchmarkedcostssum
-      expect(Y8.round(0)).to eq(101481)
+      expect(Y8.round(0)).to eq(104157)
 
       Y9 = FMCalculator::Calculator.new(3, 'K7', 680, 0, 'N', 'N', 'N', 'N', rates).benchmarkedcostssum
-      expect(Y9.round(0)).to eq(57682)
+      expect(Y9.round(0)).to eq(59203)
 
       SumX = X1 + X2 + X3 + X4 + X5 + X6 + X7 + X8 + X9
       expect(SumX.round(0)).to eq(2384177)
 
       SumY = Y1 + Y2 + Y3 + Y4 + Y5 + Y6 + Y7 + Y8 + Y9
-      expect(SumY.round(0)).to eq(1536518)
+      expect(SumY.round(0)).to eq(1577036)
     end
   end
 end

--- a/spec/models/facilities_management/summary_report_spec.rb
+++ b/spec/models/facilities_management/summary_report_spec.rb
@@ -617,8 +617,8 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
 
     # report.workout_current_lot
     # p report.assessed_value
-    # assessed_value.round == GBP 8,509,504.71
-    expect(report.assessed_value.round(2)).to be 8509504.71
+    # assessed_value.round == GBP 8,609,444.55
+    expect(report.assessed_value.round(2)).to be 8609444.55
   end
 
   it 'price individual services E.4' do
@@ -839,7 +839,7 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
     end
 
     expect(sum_uom.round(2)).to be 939817.98
-    expect(sum_benchmark.round(2)).to be 925409.13
+    expect(sum_benchmark.round(2)).to be 949771.07
   end
   # rubocop:enable RSpec/ExampleLength
 end


### PR DESCRIPTION
-  assessed_value should be calculated before da_value because you don't get the right value if you have already passed in supplier_name parameter
- fixed banchmark sum to use benchmark rates rather than framework rates