### PR TITLE
FM-981/Focus Visible – Visible Tab Focus Indicator

### DIFF
--- a/app/assets/stylesheets/facilities_management/beta/building_services.scss
+++ b/app/assets/stylesheets/facilities_management/beta/building_services.scss
@@ -131,6 +131,10 @@
 
 .browse-panes .root-pane li.active .building-button {
   color: #fff !important;
+  &:focus {
+    background: #fd0;
+    color: #000 !important;
+  }
 }
 
 @media (min-width: 641px) {

--- a/app/views/facilities_management/beta/procurements/long_list/_lot1a.html.erb
+++ b/app/views/facilities_management/beta/procurements/long_list/_lot1a.html.erb
@@ -9,10 +9,8 @@
     </thead>
     <tbody class="govuk-table__body">
       <% @suppliers_lot1a.each do |supplier| %>
-        <tr id="fm-supplier-<%= SecureRandom.uuid %>" name="<%= supplier['name'] %>" class="govuk-table__row" servicecode="<%= supplier['service_code'] %>" regioncode="<%= supplier['region_code'] %>">
+        <tr>
           <td class="govuk-table__cell">
-            <%= label_tag "facilities_management_procurement[suppliers_names][#{supplier['name']}][lot1a]", supplier['name'], class: 'govuk-visually-hidden' %>
-            <%= check_box_tag "facilities_management_procurement[suppliers_names][#{supplier['name']}][lot1a]", supplier['name'], false, class: 'govuk-visually-hidden'%>
             <span><%= supplier['name'] %></span>
           </td>
         </tr>

--- a/app/views/facilities_management/beta/procurements/long_list/_lot1b.html.erb
+++ b/app/views/facilities_management/beta/procurements/long_list/_lot1b.html.erb
@@ -8,10 +8,8 @@
     </thead>
     <tbody class="govuk-table__body">
       <% @suppliers_lot1b.each do |supplier| %>
-        <tr id="fm-supplier-<%= SecureRandom.uuid %>" name="<%= supplier['name'] %>" class="govuk-table__row" servicecode="<%= supplier['service_code'] %>" regioncode="<%= supplier['region_code'] %>">
+        <tr>
           <td class="govuk-table__cell">
-            <%= label_tag "facilities_management_procurement[suppliers_names][#{supplier['name']}][lot1b]", supplier['name'], class: 'govuk-visually-hidden' %>
-            <%= check_box_tag "facilities_management_procurement[suppliers_names][#{supplier['name']}][lot1b]", supplier['name'], false, class: 'govuk-visually-hidden'%>
             <span><%= supplier['name'] %></span>
           </td>
         </tr>

--- a/app/views/facilities_management/beta/procurements/long_list/_lot1c.html.erb
+++ b/app/views/facilities_management/beta/procurements/long_list/_lot1c.html.erb
@@ -8,10 +8,8 @@
     </thead>
     <tbody class="govuk-table__body">
       <% @suppliers_lot1c.each do |supplier| %>
-        <tr id="fm-supplier-<%= SecureRandom.uuid %>" name="<%= supplier['name'] %>" class="govuk-table__row" servicecode="<%= supplier['service_code'] %>" regioncode="<%= supplier['region_code'] %>">
+        <tr>
           <td class="govuk-table__cell">
-            <%= label_tag "facilities_management_procurement[suppliers_names][#{supplier['name']}][lot1c]", supplier['name'], class: 'govuk-visually-hidden' %>
-            <%= check_box_tag "facilities_management_procurement[suppliers_names][#{supplier['name']}][lot1c]", supplier['name'], false, class: 'govuk-visually-hidden'%>
             <span><%= supplier['name'] %></span>
           </td>
         </tr>


### PR DESCRIPTION
- Remove unnecessary labels and inputs as no Quick Search filter
- Add CSS for when the element is focused over