### PR TITLE
London variance is now using framework rate rather than benchmark rat…

### DIFF
--- a/app/calculators/fm_calculator/calculator.rb
+++ b/app/calculators/fm_calculator/calculator.rb
@@ -77,7 +77,7 @@ module FMCalculator
         if @supplier_name
           subtotal1 * @rate_card_variances[:'London Location Variance Rate (%)'].to_f
         else
-          subtotal1 * @benchmark_rates['M144'].to_f
+          subtotal1 * @framework_rates['M144'].to_f
         end
       else
         0


### PR DESCRIPTION
…e when calculating the sum of unit of measure