### PR TITLE
FM-874 Trigger Contract Sent Reminder

### DIFF
--- a/app/workers/facilities_management/contract_sent_reminder.rb
+++ b/app/workers/facilities_management/contract_sent_reminder.rb
@@ -1,0 +1,11 @@
+module FacilitiesManagement
+  class ContractSentReminder
+    include Sidekiq::Worker
+    sidekiq_options queue: 'fm', retry: true
+
+    def perform(id)
+      contract = FacilitiesManagement::ProcurementSupplier.find(id)
+      contract.send_reminder_email if contract.aasm_state == 'sent'
+    end
+  end
+end

--- a/spec/models/facilities_management/procurement_spec.rb
+++ b/spec/models/facilities_management/procurement_spec.rb
@@ -502,6 +502,7 @@ RSpec.describe FacilitiesManagement::Procurement, type: :model do
       before do
         allow(obj).to receive(:sorted_list).and_return([[:test, da_value_test2], [:test1, da_value_test], [:test2, da_value_test3], [:test3, da_value_test1]])
         allow(FacilitiesManagement::ChangeStateWorker).to receive(:perform_at).and_return(nil)
+        allow(FacilitiesManagement::ContractSentReminder).to receive(:perform_at).and_return(nil)
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(FacilitiesManagement::ProcurementSupplier).to receive(:send_email_to_supplier).and_return(nil)
         # rubocop:enable RSpec/AnyInstance


### PR DESCRIPTION
- Create worker to send reminder email
- Add method to trigger worker in the procurement_supplier model
- Create tests for the time_delta_in_days
- Add stup to procurement_spec
- Update the method to us perform_at
- Update the method so that it works
- Added method to check worker is called