### PR TITLE
FM-986-HTML-Validation

### DIFF
--- a/app/views/facilities_management/beta/buyer_details/edit.html.erb
+++ b/app/views/facilities_management/beta/buyer_details/edit.html.erb
@@ -21,19 +21,19 @@
         </h2>
         <div class="govuk-form-group <%= "govuk-form-group--error" if f.object.errors[:full_name].any? %>" data-propertyname="full_name">
           <%= f.label :full_name, t('.name'), class: 'govuk-label' %>
-          <%= display_potential_errors(f.object, :full_name, f.object_name) %>
+          <%= display_errors(f.object, :full_name)%>
           <%= f.text_field :full_name, class: 'govuk-input', maxlength: 255, required: true %>
         </div>
 
         <div class="govuk-form-group <%= "govuk-form-group--error" if f.object.errors[:job_title].any? %>" data-propertyname="job_title">
           <%= f.label :job_title, class: 'govuk-label' %>
-          <%= display_potential_errors(f.object, :job_title, f.object_name) %>
+          <%= display_errors(f.object, :job_title)%>
           <%= f.text_field :job_title, class: 'govuk-input', maxlength: 255 %>
         </div>
 
         <div class="govuk-form-group govuk-!-margin-bottom-6 govuk-!-width-one-half <%= "govuk-form-group--error" if f.object.errors[:telephone_number].any? %>" data-propertyname="telephone_number">
           <%= f.label :telephone_number, class: 'govuk-label' %>
-          <%= display_potential_errors(f.object, :telephone_number, f.object_name) %>
+          <%= display_errors(f.object, :telephone_number)%>
           <%= f.number_field :telephone_number, class: 'govuk-input', required:true %>
         </div>
 
@@ -43,7 +43,7 @@
 
         <div class="govuk-form-group  <%= "govuk-form-group--error" if f.object.errors[:organisation_name].any? %>" data-propertyname="organisation_name">
           <%= f.label :organisation_name, class: 'govuk-label' %>
-          <%= display_potential_errors(f.object, :organisation_name, f.object_name) %>
+          <%= display_errors(f.object, :organisation_name)%>
           <%= f.text_field :organisation_name, class: 'govuk-input', maxlength: 255, required: true %>
         </div>
 
@@ -60,7 +60,7 @@
                 <div class="govuk-grid-column-one-half">
                   <%= f.label :organisation_address_postcode, t('.postcode'), class: 'govuk-label govuk-!-margin-bottom-1' %>
                   <div class="govuk-error-message" id="fm-postcode-error"></div>
-                  <%= display_potential_errors(f.object, :organisation_address_postcode, f.object_name) %>
+                  <%= display_errors(f.object, :organisation_address_postcode)%>
                   <%= f.text_field :organisation_address_postcode, class: 'govuk-input fm-postcode-input govuk-!-margin-bottom-4 govuk-!-width-full', id: 'buyer-details-postcode', maxlength: 10, required: true %>
                 </div>
               </div>
@@ -124,7 +124,7 @@
           <div class="govuk-!-margin-top-0 govuk-!-margin-bottom-3">
             <span class="govuk-caption-m"><%= t('.search_html', url: 'https://www.gov.uk/government/organisations') %></span>
           </div>
-          <%= display_potential_errors(f.object, :central_government, f.object_name) %>
+          <%= display_errors(f.object, :central_government)%>
           <div class="govuk-radios govuk-radios--inline govuk-!-margin-bottom-6 govuk-!-margin-top-6">
             <div class="govuk-radios govuk-radios--inline">
               <div class="govuk-radios__item">

--- a/app/views/facilities_management/beta/procurements/_quick_search_form.html.erb
+++ b/app/views/facilities_management/beta/procurements/_quick_search_form.html.erb
@@ -27,7 +27,7 @@
           <div class="govuk-caption-m govuk-!-margin-top-3" data-module="character-count" data-maxlength="100">
             <div class="govuk-form-group <%= 'govuk-form-group--error' if @procurement.errors[:contract_name].any? %>" data-propertyname="name">
               <%= govuk_form_group_with_optional_error @procurement, :contract_name do %>
-                <%= display_potential_errors @procurement, :contract_name, f.object_name %>
+                <%= display_errors(f.object, :contract_name)%>
                 <%= f.label :contract_name, t('.new_name_label'), class: 'govuk-label' %>
                 <%= f.text_field :contract_name, maxlength: 110, required: true, class: 'govuk-input govuk-input--width-20 js-character-count' %>
               <% end %>

--- a/app/views/facilities_management/beta/procurements/further_competition/_further_competition_partial.html.erb
+++ b/app/views/facilities_management/beta/procurements/further_competition/_further_competition_partial.html.erb
@@ -169,7 +169,7 @@
               </ol>
             </div>
           </li>
-         <li class="app-step-nav__step js-step step-is-shown" id="offer-declined">
+         <li class="app-step-nav__step js-step step-is-shown" id="offer-awarding">
             <div class="app-step-nav__header js-toggle-panel" data-position="5">
               <h2 class="app-step-nav__title">
               <span class="app-step-nav__circle app-step-nav__circle--number">
@@ -180,13 +180,13 @@
                 </span>
               </span>
 
-                <span class="js-step-title"><button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="true" aria-controls="step-panel-offer-declined-4"><span class="js-step-title-text">
+                <span class="js-step-title"><button class="app-step-nav__button app-step-nav__button--title js-step-title-button" aria-expanded="true" aria-controls="step-panel-offer-awarding-4"><span class="js-step-title-text">
                   <%= t('.awarding_the_contract') %>
               </span><span class="app-step-nav__toggle-link js-toggle-link" aria-hidden="true" hidden="">Hide</span></button></span>
               </h2>
             </div>
 
-            <div class="app-step-nav__panel js-panel" id="step-panel-offer-declined-4">
+            <div class="app-step-nav__panel js-panel" id="step-panel-offer-awarding-4">
               <ol class="app-step-nav__list " data-length="3">
                 <li class="app-step-nav__list-item js-list-item ">
                   <span data-position="4.1"><%= t('.awarding_the_contract_1') %>

--- a/app/views/facilities_management/beta/procurements/new.html.erb
+++ b/app/views/facilities_management/beta/procurements/new.html.erb
@@ -1,5 +1,5 @@
   <%= render partial: 'shared/error_summary', locals: { errors: @procurement.errors } %>
-<%= form_for @procurement, url: facilities_management_beta_procurements_path, method: :post, html: { novalidate:true, multipart: true } do |f| %>
+<%= form_for @procurement, url: facilities_management_beta_procurements_path, method: :post, html: { specialvalidation:true, novalidate:true, multipart: true } do |f| %>
   <div class="quicksearchassistant" classification="procurement" action="new" module="facilities_management">
     <div class="procurement govuk-row">
       <div class="govuk-grid-row">


### PR DESCRIPTION
removed display_potential_errors and replace with display_errors as well as disable JavaScript on new procurement page

Overall, this should have no impact to the user