### PR TITLE
FM-857: Fix supplier query and filter

### DIFF
--- a/app/assets/javascripts/facilities_management/beta/procurement/QuickSearchResultsAssistant.js
+++ b/app/assets/javascripts/facilities_management/beta/procurement/QuickSearchResultsAssistant.js
@@ -13,6 +13,17 @@ const QuickSearchResultsAssistant = {
         this.helper.init();
         this.helper.UpdateCounts();
         this.helper.ConnectCheckboxes(this.FilterSuppliers.bind(this));
+
+        // Filter the list of suppliers
+        let filterEvent = {
+            FilterTarget: this.helper.getFilterTarget()
+        };
+        this.helper._filterHelper.forEach(function (x) {
+            let propertyName = x._sectionName;
+            let selectedCheckboxes = x.GetSelectedCheckboxes();
+            filterEvent[propertyName + "_checkboxes"] = selectedCheckboxes;
+        });
+        this.FilterSuppliers(filterEvent);
     },
     FilterSuppliers : function(filterEvent) {
         let tableSource = filterEvent.FilterTarget.jqueryObject;
@@ -36,11 +47,11 @@ const QuickSearchResultsAssistant = {
                     operationalRegions = JSON.parse(operationalRegions);
                     let serviceOfferings = JSON.parse($(id).attr('servicecode'));
 
-                    let isServiceOfferingSelected = selectedServices.some(function (selectedService) {
+                    let isServiceOfferingSelected = selectedServices.every(function (selectedService) {
                         return serviceOfferings.includes(selectedService.code.replace('-', '.'));
                     });
 
-                    let isOperationalAreaSelected = selectedLocations.some(function (selectedLocation) {
+                    let isOperationalAreaSelected = selectedLocations.every(function (selectedLocation) {
                         return operationalRegions.includes(selectedLocation.code);
                     });
 

--- a/app/models/ccs/fm/supplier.rb
+++ b/app/models/ccs/fm/supplier.rb
@@ -24,9 +24,9 @@ module CCS
       def self.selected_suppliers(for_lot, for_regions, for_services)
         CCS::FM::Supplier.all.select do |s|
           s.data['lots'].find do |l|
-            l['lot_number'] == for_lot && 
-              l['regions'].any? { |r| for_regions.include?(r) } &&
-              l['services'].any? { |s| for_services.include?(s) }
+            l['lot_number'] == for_lot &&
+              l['regions'].any? { |reg| for_regions.include?(reg) } &&
+              l['services'].any? { |ser| for_services.include?(ser) }
           end
         end
       end

--- a/app/models/ccs/fm/supplier.rb
+++ b/app/models/ccs/fm/supplier.rb
@@ -24,8 +24,9 @@ module CCS
       def self.selected_suppliers(for_lot, for_regions, for_services)
         CCS::FM::Supplier.all.select do |s|
           s.data['lots'].find do |l|
-            # ([2, 6, 13, 99, 27] & [2, 6]).any?
-            (for_regions - l['regions']).empty? && (for_services - l['services']).empty? if l['lot_number'] == for_lot
+            l['lot_number'] == for_lot && 
+              l['regions'].any? { |r| for_regions.include?(r) } &&
+              l['services'].any? { |s| for_services.include?(s) }
           end
         end
       end

--- a/spec/models/ccs/fm/supplier_spec.rb
+++ b/spec/models/ccs/fm/supplier_spec.rb
@@ -6,19 +6,29 @@ RSpec.describe CCS::FM::Supplier, type: :model do
 
     before do
       [
-        { lots: [ { lot_number: lot, regions: %w{r0 r1 r2}, services: %w{s0 s1 s2} } ] },
-        { lots: [ { lot_number: lot, regions: %w{r0 r3 r4}, services: %w{s0 s3 s4} } ] },
-        { lots: [ { lot_number: lot, regions: %w{r0 r5 r6}, services: %w{s0 s5 s6} } ] }
+        { lots: [{ lot_number: lot, regions: %w[r0 r1 r2], services: %w[s0 s1 s2] }] },
+        { lots: [{ lot_number: lot, regions: %w[r0 r3 r4], services: %w[s0 s3 s4] }] },
+        { lots: [{ lot_number: lot, regions: %w[r0 r5 r6], services: %w[s0 s5 s6] }] }
       ].each do |data|
         FactoryBot.create(:ccs_fm_supplier, data: data)
       end
     end
 
-    it 'selects suppliers for a given lot, containing ANY specified regions AND ANY specified services' do
-      expect(CCS::FM::Supplier.selected_suppliers(lot, %w{r0}, %w{s0}).count).to eq 3
-      expect(CCS::FM::Supplier.selected_suppliers(lot, %w{r0}, %w{s1}).count).to eq 1
-      expect(CCS::FM::Supplier.selected_suppliers(lot, %w{r1}, %w{s1}).count).to eq 1
-      expect(CCS::FM::Supplier.selected_suppliers(lot, %w{r6}, %w{s0}).count).to eq 1
+    it 'selects suppliers containing ANY specified regions' do
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w[r0], %w[s0]).count).to eq 3
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w[r1 r3], %w[s0]).count).to eq 2
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w[r5], %w[s0]).count).to eq 1
+    end
+
+    it 'selects suppliers containing ANY specified services' do
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w[r0], %w[s0]).count).to eq 3
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w[r0], %w[s1 s3]).count).to eq 2
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w[r0], %w[s5]).count).to eq 1
+    end
+
+    it 'selects suppliers where BOTH region and service selections overlap' do
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w[r0], %w[s1]).count).to eq 1
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w[r1], %w[s0]).count).to eq 1
     end
   end
 end

--- a/spec/models/ccs/fm/supplier_spec.rb
+++ b/spec/models/ccs/fm/supplier_spec.rb
@@ -1,12 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe CCS::FM::Supplier, type: :model do
-  it 'can select suppliers for a given lot, regions and services' do
-    for_lot = '1a'
-    for_regions = ['UKC1', 'UKM21']
-    for_services = ['C.1', 'L.1']
-    vals = CCS::FM::Supplier.selected_suppliers(for_lot, for_regions, for_services)
+  describe '.selected_suppliers' do
+    let(:lot) { '1a' }
 
-    expect(vals.count).to be > 0
+    before do
+      [
+        { lots: [ { lot_number: lot, regions: %w{r0 r1 r2}, services: %w{s0 s1 s2} } ] },
+        { lots: [ { lot_number: lot, regions: %w{r0 r3 r4}, services: %w{s0 s3 s4} } ] },
+        { lots: [ { lot_number: lot, regions: %w{r0 r5 r6}, services: %w{s0 s5 s6} } ] }
+      ].each do |data|
+        FactoryBot.create(:ccs_fm_supplier, data: data)
+      end
+    end
+
+    it 'selects suppliers for a given lot, containing ANY specified regions AND ANY specified services' do
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w{r0}, %w{s0}).count).to eq 3
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w{r0}, %w{s1}).count).to eq 1
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w{r1}, %w{s1}).count).to eq 1
+      expect(CCS::FM::Supplier.selected_suppliers(lot, %w{r6}, %w{s0}).count).to eq 1
+    end
   end
 end


### PR DESCRIPTION
Fetch suppliers having ANY of the selected regions and services rather than ALL. Filter displayed suppliers having ALL selected regions and services rather than ANY. Apply this filter on page load as well as filter change.