### PR TITLE
FM-891-Authenticate-Supplier-And-Buyer-Dashboard-Link

### DIFF
--- a/app/controllers/facilities_management/beta/procurements/contracts_controller.rb
+++ b/app/controllers/facilities_management/beta/procurements/contracts_controller.rb
@@ -7,6 +7,7 @@ module FacilitiesManagement
 
         before_action :set_procurement
         before_action :set_contract
+        before_action :authorize_user
         before_action :set_page_detail, only: %i[show edit]
         before_action :assign_contract_attributes, only: :update
 
@@ -92,6 +93,10 @@ module FacilitiesManagement
                   :contract_end_date_mm,
                   :contract_end_date_yyyy
                 )
+        end
+
+        def authorize_user
+          authorize! :manage, @procurement
         end
       end
     end

--- a/app/controllers/facilities_management/beta/supplier/contracts_controller.rb
+++ b/app/controllers/facilities_management/beta/supplier/contracts_controller.rb
@@ -6,6 +6,7 @@ module FacilitiesManagement
         include FacilitiesManagement::Beta::Supplier::ContractsHelper
 
         before_action :set_contract
+        before_action :authorize_user
         before_action :set_procurement
         before_action :set_page_detail, only: %i[show edit]
 
@@ -43,6 +44,10 @@ module FacilitiesManagement
 
         def set_procurement
           @procurement = Procurement.find(@contract.procurement.id)
+        end
+
+        def authorize_user
+          authorize! :manage, @contract
         end
       end
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,11 +6,10 @@ class Ability
     cannot :manage, :all
     if user.has_role? :ccs_admin
       can :manage, :all
-    elsif user.has_role? :ccs_employee
-      admin_tool_specific_auth(user)
     else
+      admin_tool_specific_auth(user) if user.has_role? :ccs_employee
       service_specific_auth(user) if user.has_role? :buyer
-      can :read, FacilitiesManagement::Supplier if user.has_role?(:fm_access) && user.has_role?(:supplier)
+      fm_supplier_specific_auth(user) if user.has_role?(:fm_access) && user.has_role?(:supplier)
     end
   end
 
@@ -23,6 +22,7 @@ class Ability
       can :read, LegalServices
       can :read, Apprenticeships
     end
+    can :manage, FacilitiesManagement::Procurement, user_id: user.id if user.has_role? :fm_access
     can :read, SupplyTeachers if user.has_role? :st_access
   end
 
@@ -34,5 +34,10 @@ class Ability
     end
     can :manage, SupplyTeachers::Admin::Upload if user.has_role? :st_access
     can :manage, FacilitiesManagement::Beta::Admin if user.has_role? :fm_access
+  end
+
+  def fm_supplier_specific_auth(user)
+    can :read, FacilitiesManagement::Supplier
+    can :manage, FacilitiesManagement::ProcurementSupplier, supplier_email: user.email
   end
 end

--- a/app/models/facilities_management/procurement_supplier.rb
+++ b/app/models/facilities_management/procurement_supplier.rb
@@ -178,6 +178,10 @@ module FacilitiesManagement
       procurement.procurement_suppliers.where(direct_award_value: 0..0.15e7).last == self
     end
 
+    def supplier_email
+      supplier.data['contact_email']
+    end
+
     private
 
     # Custom Validation
@@ -266,7 +270,7 @@ module FacilitiesManagement
 
     def send_email_to_supplier(email_type)
       template_name = email_type
-      email_to = supplier.data['contact_email']
+      email_to = supplier_email
 
       gov_notify_template_arg = {
         'da-offer-1-buyer-1': procurement.user.buyer_detail.organisation_name,

--- a/spec/controllers/facilities_management/beta/procurements/contracts_controller_spec.rb
+++ b/spec/controllers/facilities_management/beta/procurements/contracts_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::Beta::Procurements::ContractsController, type: :controller do
+  let(:contract) { create(:facilities_management_procurement_supplier) }
+
+  describe '.authorize_user' do
+    let(:procurement) { create(:facilities_management_procurement, user: user) }
+
+    let(:user) { FactoryBot.create(:user, :without_detail, confirmed_at: Time.zone.now, roles: %i[buyer fm_access]) }
+    let(:wrong_user) { FactoryBot.create(:user, :without_detail, confirmed_at: Time.zone.now, roles: %i[buyer fm_access]) }
+
+    context 'when the user is not the intended buyer' do
+      it 'will not be able to manage the procurement' do
+        sign_in wrong_user
+        ability = Ability.new(wrong_user)
+        assert ability.cannot?(:manage, procurement)
+      end
+    end
+
+    context 'when the user is the intended buyer' do
+      it 'will be able to manage the procurement' do
+        sign_in user
+        ability = Ability.new(user)
+        assert ability.can?(:manage, procurement)
+      end
+    end
+  end
+end

--- a/spec/controllers/facilities_management/beta/supplier/contracts_controller_spec.rb
+++ b/spec/controllers/facilities_management/beta/supplier/contracts_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::Beta::Supplier::ContractsController, type: :controller do
+  let(:contract) { create(:facilities_management_procurement_supplier) }
+
+  describe '.authorize_user' do
+    let(:procurement) { create(:facilities_management_procurement, user: user) }
+    let(:user) { FactoryBot.create(:user, :without_detail, confirmed_at: Time.zone.now, roles: %i[supplier fm_access]) }
+    let(:wrong_user) { FactoryBot.create(:user, :without_detail, confirmed_at: Time.zone.now, roles: %i[supplier fm_access]) }
+    let(:supplier) { CCS::FM::Supplier.all.first }
+
+    before do
+      supplier.data['contact_email'] = user.email
+      allow(CCS::FM::Supplier).to receive(:find).and_return(supplier)
+    end
+
+    context 'when the user is not the intended buyer' do
+      it 'will not be able to manage the contract' do
+        sign_in wrong_user
+        ability = Ability.new(wrong_user)
+        assert ability.cannot?(:manage, contract)
+      end
+    end
+
+    context 'when the user is the intended buyer' do
+      it 'will be able to manage the contract' do
+        sign_in user
+        ability = Ability.new(user)
+        assert ability.can?(:manage, contract)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add authorisation for when the user clicks on the link
- Create tests for the authenticate user buyer side
- Add tests for authentication on the supplier side

To do this I created a method in the controller which checks that the contract they're trying to view through the link belongs to them