### PR TITLE
Assessed value fix

### DIFF
--- a/app/services/facilities_management/assessed_value_calculator.rb
+++ b/app/services/facilities_management/assessed_value_calculator.rb
@@ -1,4 +1,4 @@
-class FacilitiesManagement::EligibleSuppliers
+class FacilitiesManagement::AssessedValueCalculator
   attr_reader :assessed_value, :lot_number, :results
 
   def initialize(procurement_id)

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -699,8 +699,8 @@ en:
           contract_value_heading: When calculating your total contract value, we haven't been able to estimate the costs of some of your services, for which pricing is very customer specific.
           description_html: This will help us place your requirement in the correct sub-lot. <br> NB. The value ranges are total contract values for the full term contract for the services you selected.
           following_services_are_not_included: The following services aren’t included within the above value
-          heading: Looking at the options below, are you able to select the correct value range based on your budget, and expected cost of the contract?
-          help_place_sublot_html: This will help us place your requirement in the correct sub-lot.<br/>NB. The value ranges are total contract values for the full term of the contract for the services you've selected.
+          heading: Looking at the options below, can you select the correct value range based on your budget, and expected cost of the contract?
+          help_place_sublot_html: This will help us place your requirement in the correct sub-lot.<br/>NB. The value ranges are total contract values for the full term of the contract for the services you have selected.
           lot_number_1a_description: Total contract value up to £7 million
           lot_number_1b_description: Total contract value between £7 million and £50 million
           lot_number_1c_description: Total contract value over £50 million

--- a/spec/models/facilities_management/procurement_spec.rb
+++ b/spec/models/facilities_management/procurement_spec.rb
@@ -456,7 +456,7 @@ RSpec.describe FacilitiesManagement::Procurement, type: :model do
     before do
       # rubocop:disable RSpec/AnyInstance, RSpec/SubjectStub
       allow(CCS::FM::Supplier.supplier_name('any')).to receive(:id).and_return(supplier_uuid)
-      allow(FacilitiesManagement::EligibleSuppliers).to receive(:new).with(procurement.id).and_return(obj)
+      allow(FacilitiesManagement::AssessedValueCalculator).to receive(:new).with(procurement.id).and_return(obj)
       allow(obj).to receive(:assessed_value).and_return(0.1234)
       allow(obj).to receive(:lot_number).and_return('1a')
       allow(obj).to receive(:sorted_list).and_return([[:test, da_value_test], [:test1, da_value_test1]])

--- a/spec/models/facilities_management/procurement_supplier_spec.rb
+++ b/spec/models/facilities_management/procurement_supplier_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe FacilitiesManagement::ProcurementSupplier, type: :model do
 
     before do
       allow(CCS::FM::Supplier.supplier_name('any')).to receive(:id).and_return(supplier_uuid)
-      allow(FacilitiesManagement::EligibleSuppliers).to receive(:new).with(procurement.id).and_return(obj)
+      allow(FacilitiesManagement::AssessedValueCalculator).to receive(:new).with(procurement.id).and_return(obj)
       allow(obj).to receive(:assessed_value).and_return(0.1234)
       allow(obj).to receive(:lot_number).and_return('1a')
       allow(obj).to receive(:sorted_list).and_return([[:test1, da_value_test1], [:test2, da_value_test2], [:test3, da_value_test3], [:test4, da_value_test4]])


### PR DESCRIPTION
- Rates should be frozen before the assessed value is calculated
- Changed eligible_suppliers service name because it does a lot more than that
- Some refactoring of procurement.rb so it creates only one instance of the new assessed_value_calculator service
- Copy changes because the copy has changed