### PR TITLE
copy edit mobilisation start date error message

### DIFF
--- a/app/assets/javascripts/facilities_management/beta/procurement/contract_dates.js
+++ b/app/assets/javascripts/facilities_management/beta/procurement/contract_dates.js
@@ -320,12 +320,12 @@ $(function () {
                             message = "Mobilisation period must be a minimum of 4 weeks when TUPE is selected";
                             break;
                         case "min":
-                            message = "Mobilisation start date must be today or in the future";
+                            message = "Mobilisation start date must be in the future";
                             break;
                     }
                     break;
                 case "Mobilisation start date":
-                    message = "Mobilisation start date must be today or in the future";
+                    message = "Mobilisation start date must be in the future";
                     break;
 
                 default:

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -118,7 +118,7 @@ en:
               not_an_integer: Enter mobilisation length as a whole number
               not_valid_with_tupe: Mobilisation length must be a minimum of 4 weeks when TUPE is selected
             mobilisation_start_date:
-              greater_than: Mobilisation start date must be today or in the future
+              greater_than: Mobilisation start date must be in the future
             name:
               blank: Enter the name for the search
               invalid: Search name must only include letters a to z, numbers, hyphens, spaces and apostrophes


### PR DESCRIPTION
mobilisation start date error now says "Mobilisation start date must be in the future" - not "today or in the future"