### PR TITLE
FM 895: Bug - Handle nil lot number

### DIFF
--- a/app/services/procurement_csv_export.rb
+++ b/app/services/procurement_csv_export.rb
@@ -95,7 +95,7 @@ class ProcurementCsvExport
           expand_services(contract.procurement.procurement_building_service_codes),
           expand_regions(contract.procurement.active_procurement_building_region_codes),
           helpers.number_to_currency(contract.procurement.assessed_value),
-          'Sub-lot ' + contract.procurement.lot_number,
+          format_lot_number(contract.procurement.lot_number),
           yes_no(contract.procurement.eligible_for_da),
           contract.procurement.procurement_suppliers.map { |s| s.supplier.data['supplier_name'] } .join(",\n"),
           expand_services(unpriced_services(contract.procurement.procurement_building_service_codes)),
@@ -138,7 +138,7 @@ class ProcurementCsvExport
           expand_services(procurement.procurement_building_service_codes),
           expand_regions(procurement.active_procurement_building_region_codes),
           helpers.number_to_currency(procurement.assessed_value),
-          'Sub-lot ' + procurement.lot_number,
+          format_lot_number(procurement.lot_number),
           yes_no(procurement.eligible_for_da),
           nil,
           expand_services(unpriced_services(procurement.procurement_building_service_codes)),
@@ -234,5 +234,11 @@ class ProcurementCsvExport
 
     "#{helpers.pluralize(extensions.size, 'extension')}, " +
       extensions.map { |ext| helpers.pluralize(ext, 'year') } .join(', ')
+  end
+
+  def self.format_lot_number(lot_number)
+    return '' if lot_number.blank?
+
+    'Sub-lot ' + lot_number
   end
 end


### PR DESCRIPTION
A bug was discovered where nil lot numbers cause an error on the Procurements CSV export. This resolves it.

Ticket: https://pushback.atlassian.net/browse/FM-895?atlOrigin=eyJpIjoiOTAxNjAzZDk3YTU2NGYwYzhiODViNTkzMmQ1ZmE4YTUiLCJwIjoiaiJ9