### PR TITLE
FM-711 only show contract rate worksheet table 1 values if building l…

### DIFF
--- a/app/controllers/facilities_management/beta/summary_controller.rb
+++ b/app/controllers/facilities_management/beta/summary_controller.rb
@@ -28,8 +28,6 @@ module FacilitiesManagement
 
         return if params[:'download-spreadsheet'] != 'yes'
 
-        spreadsheet1 = FacilitiesManagement::DirectAwardSpreadsheet.new @supplier_name, @report_results[@supplier_name], @rate_card, @report_results_no_cafmhelp_removed[@supplier_name]
-
         uvals = []
         buildings_ids = []
         @selected_buildings.each do |building|
@@ -51,6 +49,8 @@ module FacilitiesManagement
 
         spreadsheet_builder = FacilitiesManagement::DeliverableMatrixSpreadsheetCreator.new(building_ids_with_service_codes2, uvals)
         spreadsheet_builder.build
+
+        spreadsheet1 = FacilitiesManagement::DirectAwardSpreadsheet.new @supplier_name, @report_results[@supplier_name], @rate_card, @report_results_no_cafmhelp_removed[@supplier_name], uvals
 
         # render xlsx: spreadsheet.to_stream.read, filename: 'deliverable_matrix', format: # 'application/vnd.openxmlformates-officedocument.spreadsheetml.sheet'
         # IO.write('/tmp/deliverable_matrix_3.xlsx', spreadsheet.to_stream.read)

--- a/lib/tasks/facilities_management/fm.rake
+++ b/lib/tasks/facilities_management/fm.rake
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ModuleLength
 module FM
   require 'pg'
   require 'json'
@@ -24,7 +25,8 @@ INSERT INTO public.fm_units_of_measurement (id, title_text, example_text, unit_t
 INSERT INTO public.fm_units_of_measurement (id, title_text, example_text, unit_text, data_type, spreadsheet_label, unit_measure_label, service_usage) VALUES(7, 'How many hours are required each year?', 'Example, 520. If this service is required for 10 hours per week, then enter 520 hours (each year)', '', 'numeric', 'Number of hours required per annum', 'hourly rate', '{H.4,H.5,I.1,I.2,I.3,I.4,J.1,J.2,J.3,J.4,J.5,J.6}');
 INSERT INTO public.fm_units_of_measurement (id, title_text, example_text, unit_text, data_type, spreadsheet_label, unit_measure_label, service_usage) VALUES(9, 'How many classified waste consoles need emptying each year?', 'Example 60. When 5 consoles are emptied monthly, enter 60 consoles each year', 'units (each year)', 'numeric', 'Number of consoles per annum', 'price per console', '{K.1}');
 INSERT INTO public.fm_units_of_measurement (id, title_text, example_text, unit_text, data_type, spreadsheet_label, unit_measure_label, service_usage) VALUES(10, 'How many units of feminine hygiene waste need to be emptied each year?', 'Example, 600. When 50 units per month need emptying, enter 600 units each year', 'units (each year)', 'numeric', 'Number of units per annum', 'price per unit', '{K.7}');
-INSERT INTO public.fm_units_of_measurement (id, title_text, example_text, unit_text, data_type, spreadsheet_label, unit_measure_label, service_usage) VALUES(11, 'help,cafm', 'Example, help,cafm', 'units (each year)', 'numeric', 'Percentage of Year 1 Deliverables Value (excluding Management and Corporate Overhead, and Profit) at call-off.', 'per % of Year 1 Deliverables Value', '{N.1,M.1}');"
+INSERT INTO public.fm_units_of_measurement (id, title_text, example_text, unit_text, data_type, spreadsheet_label, unit_measure_label, service_usage) VALUES(11, 'help,cafm', 'Example, help,cafm', 'units (each year)', 'numeric', 'Percentage of Year 1 Deliverables Value (excluding Management and Corporate Overhead, and Profit) at call-off.', 'per % of Year 1 Deliverables Value', '{N.1,M.1}');
+INSERT INTO public.fm_units_of_measurement (id, title_text, example_text, unit_text, data_type, spreadsheet_label, unit_measure_label, service_usage) VALUES(12, 'what''s the number of square metres?', 'Example, 1000 sqm', 'sqm (square metres)', 'numeric', 'Square Metre (GIA) per annum', 'price per Square Metre (GIA)', '{C.1,C.2,C.3,C.4,C.6,C.7,C.11,C.12,C.13,E.1,E.2,E.3,E.5,E.6,E.7,E.8,G.1,G.2,G.6,G.7,G.15}');"
       db.query query
     end
   rescue PG::Error => e
@@ -134,3 +136,4 @@ namespace :db do
   task static: :fmdata do
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/spec/models/facilities_management/summary_report2_spec.rb
+++ b/spec/models/facilities_management/summary_report2_spec.rb
@@ -275,6 +275,7 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
               'gia' => 1234,
               'name' => 'c4',
               'region' => 'London',
+              'building-type' => 'Warehouses',
               'address' => { 'fm-address-town' => 'London', 'fm-address-line-1' => '1 Horseferry Road', 'fm-address-postcode' => 'SW1P 2BA' },
               'isLondon' => 'No',
               'services' => [{ 'code' => 'J-8', 'name' => 'Additional security services' },
@@ -402,6 +403,7 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
             'gia' => 2000,
             'name' => 'Victoria Station',
             'region' => 'London',
+            'building-type' => 'Warehouses',
             'address' => { 'fm-address-town' => 'London', 'fm-address-line-1' => '121 Buckingham Palace Road', 'fm-address-postcode' => 'SW1W 9SZ' }, 'isLondon' => 'No', 'services' => [{ 'code' => 'J-8', 'name' => 'Additional security services' },
               { 'code' => 'H-16', 'name' => 'Administrative support services' },
               { 'code' => 'C-21', 'name' => 'Airport and aerodrome maintenance services' },
@@ -528,6 +530,7 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
             'gia' => 12345,
             'name' => 'ccs',
             'region' => 'London',
+            'building-type' => 'Warehouses',
             'address' => { 'fm-address-town' => 'London', 'fm-address-line-1' => '151 Buckingham Palace Road', 'fm-address-postcode' => 'SW1W 9SZ' }, 'isLondon' => 'No', 'services' => [{ 'code' => 'J-8', 'name' => 'Additional security services' },
               { 'code' => 'H-16', 'name' => 'Administrative support services' },
               { 'code' => 'C-21', 'name' => 'Airport and aerodrome maintenance services' },
@@ -697,7 +700,7 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
       supplier_name = 'Hirthe-Mills'.to_sym
       expect(report_results[supplier_name][report_results[supplier_name].keys.third].count).to eq 22
 
-      spreadsheet = FacilitiesManagement::DirectAwardSpreadsheet.new supplier_name, report_results[supplier_name], rate_card
+      spreadsheet = FacilitiesManagement::DirectAwardSpreadsheet.new supplier_name, report_results[supplier_name], rate_card, {}, uvals
 
       IO.write('/tmp/direct_award_prices.xlsx', spreadsheet.to_xlsx)
 
@@ -742,7 +745,7 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
       end
 
       supplier_name = 'Hirthe-Mills'.to_sym
-      spreadsheet = FacilitiesManagement::DirectAwardSpreadsheet.new supplier_name, report_results[supplier_name], rate_card, report_results_no_cafmhelp_removed[supplier_name]
+      spreadsheet = FacilitiesManagement::DirectAwardSpreadsheet.new supplier_name, report_results[supplier_name], rate_card, report_results_no_cafmhelp_removed[supplier_name], uvals
 
       IO.write('/tmp/direct_award_prices.xlsx', spreadsheet.to_xlsx)
 
@@ -780,7 +783,7 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
       end
 
       supplier_name = 'Hirthe-Mills'.to_sym
-      spreadsheet = FacilitiesManagement::DirectAwardSpreadsheet.new supplier_name, report_results[supplier_name], rate_card, report_results_no_cafmhelp_removed[supplier_name]
+      spreadsheet = FacilitiesManagement::DirectAwardSpreadsheet.new supplier_name, report_results[supplier_name], rate_card, report_results_no_cafmhelp_removed[supplier_name], uvals
 
       IO.write('/tmp/direct_award_prices.xlsx', spreadsheet.to_xlsx)
 
@@ -790,6 +793,43 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
       expect(wb.sheet('Contract Rate Card').row(8)[1]).to eq 'Lifts, Hoists & Conveyance Systems Maintenance - Standard A'
       # note: enable once everyone runs otherwise all tests will fail: rake lib/tasks/facilities_management/fm.rake db:fmdata
       # expect(wb.sheet('Contract Rate Card').row(8)[2]).to eq 'price per Number (per lift per floor)'
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'verify building columns in table 1 contract rate card workbook' do
+      user_email = 'test@example.com'
+      start_date = DateTime.now.utc
+
+      report = described_class.new(start_date, user_email, data)
+
+      rates = CCS::FM::Rate.read_benchmark_rates
+      rate_card = CCS::FM::RateCard.latest
+
+      results = {}
+      report_results = {}
+      report_results_no_cafmhelp_removed = {}
+
+      supplier_names = rate_card.data[:Prices].keys
+      supplier_names.each do |supplier_name|
+        report_results[supplier_name] = {}
+        # e.g. dummy supplier_name = 'Hickle-Schinner'
+        report.calculate_services_for_buildings @selected_buildings2, uvals, rates, rate_card, supplier_name, report_results[supplier_name], true
+        results[supplier_name] = report.direct_award_value
+
+        report_results_no_cafmhelp_removed[supplier_name] = {}
+        report.calculate_services_for_buildings @selected_buildings2, uvals, rates, rate_card, supplier_name, report_results_no_cafmhelp_removed[supplier_name], false
+      end
+
+      supplier_name = 'Hirthe-Mills'.to_sym
+      spreadsheet = FacilitiesManagement::DirectAwardSpreadsheet.new supplier_name, report_results[supplier_name], rate_card, report_results_no_cafmhelp_removed[supplier_name], uvals
+
+      IO.write('/tmp/direct_award_prices.xlsx', spreadsheet.to_xlsx)
+
+      # check warehouse building is added to table 1 in contract Rate Card worksheet
+      wb = Roo::Excelx.new('/tmp/direct_award_prices.xlsx')
+      expect(wb.sheet('Contract Rate Card').row(3).length).to eq 4
+      expect(wb.sheet('Contract Rate Card').row(3)[3]).to eq 'Warehouses'
     end
     # rubocop:enable RSpec/ExampleLength
   end


### PR DESCRIPTION
FM-711 fix, only show the buildings used in the procurement in the contract rate buildings column, and in these columns only show the rates if the service uses the building.

also for FM-708 add default excel label values for missing services in fm.rake 