### PR TITLE
FM-811-fix-for-dashboard-link-and-breadcrum

### DIFF
--- a/app/views/facilities_management/beta/admin/supplier_rates/supplier_benchmark_rates.erb
+++ b/app/views/facilities_management/beta/admin/supplier_rates/supplier_benchmark_rates.erb
@@ -3,7 +3,7 @@
     <li class="govuk-breadcrumbs__list-item">
       <a class="govuk-breadcrumbs__link" href="<%= facilities_management_beta_admin_path %>">Home</a>
     </li>
-    <li class="govuk-breadcrumbs__list-item" aria-current="page"><%= t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.leading_text') %></li>
+    <li class="govuk-breadcrumbs__list-item" aria-current="page"><%= t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.heading_title') %></li>
   </ol>
 </div>
 <h1 class="govuk-heading-xl"><%= t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.heading_title') %></h1>
@@ -80,8 +80,8 @@
 
 
 
-  <h3 class="govuk-heading-xl govuk-!-font-weight-bold"><%= t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.heading_title_two') %></h3>
-  <p class="govuk-body govuk-body govuk-brand-light-grey-benchmark">
+  <h3 class="govuk-heading-xl govuk-!-font-weight-bold govuk-!-margin-bottom-2"><%= t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.heading_title_two') %></h3>
+  <p class="govuk-body govuk-brand-light-grey-benchmark">
     <%= t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.benchmark_text') %>
   </p>
   

--- a/app/views/facilities_management/beta/admin/supplier_rates/supplier_framework_rates.erb
+++ b/app/views/facilities_management/beta/admin/supplier_rates/supplier_framework_rates.erb
@@ -56,7 +56,7 @@
 
 
 
-  <h3 class="govuk-heading-xl govuk-!-font-weight-bold"><%= t('facilities_management.beta.admin.supplier_rates.supplier_framework_rates.heading_title_two') %></h3>
+  <h3 class="govuk-heading-xl govuk-!-font-weight-bold govuk-!-margin-bottom-2"><%= t('facilities_management.beta.admin.supplier_rates.supplier_framework_rates.heading_title_two') %></h3>
 
     <table class="govuk-table">
       <thead class="govuk-table__head">

--- a/app/views/layouts/admin/_header-banner.html.erb
+++ b/app/views/layouts/admin/_header-banner.html.erb
@@ -3,7 +3,7 @@
   <%= render 'layouts/admin/header-title', service: 'admin_account', path: facilities_management_admin_start_path %>
   <nav>
     <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-      <%= render 'layouts/admin/header-dashboard-link', admin_dashboard_path: facilities_management_beta_admin_path %>
+      <%= render 'layouts/admin/header-dashboard-link', admin_dashboard_path: facilities_management_beta_admin_path %> 
       <%= render 'layouts/sign-out-link', sign_out_path: facilities_management_beta_admin_destroy_user_session_path %>
     </ul>
   </nav>

--- a/app/views/layouts/admin/_header-dashboard-link.html.erb
+++ b/app/views/layouts/admin/_header-dashboard-link.html.erb
@@ -1,4 +1,4 @@
-  <% if !current_page?(url_for(:controller => 'admin_account', :action => 'admin_account')) %>
+  <% if user_signed_in? && request.original_fullpath != facilities_management_beta_admin_path %>
     <li class="govuk-header__navigation-item">
       <%= link_to 'Admin dashboard', admin_dashboard_path, class: 'govuk-header__link ccs-header__dashboard' %>
     </li>


### PR DESCRIPTION
Fixes for spacing issues and admin header link appearing even if user is logged out.