### PR TITLE
Google analytics now runs on all pages

### DIFF
--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -1,4 +1,4 @@
-<% if Marketplace.google_analytics_tracking_id.present? && a_supply_teachers_path? %>
+<% if Marketplace.google_analytics_tracking_id.present? %>
   <script async src="https://www.googletagmanager.com/gtag/js?id=<%= Marketplace.google_analytics_tracking_id %>"></script>
   <script>
       window.dataLayer = window.dataLayer || [];

--- a/spec/views/shared/_google_analytics.html.erb_spec.rb
+++ b/spec/views/shared/_google_analytics.html.erb_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'shared/_google_analytics.html.erb' do
   before do
     allow(Marketplace).to receive(:google_analytics_tracking_id)
       .and_return(google_analytics_tracking_id)
-    allow(view).to receive(:a_supply_teachers_path?).and_return true
   end
 
   context 'when Google Analytics tracking ID is missing' do
@@ -25,20 +24,6 @@ RSpec.describe 'shared/_google_analytics.html.erb' do
 
       expect(rendered).to match(/script/)
       expect(rendered).to match(/UA-999-9/)
-    end
-  end
-
-  context 'when view is not a supply_teachers path' do
-    let(:google_analytics_tracking_id) { 'UA-999-9' }
-
-    before do
-      allow(view).to receive(:a_supply_teachers_path?).and_return false
-    end
-
-    it 'does not render anything' do
-      render partial: 'shared/google_analytics'
-
-      expect(rendered).to be_blank
     end
   end
 end


### PR DESCRIPTION
Google Analytics now runs on all pages as we're filtering the views through GA based on path