### PR TITLE
bug/FM-657 service information fix

### DIFF
--- a/app/controllers/concerns/further_competition_concern.rb
+++ b/app/controllers/concerns/further_competition_concern.rb
@@ -8,7 +8,7 @@ module FurtherCompetitionConcern
     @report = FacilitiesManagement::SummaryReport.new(@start_date, user_email, TransientSessionInfo[session.id], @procurement)
 
     if @procurement
-      @selected_buildings = @procurement.procurement_buildings.active
+      @selected_buildings = @procurement.active_procurement_buildings
     else
       @selected_buildings = CCS::FM::Building.buildings_for_user(user_email)
       uvals = @report.uom_values(selected_buildings)

--- a/app/controllers/facilities_management/beta/procurements_controller.rb
+++ b/app/controllers/facilities_management/beta/procurements_controller.rb
@@ -419,7 +419,7 @@ module FacilitiesManagement
         @page_data[:estimated_cost] = @procurement.assessed_value
         @page_data[:selected_sublot] = @procurement.lot_number
         @page_data[:buildings] = @active_procurement_buildings.map { |b| b[:name] }
-        @page_data[:services] = @procurement.procurement_building_services.where(facilities_management_procurement_building_id: @active_procurement_buildings).map { |s| s[:name] }
+        @page_data[:services] = @procurement.procurement_building_services.map { |s| s[:name] }
         @page_data[:supplier_prices] = @procurement.procurement_suppliers.map(&:direct_award_value)
       end
 

--- a/app/controllers/facilities_management/beta/summary_controller.rb
+++ b/app/controllers/facilities_management/beta/summary_controller.rb
@@ -69,11 +69,8 @@ module FacilitiesManagement
 
         @report = SummaryReport.new(@start_date, user_email, TransientSessionInfo[session.id], @procurement)
 
-        # @procurement.procurement_buildings.first.procurement_building_services
         if @procurement
-          @selected_buildings = @procurement.procurement_buildings.active
-          # uvals = @procurement.procurement_buildings.first.procurement_building_services
-          # uvals = nil
+          @selected_buildings = @procurement.active_procurement_buildings
         else
           @selected_buildings = CCS::FM::Building.buildings_for_user(user_email)
           uvals = @report.uom_values(selected_buildings)

--- a/app/models/concerns/procurement_validator.rb
+++ b/app/models/concerns/procurement_validator.rb
@@ -141,15 +141,15 @@ module ProcurementValidator
     end
 
     def at_least_one_building
-      errors.add(:procurement_buildings, :not_present) if procurement_buildings.active.none?
+      errors.add(:procurement_buildings, :not_present) if active_procurement_buildings.none?
     end
 
     def at_least_one_service_per_building
-      errors.add(:base, :services_not_present) if procurement_buildings.active.none? || procurement_buildings.active.map(&:procurement_building_services).flatten.none?
+      errors.add(:base, :services_not_present) if active_procurement_buildings.none? || procurement_building_services.none?
     end
 
     def all_services_valid
-      procurement_buildings.active.each do |pb|
+      active_procurement_buildings.each do |pb|
         pb.errors.add(:base, :services_invalid) unless pb.valid?(:procurement_building_services)
       end
     end

--- a/app/models/facilities_management/procurement.rb
+++ b/app/models/facilities_management/procurement.rb
@@ -12,7 +12,8 @@ module FacilitiesManagement
     before_save :update_procurement_building_services, if: :service_codes_changed?
 
     has_many :procurement_buildings, foreign_key: :facilities_management_procurement_id, inverse_of: :procurement, dependent: :destroy
-    has_many :procurement_building_services, through: :procurement_buildings
+    has_many :active_procurement_buildings, -> { where(active: true) }, foreign_key: :facilities_management_procurement_id, class_name: 'FacilitiesManagement::ProcurementBuilding', inverse_of: :procurement, dependent: :destroy
+    has_many :procurement_building_services, through: :active_procurement_buildings
     accepts_nested_attributes_for :procurement_buildings, allow_destroy: true
 
     has_many :procurement_suppliers, foreign_key: :facilities_management_procurement_id, inverse_of: :procurement, dependent: :destroy
@@ -190,11 +191,7 @@ module FacilitiesManagement
     end
 
     def valid_services?
-      active_procurement_buildings.map(&:procurement_building_services).any? && active_procurement_buildings.all? { |p| p.valid?(:procurement_building_services) }
-    end
-
-    def active_procurement_buildings
-      procurement_buildings.active
+      procurement_building_services.any? && active_procurement_buildings.all? { |p| p.valid?(:procurement_building_services) }
     end
 
     def save_eligible_suppliers_and_set_state

--- a/app/services/facilities_management/procurement_router.rb
+++ b/app/services/facilities_management/procurement_router.rb
@@ -68,7 +68,7 @@ class FacilitiesManagement::ProcurementRouter
       return QUICK_SEARCH_EDIT_STEPS.include?(@step) ? edit_facilities_management_beta_procurement_path(id: @id) : facilities_management_beta_procurements_path
     end
     return edit_facilities_management_beta_procurement_path(id: @id, step: previous_step) if @step == 'services'
-    return facilities_management_beta_procurement_building_path(FacilitiesManagement::Procurement.find_by(id: @id).procurement_buildings.first) if @step == 'building_services'
+    return facilities_management_beta_procurement_building_path(FacilitiesManagement::Procurement.find_by(id: @id).active_procurement_buildings.first) if @step == 'building_services'
 
     next_step.nil? ? facilities_management_beta_procurement_path(id: @id) : edit_facilities_management_beta_procurement_path(id: @id, step: next_step)
   end

--- a/app/views/facilities_management/beta/procurements/edit/_building_services.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit/_building_services.html.erb
@@ -10,7 +10,7 @@
     <div id="root" class="pane root-pane">
       <h2 class="govuk-heading-m" tabindex="-1"><%= t('.your_buildings') %></h2>
       <ul>
-        <% f.object.procurement_buildings.active.each_with_index do |building, i| %>
+        <% f.object.active_procurement_buildings.each_with_index do |building, i| %>
           <li class="<%= 'active' if i == 0 %>">
             <a id="<%= 'building-' + building.id %>" class="building-button govuk-!-font-size-19" href="#"><%= building.name %>
               <strong class="<%= 'building-services-' + building.id %>">(0 selected)</strong></a>
@@ -23,7 +23,7 @@
       <%= f.fields_for :procurement_buildings do |procurement_building| %>
         <% if procurement_building.object.active %>
           <%= procurement_building.hidden_field :name, value: procurement_building.object.name %>
-          <div id="<%= 'building-services-' + procurement_building.object.id %>" class="pane-inner services-pane <%= 'hidden-pane' if procurement_building.object.id != f.object.procurement_buildings.active.first.id %>">
+          <div id="<%= 'building-services-' + procurement_building.object.id %>" class="pane-inner services-pane <%= 'hidden-pane' if procurement_building.object.id != f.object.active_procurement_buildings.first.id %>">
             <div class="govuk-form-group <%= 'govuk-form-group--error' if procurement_building.object.errors.any? %>">
               <h2 tabindex="-1" class="govuk-heading-m govuk-!-margin-top-7">Choose from <%= @services.count %>
                 services</h2>


### PR DESCRIPTION
- When calling procurement_building_services from procurement, we always get the ones from active procurement_buildings
- Procurement router fixed to redirect to the first active_procurement_building (not procurement_building) on the services step
- Also some quick refactoring