### PR TITLE
Create a copy of a procurement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,9 @@ gem 'notifications-ruby-client'
 # DOCX generation
 gem 'caracal-rails'
 
+# duplicating procurements
+gem 'amoeba'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.0.1)
+    amoeba (3.1.0)
+      activerecord (>= 3.2.6)
     arel (9.0.0)
     ast (2.4.0)
     attr_required (1.0.1)
@@ -511,6 +513,7 @@ DEPENDENCIES
   active_storage_validations
   activerecord-import (~> 0.15.0)
   activerecord-postgis-adapter
+  amoeba
   aws-sdk-cognitoidentityprovider (~> 1.23.0)
   aws-sdk-s3 (~> 1)
   axlsx!

--- a/app/assets/javascripts/facilities_management/beta/contract/contract_forms.js
+++ b/app/assets/javascripts/facilities_management/beta/contract/contract_forms.js
@@ -7,7 +7,7 @@ $(function () {
     }
     
     // Check if on a procurement supplier page
-    if ($(".edit_facilities_management_procurement_supplier").length) {
+    if ($("#facilities_management_contract").length) {
         if ($(".edit_facilities_management_procurement_supplier").length) {
             let textArea = document.getElementsByTagName("textarea")[0].id;
             let maxLength = parseInt($("#" + textArea).attr("maxLength"), 10);

--- a/app/assets/javascripts/facilities_management/beta/contract/copy_procurement.js
+++ b/app/assets/javascripts/facilities_management/beta/contract/copy_procurement.js
@@ -1,0 +1,22 @@
+/*global FM */
+$(function () {
+
+    function putCharsLeft(value, maxLength) {
+        let charsLeft = FM.calcCharsLeft(value, maxLength);
+        $("#facilities_management_procurement_supplier_character_left").text("You have " + charsLeft + " characters remaining");
+    }
+
+    // Check if on a procurement supplier page
+    if ($("#facilities_management_contract").length) {
+        console.log('im on');
+        let textField = document.getElementById("facilities_management_procurement_contract_name");
+        let maxLength = parseInt($(textField).attr("maxLength"), 10);
+
+        putCharsLeft(textField.value, maxLength);
+
+        $(textField).on("keyup", function(e) {
+            let value = e.target.value;
+            putCharsLeft(value, maxLength);
+        });
+    }
+});

--- a/app/controllers/facilities_management/beta/procurements/copy_procurement_controller.rb
+++ b/app/controllers/facilities_management/beta/procurements/copy_procurement_controller.rb
@@ -1,0 +1,46 @@
+module FacilitiesManagement
+  module Beta
+    module Procurements
+      class CopyProcurementController < FacilitiesManagement::Beta::FrameworkController
+        include FacilitiesManagement::ControllerLayoutHelper
+        include FacilitiesManagement::Beta::Procurements::CopyProcurementHelper
+
+        before_action :set_procurement_data
+        before_action :set_contract_data
+        before_action :duplicate_procurement
+        before_action :set_page_detail
+
+        def new; end
+
+        def create
+          @procurement_copy.assign_attributes(procurement_params)
+          if @procurement_copy.save(context: :contract_name)
+            redirect_to facilities_management_beta_procurement_path(@procurement_copy.id)
+          else
+            @errors = @procurement.errors
+            set_procurement_data
+            render :new
+          end
+        end
+
+        private
+
+        def set_procurement_data
+          @procurement = current_user.procurements.find_by(id: params[:procurement_id])
+        end
+
+        def set_contract_data
+          @contract = @procurement.procurement_suppliers.find_by(id: params[:contract_id])
+        end
+
+        def duplicate_procurement
+          @procurement_copy = @procurement.create_procurement_copy
+        end
+
+        def procurement_params
+          params.require(:facilities_management_procurement).permit(:contract_name)
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/facilities_management/beta/procurements/copy_procurement_helper.rb
+++ b/app/helpers/facilities_management/beta/procurements/copy_procurement_helper.rb
@@ -1,0 +1,23 @@
+module FacilitiesManagement::Beta::Procurements::CopyProcurementHelper
+  include FacilitiesManagement::Beta::ProcurementsHelper
+
+  def page_details(*)
+    @page_details ||= page_definitions[:default].merge(page_definitions[:new])
+  end
+
+  def page_definitions
+    @page_definitions ||= {
+      default: {},
+      new: {
+        page_title: 'Create a copy',
+        caption1: @procurement.contract_name,
+        continuation_text: 'Save and contiue',
+        secondary_text: 'Cancel',
+        secondary_url: facilities_management_beta_procurement_contract_path(procurement_id: @procurement.id, id: @contract.id),
+        back_text: 'Back',
+        back_name: 'Back',
+        back_url: facilities_management_beta_procurement_contract_path(procurement_id: @procurement.id, id: @contract.id)
+      },
+    }.freeze
+  end
+end

--- a/app/models/facilities_management/procurement.rb
+++ b/app/models/facilities_management/procurement.rb
@@ -44,6 +44,24 @@ module FacilitiesManagement
     attribute :route_to_market
     validates :route_to_market, inclusion: { in: %w[da_draft further_competition] }, on: :route_to_market
 
+    # For making a copy of a procurement
+    amoeba do
+      exclude_association :procurement_suppliers
+      exclude_association :active_procurement_buildings
+    end
+
+    def create_procurement_copy
+      procurement_copy = amoeba_dup
+      procurement_copy.contract_name = nil
+      procurement_copy.aasm_state = 'detailed_search'
+      procurement_copy.da_journey_state = 'pricing'
+      if security_policy_document_required
+        procurement_copy.security_policy_document_file = nil
+        procurement_copy.security_policy_document_file.attach(security_policy_document_file.blob)
+      end
+      procurement_copy
+    end
+
     def before_each_procurement_pension_funds(new_pension_fund)
       new_pension_fund.case_sensitive_error = false
       procurement_pension_funds.each do |saved_pension_fund|

--- a/app/models/facilities_management/procurement_building.rb
+++ b/app/models/facilities_management/procurement_building.rb
@@ -14,6 +14,10 @@ module FacilitiesManagement
     before_validation :cleanup_service_codes
     after_save :update_procurement_building_services
 
+    amoeba do
+      include_association :procurement_building_services
+    end
+
     def full_address
       "#{address_line_1 + ', ' if address_line_1.present?}
       #{address_line_2 + ', ' if address_line_2.present?}

--- a/app/views/ccs_patterns/prototype/create_a_copy.html.erb
+++ b/app/views/ccs_patterns/prototype/create_a_copy.html.erb
@@ -9,7 +9,7 @@
               </ul>
           </div>
         <div>
-          <div class="govuk-!-width-one-half govuk-!-margin-bottom-6"</div>
+          <div class="govuk-!-width-one-half govuk-!-margin-bottom-6">
             <div class="govuk-form-group">
               <label class="govuk-heading-m govuk-!-font-weight-bold govuk-!-margin-bottom-3">
                 What do you want to call your contract?

--- a/app/views/facilities_management/beta/procurements/_about_the_work.html.erb
+++ b/app/views/facilities_management/beta/procurements/_about_the_work.html.erb
@@ -3,13 +3,13 @@
   <tbody class="govuk-table__body">
   <tr class="govuk-table__row">
     <th scope="row" class="govuk-table__header govuk-!-font-size-24" width="30%">About the work</th>
-    <td class="govuk-table__cell">
+    <td class="govuk-table__cell" width="45%">
     </td>
-    <td class="govuk-table__cell">
+    <td class="govuk-table__cell" width="25%">
     </td>
   </tr>
   <tr class="govuk-table__row <%= 'govuk-no-border govuk-form-group--error' if @procurement.errors[:procurement_buildings].any? %>">
-    <th scope="row" class="govuk-table__header govuk-!-font-size-18 <%= 'govuk-!-padding-left-2' if @procurement.errors[:procurement_buildings].any? %>" width="30%"> 1. Buildings</th>
+    <th scope="row" class="govuk-table__header govuk-!-font-size-18 <%= 'govuk-!-padding-left-2' if @procurement.errors[:procurement_buildings].any? %>"> 1. Buildings</th>
     <% if @active_procurement_buildings.any? %>
 
       <td class="govuk-table__cell">

--- a/app/views/facilities_management/beta/procurements/_results.html.erb
+++ b/app/views/facilities_management/beta/procurements/_results.html.erb
@@ -21,20 +21,24 @@
   <% end %>
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-width-two-thirds"/>
   <h2 class="govuk-heading govuk-heading-m"><%= t('.building_services_summary') %></h2>
-  <%= govuk_details "#{'Building'.pluralize(@page_data[:buildings].length)} (#{@page_data[:buildings].length})" do %>
-    <ul>
-      <% @page_data[:buildings].each do |b| %>
-        <li><%= b %></li>
-      <% end %>
-    </ul>
-  <% end %>
-  <%= govuk_details "#{'Service'.pluralize(@page_data[:services].uniq.length)} (#{@page_data[:services].uniq.length})" do %>
-    <ul>
-      <% @page_data[:services].uniq.each do |s| %>
-        <li><%= s %></li>
-      <% end %>
-    </ul>
-  <% end %>
+  <div class="govuk-!-margin-bottom-4">
+    <%= govuk_details "#{'Building'.pluralize(@page_data[:buildings].length)} (#{@page_data[:buildings].length})", true do %>
+      <ul class="govuk-list govuk-list--bullet">
+        <% @page_data[:buildings].each do |b| %>
+          <li><%= b %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+  <div>
+    <%= govuk_details "#{'Service'.pluralize(@page_data[:services].uniq.length)} (#{@page_data[:services].uniq.length})", true do %>
+      <ul class="govuk-list govuk-list--bullet">
+        <% @page_data[:services].uniq.each do |s| %>
+          <li><%= s %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-width-two-thirds"/>
   <%= form_for @procurement, url: facilities_management_beta_procurement_path(@procurement.id), method: :patch, html: { specialvalidation: false, novalidate: true, multipart: true } do |f| %>
     <%= govuk_grouped_field(f, t('.available_routes_to_market'), :route_to_market) do |ff, attr| %>

--- a/app/views/facilities_management/beta/procurements/contracts/_closing_direct_award_offer.html.erb
+++ b/app/views/facilities_management/beta/procurements/contracts/_closing_direct_award_offer.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-!-width-three-quarters">
+<div id="facilities_management_contract" class="govuk-!-width-three-quarters">
     <h1 class="govuk-heading govuk-heading-m govuk-!-margin-bottom-5">
         <%= t('.are_you_sure_1') %> '<%= @procurement[:contract_name] %>' (<%= @contract[:contract_number] %>) <%= t('.are_you_sure_2') %>
     </h1>

--- a/app/views/facilities_management/beta/procurements/contracts/_create_a_copy.html.erb
+++ b/app/views/facilities_management/beta/procurements/contracts/_create_a_copy.html.erb
@@ -1,3 +1,0 @@
-<h1 class = 'govuk-heading-xl'>
-    Create a copy
-</h1>

--- a/app/views/facilities_management/beta/procurements/contracts/show.html.erb
+++ b/app/views/facilities_management/beta/procurements/contracts/show.html.erb
@@ -51,7 +51,7 @@
                 </div>
             <% end %>
         <% else %>
-            <%= link_to(pd.navigation_details.secondary_text, edit_facilities_management_beta_procurement_contract_path(id: @contract.id, name: 'copy'), role: 'button', class: 'govuk-button govuk-button--secondary') %>
+            <%= link_to(pd.navigation_details.secondary_text, new_facilities_management_beta_procurement_contract_copy_procurement_path(id: @procurement.id, contract_id: @contract.id), role: 'button', class: 'govuk-button govuk-button--secondary') %>
             <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-caption-m') %>
         <% end %>
     <% end %>

--- a/app/views/facilities_management/beta/procurements/copy_procurement/new.html.erb
+++ b/app/views/facilities_management/beta/procurements/copy_procurement/new.html.erb
@@ -1,0 +1,26 @@
+<%= govuk_page_content(@page_description, @procurement_copy) do |pd|%>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-4">
+        Create a new procurement using the service requirements and buildings you have previously entered.
+    </h1>
+    <div>
+        <p class="govuk-body-m govuk-!-width-one-half govuk-!-margin-bottom-3">Once saved under a new contract name:</p>
+        <ul class="govuk-list govuk-!-width-one-half govuk-list--bullet govuk-!-margin-bottom-6">
+            <li>you will have the option to amend your requirements (if needed), and re-run your results</li>
+            <li>you will be able to choose from the contract options of direct award (if eligible) or further competition</li>
+        </ul>
+    </div>
+    <%=form_for @procurement_copy, url: facilities_management_beta_procurement_contract_copy_procurement_index_path, method: :post do |f, attr|%>
+        <div id="facilities_management_contract" class="govuk-form-group govuk-!-width-one-half govuk-!-margin-bottom-6 <%= 'govuk-form-group--error' if @procurement_copy.errors.any?  %>">
+            <%= f.label :contract_name, ' What do you want to call your contract?', class: 'govuk-heading-m' %>
+            <%= display_errors @procurement_copy, :contract_name %>
+            <%= f.text_field :contract_name, class: 'govuk-input', maxlength: 100, id: 'facilities_management_procurement_contract_name' %>
+            <span id="facilities_management_procurement_supplier_character_left" class="govuk-hint govuk-character-count__message" aria-live="polite">
+                You have 100 characters remaining
+            </span>
+        </div>
+        <%= f.submit pd.navigation_details.primary_text, class: 'govuk-button govuk-!-margin-right-4' %>
+        <%= link_to pd.navigation_details.secondary_text, pd.navigation_details.secondary_url, class: 'govuk-button govuk-button--secondary' %>
+    <% end %>
+
+
+<% end %>

--- a/app/views/facilities_management/beta/procurements/da_buyer/_did_you_know.html.erb
+++ b/app/views/facilities_management/beta/procurements/da_buyer/_did_you_know.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_page_content(@page_description, @page_data[:model_object]) do |pd| %>
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-!-width-two-thirds">
     <p class="govuk-body-l">
       <%= t('.intro-text') %>
     </p>

--- a/app/views/facilities_management/beta/supplier/contracts/edit.html.erb
+++ b/app/views/facilities_management/beta/supplier/contracts/edit.html.erb
@@ -12,7 +12,7 @@
                 </tr>
             </tbody>
         </table>
-        <div class="govuk-form-group <%= 'govuk-form-group--error' if @contract.errors.any? %>">
+        <div id="facilities_management_contract" class="govuk-form-group <%= 'govuk-form-group--error' if @contract.errors.any? %>">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                 <h1 class="govuk-fieldset__heading"><%= "#{t('.form_title')} #{@procurement.user.buyer_detail.organisation_name}?" %></h1>
             </legend>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,7 @@ Rails.application.routes.draw do
           resources :sent, only: %i[index], controller: 'procurements/contracts/sent'
           resources :closed, only: %i[index], controller: 'procurements/contracts/closed'
           get '/documents/call-off-schedule', to: 'procurements/contracts/documents#call_off_schedule'
+          resources :copy_procurement, only: %i[new create], controller: 'procurements/copy_procurement'
         end
       end
       resources :procurement_buildings, only: %i[show edit update]

--- a/spec/factories/facilities_management_procurement.rb
+++ b/spec/factories/facilities_management_procurement.rb
@@ -31,4 +31,27 @@ FactoryBot.define do
   factory :facilities_management_procurement_no_procurement_buildings, parent: :facilities_management_procurement do
     procurement_buildings { [] }
   end
+
+  factory :facilities_management_procurement_with_contact_details, parent: :facilities_management_procurement_with_extension_periods do
+    aasm_state { 'direct_award' }
+    security_policy_document_required { false }
+    security_policy_document_name { Faker::Name.name }
+    security_policy_document_version_number { 1 }
+    security_policy_document_date { DateTime.now.in_time_zone('London') }
+    lot_number { '1a' }
+    assessed_value { rand(500..5000) }
+    eligible_for_da { true }
+    da_journey_state { 'sent' }
+    payment_method { 'bacs' }
+    route_to_market { 'Direct Award' }
+    using_buyer_detail_for_invoice_details { true }
+    using_buyer_detail_for_notices_detail { false }
+    using_buyer_detail_for_authorised_detail { false }
+    local_government_pension_scheme { true }
+    procurement_pension_funds { build_list :facilities_management_procurement_pension_fund, 3 }
+    invoice_contact_detail { create :facilities_management_procurement_invoice_contact_detail }
+    authorised_contact_detail { create :facilities_management_procurement_authorised_contact_detail }
+    notices_contact_detail { create :facilities_management_procurement_notices_contact_detail }
+    procurement_suppliers { build_list :facilities_management_procurement_supplier, 3 }
+  end
 end

--- a/spec/factories/facilities_management_procurement_contact_detail.rb
+++ b/spec/factories/facilities_management_procurement_contact_detail.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :facilities_management_procurement_contact_detail, class: FacilitiesManagement::ProcurementContactDetail do
-    name { 'MyString' }
-    job_title { 'MyString' }
-    email { 'person@ccs.com' }
-    organisation_address_line_1 { 'MyString' }
-    organisation_address_town { 'MyString' }
-    organisation_address_postcode { 'MyString' }
+    name { Faker::Name.name[1..50] }
+    job_title { Faker::Job.title }
+    email { Faker::Internet.email }
+    organisation_address_line_1 { Faker::Address.street_address }
+    organisation_address_town { Faker::Address.city }
+    organisation_address_postcode { Faker::Address.postcode }
   end
 end

--- a/spec/factories/facilities_management_procurement_pension_funds.rb
+++ b/spec/factories/facilities_management_procurement_pension_funds.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :facilities_management_procurement_pension_fund, class: FacilitiesManagement::ProcurementPensionFund do
-    name { Faker::Name.unique.name[0..150] }
+    name { Faker::Name.unique.name[1..150] }
     percentage { rand(1..100).to_s }
   end
 end

--- a/spec/models/facilities_management/procurement_copy_spec.rb
+++ b/spec/models/facilities_management/procurement_copy_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::Procurement, type: :model do
+  subject(:procurement) { create(:facilities_management_procurement_with_contact_details, user: user) }
+
+  let(:user) { create(:user) }
+
+  before { allow(procurement.security_policy_document_file).to receive(:blob).and_return(filename: Faker::Name.name[1..20]) }
+
+  describe '#create_procurement_copy' do
+    let(:procurement_copy) { procurement.create_procurement_copy }
+
+    context 'when a copy has been made of a procurement with full use of contact details' do
+      context 'when comparing attributes' do
+        it 'will not have a contract name' do
+          expect(procurement_copy.contract_name).to be_nil
+        end
+
+        it 'will have an aasm_state of details_search' do
+          expect(procurement_copy.aasm_state).to eq 'detailed_search'
+        end
+
+        it 'will have a da_journey_state of pricing' do
+          expect(procurement_copy.da_journey_state).to eq 'pricing'
+        end
+
+        it 'will have the same attributes as the procurement' do
+          procurement_attributes = procurement.attributes.except('id', 'aasm_state', 'created_at', 'updated_at', 'contract_name', 'da_journey_state')
+          procurement_copy_attributes = procurement_copy.attributes.except('id', 'aasm_state', 'created_at', 'updated_at', 'contract_name', 'da_journey_state')
+          expect(procurement_copy_attributes).to eq procurement_attributes
+        end
+      end
+
+      context 'when considering procurement buildings' do
+        it 'will have procurement buildings' do
+          expect(procurement_copy.procurement_buildings).not_to be_empty
+        end
+
+        it 'will have the same procurement buildings' do
+          procurement_buildings = procurement.procurement_buildings.map(&:name)
+          procurement_copy_building = procurement_copy.procurement_buildings.map(&:name)
+          expect(procurement_buildings).to eq procurement_copy_building
+        end
+      end
+
+      context 'when considering pension funds' do
+        it 'will have procurement pension funds' do
+          expect(procurement_copy.procurement_pension_funds).not_to be_empty
+        end
+
+        it 'will have the same pension fund attributes as the origional procurement' do
+          procurement_pension_funds = procurement.procurement_pension_funds.map { |pension_fund| { name: pension_fund.name, percentage: pension_fund.percentage } }
+          procurement_copy_pension_funds = procurement_copy.procurement_pension_funds.map { |pension_fund| { name: pension_fund.name, percentage: pension_fund.percentage } }
+          expect(procurement_copy_pension_funds).to eq procurement_pension_funds
+        end
+      end
+
+      context 'when considering contact details' do
+        it 'will have contact details' do
+          expect(procurement_copy.invoice_contact_detail).not_to be_nil
+          expect(procurement_copy.authorised_contact_detail).not_to be_nil
+          expect(procurement_copy.notices_contact_detail).not_to be_nil
+        end
+
+        it 'will have the same invoice contact detail' do
+          procurement_invoice_contact_detail = procurement.invoice_contact_detail.attributes.except('id', 'created_at', 'updated_at', 'facilities_management_procurement_id')
+          procurement_copy_invoice_contact_detail = procurement_copy.invoice_contact_detail.attributes.except('id', 'created_at', 'updated_at', 'facilities_management_procurement_id')
+          expect(procurement_copy_invoice_contact_detail).to eq procurement_invoice_contact_detail
+        end
+
+        it 'will have the same authorised contact detail' do
+          procurement_authorised_contact_detail = procurement.authorised_contact_detail.attributes.except('id', 'created_at', 'updated_at', 'facilities_management_procurement_id')
+          procurement_copy_authorised_contact_detail = procurement_copy.authorised_contact_detail.attributes.except('id', 'created_at', 'updated_at', 'facilities_management_procurement_id')
+          expect(procurement_copy_authorised_contact_detail).to eq procurement_authorised_contact_detail
+        end
+
+        it 'will have the same notices contact detail' do
+          procurement_notices_contact_detail = procurement.notices_contact_detail.attributes.except('id', 'created_at', 'updated_at', 'facilities_management_procurement_id')
+          procurement_copy_notices_contact_detail = procurement_copy.notices_contact_detail.attributes.except('id', 'created_at', 'updated_at', 'facilities_management_procurement_id')
+          expect(procurement_copy_notices_contact_detail).to eq procurement_notices_contact_detail
+        end
+      end
+
+      it 'will not have procurement suppliers' do
+        expect(procurement_copy.procurement_suppliers).to be_empty
+      end
+
+      context 'when considering security policy document file' do
+        it 'will have a file' do
+          expect(procurement_copy.security_policy_document_file).not_to be_nil
+        end
+
+        it 'will have the same file' do
+          expect(procurement_copy.security_policy_document_file.blob).to eq procurement.security_policy_document_file.blob
+        end
+      end
+    end
+
+    context 'when a copy has been made of a procurement without full use of contact details' do
+      let(:second_procurement) { create(:facilities_management_procurement, user: user) }
+      let(:second_procurement_copy) { second_procurement.create_procurement_copy }
+
+      it 'will have the same attributes as the procurement' do
+        procurement_attributes = second_procurement.attributes.except('id', 'aasm_state', 'created_at', 'updated_at', 'contract_name', 'da_journey_state')
+        procurement_copy_attributes = second_procurement_copy.attributes.except('id', 'aasm_state', 'created_at', 'updated_at', 'contract_name', 'da_journey_state')
+        expect(procurement_copy_attributes).to eq procurement_attributes
+      end
+
+      it 'will not have contact details' do
+        expect(second_procurement_copy.invoice_contact_detail).to be_nil
+        expect(second_procurement_copy.authorised_contact_detail).to be_nil
+        expect(second_procurement_copy.notices_contact_detail).to be_nil
+      end
+
+      it 'will not have pension funds' do
+        expect(second_procurement_copy.procurement_pension_funds).to be_empty
+      end
+
+      it 'will have not have a security policy document file' do
+        expect(second_procurement_copy.security_policy_document_file.attachment).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add the ability to copy procurements
- Add pages and routes for copying of the procurement
- Update pages to remove JS error
- Create view for the create a copy page
- Changed routes
- Routing for controllers
- Javascript for the character counts
- Finish creating a copy page
- fix some errors
- Fix issue with alignment
- Fix layout of page
- Move creation of procurement to model
- Set up factories for tests
- Create initial tests for the copying of a procurement
- Update the copying in the model
- Create tests for copying the procurement