### PR TITLE
Fix issue with cookie page where it would not load

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -247,7 +247,7 @@ module ApplicationHelper
       render partial: "#{params[:service]}/header-banner"
     else
       service_name = controller.class.parent_name&.underscore
-      if service_name.include? 'admin'
+      if service_name&.include? 'admin'
         render partial: 'layouts/admin/header-banner'
       elsif service_name && lookup_context.template_exists?("#{service_name}/_header-banner")
         render partial: "#{service_name}/header-banner"

--- a/app/views/layouts/_cookie-banner.html.erb
+++ b/app/views/layouts/_cookie-banner.html.erb
@@ -1,7 +1,7 @@
 <div id="cookie_banner" class="ccs-phase-banner-wrapper" style="background-color: #ffffff">
   <div class="govuk-phase-banner govuk-width-container ccs-no-print">
       <p class="govuk-phase-banner__content">
-        Crown Marketplace uses cookies to make the site simpler. Read <a href="/cookies">more about cookies</a>
+        Crown Marketplace uses cookies to make the site simpler. Read <%= link_to 'more about cookies', cookies_path(service: request&.controller_class&.parent_name&.underscore) %>
       </p>
   </div>
 </div>


### PR DESCRIPTION
The cookie page will now render with the header-banner it was requested from.
If it can't do that then it renders the header banner for supply teachers which is the default header-banner.
The most important thing is that it should no longer crash