### PR TITLE
bug fix - changed gateway url to default to fm gateway

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::Base
     when 'legal_services'
       legal_services_gateway_url
     else
-      supply_teachers_gateway_url
+      facilities_management_gateway_url
     end
   end
 


### PR DESCRIPTION
signing out from cookies page redirected user to supply teachers as opposed to FM page. 

- this will be a problem in the future, as it will now default to FM (as opposed to a more general page - maybe homepage?) but fixes bug to meet acceptance criteria. 