### PR TITLE
BUG/FM-684-building-summary-details

### DIFF
--- a/app/views/facilities_management/beta/buildings_management/_building_details_summary.html.erb
+++ b/app/views/facilities_management/beta/buildings_management/_building_details_summary.html.erb
@@ -28,7 +28,7 @@
         </td>
       </tr>
       <tr>
-        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_desc') %></th>
+        <th><%= t('facilities_management.beta.building-details-summary.caption_desc') %></th>
         <td>
           <% if !@building['description'].blank? %>
             <%= @building['description'] %>
@@ -43,7 +43,7 @@
         </td>
       </tr>
       <tr>
-        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_addr') %></th>
+        <th><%= t('facilities_management.beta.building-details-summary.caption_addr') %></th>
         <td>
           <% if !@building['address'].blank? %>
             <% address = @building['address']['fm-address-line-1'].to_s + (@building['address']['fm-address-line-1'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-line-2'].to_s + (@building['address']['fm-address-line-2'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-town'].to_s + (@building['address']['fm-address-town'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-county'].to_s + (@building['address']['fm-address-county'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-postcode'].to_s %>
@@ -59,7 +59,7 @@
       </tr>
 
       <tr>
-        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_region_nuts') %></th>
+        <th><%= t('facilities_management.beta.building-details-summary.caption_region_nuts') %></th>
         <td>
           <% if !@building['address'].blank? %>
             <%= @building['address']['fm-address-region'].to_s %>
@@ -76,7 +76,7 @@
 
 
       <tr>
-        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_gia') %></th>
+        <th><%= t('facilities_management.beta.building-details-summary.caption_gia') %></th>
         <td>
           <% if !@building['gia'].blank? %><%=number_with_delimiter(@building['gia'], :delimiter => ',') + " sqm"  %>
           <% else %>
@@ -88,7 +88,7 @@
           <% end %></td>
       </tr>
       <tr>
-        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_type') %></th>
+        <th><%= t('facilities_management.beta.building-details-summary.caption_type') %></th>
         <td>
           <% if !@building['building-type'].blank? %><%= @building['building-type'] %>
           <% else %>
@@ -100,7 +100,7 @@
           <% end %></td>
       </tr>
       <tr>
-        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_sec') %></th>
+        <th><%= t('facilities_management.beta.building-details-summary.caption_sec') %></th>
         <td>
           <% if !@building['security-type'].blank? %>
             <%= @building['security-type'].capitalize %>

--- a/app/views/facilities_management/beta/buildings_management/_building_details_summary.html.erb
+++ b/app/views/facilities_management/beta/buildings_management/_building_details_summary.html.erb
@@ -5,7 +5,7 @@
     <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
   </form>
   <div class="govuk-table" data-module="table" id="buildings-list">
-    <table class="govuk-!-width-one-half" style="border-collapse: collapse;">
+    <table class="govuk-!-width-two-thirds" style="border-collapse: collapse;">
       <tr>
         <th></th>
         <td></td>
@@ -13,7 +13,7 @@
       </tr>
       <tbody>
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_name') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_name') %></th>
         <td>
           <% if !@building['name'].blank? %>
             <%= @building['name'] %>
@@ -28,7 +28,7 @@
         </td>
       </tr>
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_desc') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_desc') %></th>
         <td>
           <% if !@building['description'].blank? %>
             <%= @building['description'] %>
@@ -43,7 +43,7 @@
         </td>
       </tr>
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_addr') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_addr') %></th>
         <td>
           <% if !@building['address'].blank? %>
             <% address = @building['address']['fm-address-line-1'].to_s + (@building['address']['fm-address-line-1'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-line-2'].to_s + (@building['address']['fm-address-line-2'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-town'].to_s + (@building['address']['fm-address-town'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-county'].to_s + (@building['address']['fm-address-county'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-postcode'].to_s %>
@@ -59,7 +59,7 @@
       </tr>
 
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_region_nuts') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_region_nuts') %></th>
         <td>
           <% if !@building['address'].blank? %>
             <%= @building['address']['fm-address-region'].to_s %>
@@ -76,7 +76,7 @@
 
 
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_gia') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_gia') %></th>
         <td>
           <% if !@building['gia'].blank? %><%=number_with_delimiter(@building['gia'], :delimiter => ',') + " sqm"  %>
           <% else %>
@@ -88,7 +88,7 @@
           <% end %></td>
       </tr>
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_type') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_type') %></th>
         <td>
           <% if !@building['building-type'].blank? %><%= @building['building-type'] %>
           <% else %>
@@ -100,7 +100,7 @@
           <% end %></td>
       </tr>
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_sec') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_sec') %></th>
         <td>
           <% if !@building['security-type'].blank? %>
             <%= @building['security-type'].capitalize %>

--- a/app/views/facilities_management/beta/buildings_management/_building_details_summary.html.erb
+++ b/app/views/facilities_management/beta/buildings_management/_building_details_summary.html.erb
@@ -5,7 +5,7 @@
     <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
   </form>
   <div class="govuk-table" data-module="table" id="buildings-list">
-    <table class="govuk-!-width-three-quarters" style="border-collapse: collapse;">
+    <table class="govuk-!-width-one-half" style="border-collapse: collapse;">
       <tr>
         <th></th>
         <td></td>

--- a/app/views/facilities_management/beta/buildings_management/_building_details_summary.html.erb
+++ b/app/views/facilities_management/beta/buildings_management/_building_details_summary.html.erb
@@ -28,7 +28,7 @@
         </td>
       </tr>
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_desc') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_desc') %></th>
         <td>
           <% if !@building['description'].blank? %>
             <%= @building['description'] %>
@@ -43,7 +43,7 @@
         </td>
       </tr>
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_addr') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_addr') %></th>
         <td>
           <% if !@building['address'].blank? %>
             <% address = @building['address']['fm-address-line-1'].to_s + (@building['address']['fm-address-line-1'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-line-2'].to_s + (@building['address']['fm-address-line-2'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-town'].to_s + (@building['address']['fm-address-town'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-county'].to_s + (@building['address']['fm-address-county'].to_s.length > 0 ? ', ' : ' ') + @building['address']['fm-address-postcode'].to_s %>
@@ -59,7 +59,7 @@
       </tr>
 
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_region_nuts') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_region_nuts') %></th>
         <td>
           <% if !@building['address'].blank? %>
             <%= @building['address']['fm-address-region'].to_s %>
@@ -76,7 +76,7 @@
 
 
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_gia') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_gia') %></th>
         <td>
           <% if !@building['gia'].blank? %><%=number_with_delimiter(@building['gia'], :delimiter => ',') + " sqm"  %>
           <% else %>
@@ -88,7 +88,7 @@
           <% end %></td>
       </tr>
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_type') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_type') %></th>
         <td>
           <% if !@building['building-type'].blank? %><%= @building['building-type'] %>
           <% else %>
@@ -100,7 +100,7 @@
           <% end %></td>
       </tr>
       <tr>
-        <th><%= t('facilities_management.beta.building-details-summary.caption_sec') %></th>
+        <th class="govuk-!-width-one-third"><%= t('facilities_management.beta.building-details-summary.caption_sec') %></th>
         <td>
           <% if !@building['security-type'].blank? %>
             <%= @building['security-type'].capitalize %>


### PR DESCRIPTION
Changed the table size from three-quarters to a half on the building summary details, ensures that there's no unnecessary large space for when trying to change the GIA 