### PR TITLE
ACCESSIBILITY/FM-975-continuation-buttons-lack-labels

### DIFF
--- a/app/assets/stylesheets/components/button/_button.scss
+++ b/app/assets/stylesheets/components/button/_button.scss
@@ -57,7 +57,12 @@ $offset                        : 4;
     background-color : #ffdd00;
     box-shadow       : 0 2px 0 #0b0c0c
     }
+
+    @media (min-width: 280px) and (max-width: 640px) {
+      max-width: 90%;
+    }
   }
+
 
 .govuk-button--disabled,
 .govuk-button[disabled="disabled"],

--- a/app/assets/stylesheets/components/typography/_typography.scss
+++ b/app/assets/stylesheets/components/typography/_typography.scss
@@ -7,6 +7,10 @@ strong {
 	font-weight: $govuk-font-weight-light;
 	margin-bottom: 36px;
 	line-height: 1.15;
+	
+	@media (min-width: 300px) and (max-width: 640px){
+		word-break: break-all;
+	}
 }
 .govuk-heading-l,
 .govuk-heading-m,

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -125,12 +125,12 @@ module LayoutHelper
   def govuk_continuation_buttons(page_description, form_builder, secondary_button = true, return_link = true, primary_button = true, red_secondary_button = false, primary_btn_as_link = false, secondary_btn_as_link = false)
     buttons = ActiveSupport::SafeBuffer.new
 
-    buttons << form_builder.submit(page_description.navigation_details.primary_text, class: 'govuk-button govuk-!-margin-right-4', data: { disable_with: false }, name: [page_description.navigation_details.primary_name, 'commit'].find(&:present?)) if primary_button && !primary_btn_as_link
+    buttons << form_builder.submit(page_description.navigation_details.primary_text, class: 'govuk-button govuk-!-margin-right-4', data: { disable_with: false }, name: [page_description.navigation_details.primary_name, 'commit'].find(&:present?), aria: { label: page_description.navigation_details.primary_text }) if primary_button && !primary_btn_as_link
     buttons << link_to(page_description.navigation_details.primary_text, page_description.navigation_details.primary_url, class: "govuk-!-margin-right-4 govuk-button #{red_secondary_button ? 'govuk-button--warning' : 'govuk-button--secondary'}", role: 'button') if primary_button && primary_btn_as_link && page_description.navigation_details.primary_url.present?
-    buttons << form_builder.submit(page_description.navigation_details.secondary_text, class: "govuk-button #{red_secondary_button ? 'govuk-button--warning' : 'govuk-button--secondary'}", data: { disable_with: false }, name: [page_description.navigation_details.secondary_name, 'commit'].find(&:present?)) if secondary_button && !secondary_btn_as_link
+    buttons << form_builder.submit(page_description.navigation_details.secondary_text, class: "govuk-button #{red_secondary_button ? 'govuk-button--warning' : 'govuk-button--secondary'}", data: { disable_with: false }, name: [page_description.navigation_details.secondary_name, 'commit'].find(&:present?), aria: { label: page_description.navigation_details.secondary_text }) if secondary_button && !secondary_btn_as_link
     buttons << link_to(page_description.navigation_details.secondary_text, page_description.navigation_details.secondary_url, class: "govuk-button #{red_secondary_button ? 'govuk-button--warning' : 'govuk-button--secondary'}", role: 'button') if secondary_button && secondary_btn_as_link
     if secondary_button || primary_button
-      buttons << link_to(page_description.navigation_details.return_text, page_description.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19 break-before') if return_link
+      buttons << link_to(page_description.navigation_details.return_text, page_description.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19 break-before', aria: { label: page_description.navigation_details.return_text }) if return_link
     end
 
     content_tag :div, class: 'govuk-!-margin-top-5' do
@@ -270,6 +270,7 @@ module LayoutHelper
   def govuk_button(builder, text, options = { submit: true, class: '' })
     css_classes = ['govuk-button']
     css_classes << options[:class]
+    css_classes += text == ['aria-label']
     css_classes += ['govuk-button--secondary'] if options[:button] == :secondary
     css_classes += ['govuk-button--warning'] if options[:button] == :warning
 

--- a/app/views/facilities_management/beta/admin/management_report/index.html.erb
+++ b/app/views/facilities_management/beta/admin/management_report/index.html.erb
@@ -54,8 +54,8 @@
     <%= display_errors @management_report, :end_date %>
     <%= f.gov_uk_date_field :end_date, required: true, legend_options: { page_heading: false, visually_hidden: true } %>
     </div>
-    <%= f.submit t('facilities_management.beta.admin.management_report.download_btn_text'), class: 'govuk-button', id: 'management-report-submit', data: { disable_with: false } %>
+    <%= f.submit t('facilities_management.beta.admin.management_report.download_btn_text'), class: 'govuk-button', id: 'management-report-submit', data: { disable_with: false }, 'aria-label': "#{t('facilities_management.beta.admin.management_report.download_btn_text')}" %>
 
 <% end %>
 
-<a href="<%= facilities_management_beta_admin_path %>" class="govuk-link govuk-caption-m" alt="Return to admin dashboard"><%= t('facilities_management.beta.admin.management_report.return_link') %></a>
+<a href="<%= facilities_management_beta_admin_path %>" class="govuk-link govuk-caption-m" alt="Return to admin dashboard" aria-label="Return to admin dashboard"><%= t('facilities_management.beta.admin.management_report.return_link') %></a>

--- a/app/views/facilities_management/beta/admin/sublot_data_services_prices/index.html.erb
+++ b/app/views/facilities_management/beta/admin/sublot_data_services_prices/index.html.erb
@@ -230,7 +230,7 @@
     </tbody>
   </table>
 
-  <input type="submit" name="update_sublot_data_services_prices" value="<%= t('facilities_management.beta.admin.supplier_framework_data.sublot_data.update_button') %>" class="govuk-button" data-disable-with="Continue"><br/>
+  <input type="submit" name="update_sublot_data_services_prices" aria-label="update_sublot_data_services_prices" value="<%= t('facilities_management.beta.admin.supplier_framework_data.sublot_data.update_button') %>" class="govuk-button" data-disable-with="Continue"><br/>
   <%= link_to t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.rtrn_link'), facilities_management_beta_admin_path, class: 'govuk-link govuk-!-font-size-19' %>
   <% end %>
 </div>

--- a/app/views/facilities_management/beta/admin/sublot_regions/sublot_region.html.erb
+++ b/app/views/facilities_management/beta/admin/sublot_regions/sublot_region.html.erb
@@ -48,7 +48,7 @@
 <% end %>
 
 
-<input type="submit" name="update_supplier_regions" value="<%= t('facilities_management.beta.admin.supplier_framework_data.sublot_1a_regions.update_button') %>" class="govuk-button" data-disable-with="Continue">
+<input type="submit" name="update_supplier_regions" value="<%= t('facilities_management.beta.admin.supplier_framework_data.sublot_1a_regions.update_button') %>" aria-label="<%= t('facilities_management.beta.admin.supplier_framework_data.sublot_1a_regions.update_button') %>" class="govuk-button" data-disable-with="Continue">
 
 <% end %>
-<a href="<%= facilities_management_beta_admin_supplier_framework_data_path %>" class="govuk-link govuk-caption-m" alt="Return to admin dashboard"><%= t('facilities_management.beta.admin.supplier_framework_data.sublot_1a_regions.rtrn_link') %></a>
+<a href="<%= facilities_management_beta_admin_supplier_framework_data_path %>" class="govuk-link govuk-caption-m" alt="Return to admin dashboard" aria-label="Return to admin dashboard"><%= t('facilities_management.beta.admin.supplier_framework_data.sublot_1a_regions.rtrn_link') %></a>

--- a/app/views/facilities_management/beta/admin/sublot_services/index.html.erb
+++ b/app/views/facilities_management/beta/admin/sublot_services/index.html.erb
@@ -47,6 +47,6 @@
     </table>
   <% end %>
 
-  <input type="submit" name="update_benchmark_rates" value="<%= t('facilities_management.beta.admin.supplier_framework_data.sublot_data.update_button') %>" class="govuk-button" data-disable-with="Continue">
-  <a href="<%= facilities_management_beta_admin_supplier_framework_data_path %>" class="govuk-link govuk-caption-m" alt="Return to admin dashboard"><%= t('facilities_management.beta.admin.supplier_framework_data.sublot_data.return_button') %></a>
+  <input type="submit" name="update_benchmark_rates" value="<%= t('facilities_management.beta.admin.supplier_framework_data.sublot_data.update_button') %>" aria-label="<%= t('facilities_management.beta.admin.supplier_framework_data.sublot_data.update_button') %>" class="govuk-button" data-disable-with="Continue">
+  <a href="<%= facilities_management_beta_admin_supplier_framework_data_path %>" class="govuk-link govuk-caption-m" alt="Return to admin dashboard" aria-label="Return to admin dashboard" ><%= t('facilities_management.beta.admin.supplier_framework_data.sublot_data.return_button') %></a>
 <% end %>

--- a/app/views/facilities_management/beta/admin/supplier_rates/supplier_benchmark_rates.erb
+++ b/app/views/facilities_management/beta/admin/supplier_rates/supplier_benchmark_rates.erb
@@ -118,6 +118,6 @@
     </tbody>
   </table>
 
-  <input type="submit" name="update_benchmark_rates" value="<%= t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.update_button') %>" class="govuk-button" data-disable-with="Continue">
-  <a href="<%= facilities_management_beta_admin_path %>" class="govuk-link govuk-caption-m" alt="Return to admin dashboard"><%= t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.rtrn_link') %></a>
+  <input type="submit" name="update_benchmark_rates" value="<%= t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.update_button') %>" aria-label="<%= t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.update_button') %>" class="govuk-button" data-disable-with="Continue">
+  <a href="<%= facilities_management_beta_admin_path %>" class="govuk-link govuk-caption-m" alt="Return to admin dashboard" aria-label="Return to admin dashboard"><%= t('facilities_management.beta.admin.supplier_rates.supplier_benchmark_rates.rtrn_link') %></a>
 <% end %>

--- a/app/views/facilities_management/beta/admin/supplier_rates/supplier_framework_rates.erb
+++ b/app/views/facilities_management/beta/admin/supplier_rates/supplier_framework_rates.erb
@@ -95,6 +95,6 @@
     </tbody>
   </table>
 
-  <input type="submit" name="update_benchmark_rates" value="<%= t('facilities_management.beta.admin.supplier_rates.supplier_framework_rates.update_button') %>" class="govuk-button" data-disable-with="Continue">
-  <a href="<%= facilities_management_beta_admin_path %>" class="govuk-link govuk-caption-m" alt="Return to admin dashboard"><%= t('facilities_management.beta.admin.supplier_rates.supplier_framework_rates.rtrn_link') %></a>
+  <input type="submit" name="update_benchmark_rates" value="<%= t('facilities_management.beta.admin.supplier_rates.supplier_framework_rates.update_button') %>" aria-label="<%= t('facilities_management.beta.admin.supplier_rates.supplier_framework_rates.update_button') %>" class="govuk-button" data-disable-with="Continue">
+  <a href="<%= facilities_management_beta_admin_path %>" class="govuk-link govuk-caption-m" alt="Return to admin dashboard" aria-label="Return to admin dashboard"><%= t('facilities_management.beta.admin.supplier_rates.supplier_framework_rates.rtrn_link') %></a>
 <% end %>

--- a/app/views/facilities_management/beta/admin/suppliers_framework_data/index.erb
+++ b/app/views/facilities_management/beta/admin/suppliers_framework_data/index.erb
@@ -81,4 +81,4 @@
   
 </div>
 
-<a href="<%= facilities_management_beta_admin_path %>" class="govuk-button govuk-button--secondary govuk-!-margin-top-5" alt="Return to admin dashboard"><%= t('facilities_management.beta.admin.supplier_framework_data.rtrn_link') %></a>
+<a href="<%= facilities_management_beta_admin_path %>" class="govuk-button govuk-button--secondary govuk-!-margin-top-5" alt="Return to admin dashboard" aria-label="Return to admin dashboard"><%= t('facilities_management.beta.admin.supplier_framework_data.rtrn_link') %></a>

--- a/app/views/facilities_management/beta/buildings/_details_form.html.erb
+++ b/app/views/facilities_management/beta/buildings/_details_form.html.erb
@@ -72,7 +72,7 @@
       <%= f.hidden_field :address_region_code, id: 'address-region-code' %>
       <br/>
     <% end %>
-    <button type="button" class="govuk-button" style="clear:both" data-module-element="trigger"><%= t('.find_address') %></button>
+    <button type="button" class="govuk-button" style="clear:both" data-module-element="trigger" aria-label="<%= t('.find_address') %>"><%= t('.find_address') %></button>
   </div>
   <div class="govuk-!-margin-bottom-3 govuk-!-margin-top-0" data-module-part="lookup-container">
     <div data-module-part="lookup-postcode-results" data-module-action="<%= 'fetch' if @page_data[:model_object].address_line_1.blank? %>" class="govuk-form-group govuk-!-margin-bottom-3 <%= 'govuk-visually-hidden' unless @page_data[:model_object].errors[:address].any? %> <%= 'govuk-form-group--error' if @page_data[:model_object].errors[:address].any? %>">
@@ -106,7 +106,7 @@
       </select>
       <%= f.submit(t('.cant_find_address'),
                    class: 'govuk-link govuk-!-margin-right-4 button_as_link',
-                   data:  { disable_with: false }, name: 'add_address', style: 'display:block') %>
+                   data:  { disable_with: false }, name: 'add_address', style: 'display:block', aria-label: "#{t('.cant_find_address')}") %>
     </div>
     <div data-module-part="address-display" class="govuk-!-margin-top-3 govuk-!-margin-bottom-3 <%= ' govuk-visually-hidden' unless @page_data[:model_object].address_line_1.present? %>">
       <span class="govuk-heading-s govuk-!-margin-bottom-1" style="margin-top:-1.7ex"><%= t('.address') %></span>
@@ -144,7 +144,7 @@
             <span id="region-header" class="govuk-heading-s govuk-!-margin-bottom-1"><%= t('.region') %></span>
             <p class="govuk-!-margin-bottom-2" data-module-part="region-text"><%= @page_data[:model_object].address_region %></p>
             <a href="#region-header" class="govuk-link <%= 'govuk-visually-hidden' unless multiple_regions? %>" style="display:block;"
-               data-module-element="change-region-button"><%= t('.change') %></a>
+               data-module-element="change-region-button" aria-label="<%= t('.change') %>"><%= t('.change') %></a>
           </div>
         </div>
       </div>

--- a/app/views/facilities_management/beta/buildings/index.html.erb
+++ b/app/views/facilities_management/beta/buildings/index.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_page_content(@page_description, @page_data[:model_object], false, true, false) do |pd| %>
 <%= content_for :page_title, pd.heading_details.text %>
   <div id="buildings-container">
-    <%= link_to t('.create_new_button'), new_facilities_management_beta_building_path, class: "govuk-button ccs-no-print govuk-!-margin-bottom-6", role: "button" %>
+    <%= link_to t('.create_new_button'), new_facilities_management_beta_building_path, class: "govuk-button ccs-no-print govuk-!-margin-bottom-6", role: "button", 'aria-label': t('.create_new_button') %>
     <div class="govuk-!-width-two-thirds">
       <p class="govuk-!-margin-bottom-2">
         <%= t('.start_paragraph') %>

--- a/app/views/facilities_management/beta/buyer_details/edit.html.erb
+++ b/app/views/facilities_management/beta/buyer_details/edit.html.erb
@@ -68,7 +68,7 @@
                 </div>
               </div>
               <div class="govuk-!-margin-top-1 govuk-!-margin-bottom-0">
-                <a role="button" href="#"  tabindex=<%="#{input_index}"%> class="govuk-button govuk-!-margin-bottom-2" id="buyer-details-find-address-btn"><%= t('.find_addr') %></a>
+                <a role="button" href="#"  tabindex=<%="#{input_index}"%> class="govuk-button govuk-!-margin-bottom-2" id="buyer-details-find-address-btn" aria-label="<%= t('.find_addr') %>"><%= t('.find_addr') %></a>
               </div>
               <div class="govuk-!-margin-top-0">
                 <%= link_to t('.cant_find_addr_in_list'), facilities_management_beta_buyer_detail_edit_address_path(@buyer_detail),  class: "govuk-link--no-visited-state govuk-caption-m", id: 'add-buyer-address-link-1', tabindex: "#{input_index}" %>
@@ -144,7 +144,7 @@
         </div>
 
         <div>
-          <%= f.submit t('.submit'), class: "govuk-button", data: { disable_with:false }  %>
+          <%= f.submit t('.submit'), class: "govuk-button", data: { disable_with:false }, 'aria-label': t('.submit')  %>
         </div>
 
       </fieldset>

--- a/app/views/facilities_management/beta/buyer_details/edit_address.html.erb
+++ b/app/views/facilities_management/beta/buyer_details/edit_address.html.erb
@@ -43,7 +43,7 @@
         </div>
       </fieldset>
       <div class="govuk-!-margin-top-4">
-        <%= f.submit t('.submit'), class: "govuk-button" %>
+        <%= f.submit t('.submit'), class: "govuk-button", 'aria-label': t('.submit') %>
       </div>
     <% end %>
     </div>

--- a/app/views/facilities_management/beta/home/index.html.erb
+++ b/app/views/facilities_management/beta/home/index.html.erb
@@ -22,7 +22,7 @@
         <%= t('facilities_management.home.startlist').html_safe %>
       </ul>
 
-      <%= link_to t('facilities_management.home.startnow'), facilities_management_beta_gateway_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' %>
+      <%= link_to t('facilities_management.home.startnow'), facilities_management_beta_gateway_path, role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', 'aria-label': t('facilities_management.home.startnow') %>
     </div>
 
     <div class="govuk-grid-column-one-third">

--- a/app/views/facilities_management/beta/procurement_buildings/_building_standards.html.erb
+++ b/app/views/facilities_management/beta/procurement_buildings/_building_standards.html.erb
@@ -57,7 +57,7 @@
     <% end %>
   <% end %>
   <div class="govuk-grid-row govuk-!-margin-top-9">
-    <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4' %>
+    <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4', 'aria-label':  t('.save_and_return_to_service_information') %>
   </div>
   <%= link_to t('.back_to_service_information'), facilities_management_beta_procurement_building_path(@procurement_building), class: 'govuk-link--no-visited-state' %>
 </div>

--- a/app/views/facilities_management/beta/procurement_buildings/_cleaning_standards.html.erb
+++ b/app/views/facilities_management/beta/procurement_buildings/_cleaning_standards.html.erb
@@ -57,7 +57,7 @@
     <% end %>
   <% end %>
   <div class="govuk-grid-row govuk-!-margin-top-9">
-    <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4' %>
+    <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4', 'aria-label': t('.save_and_return_to_service_information') %>
   </div>
   <%= link_to t('.back_to_service_information'), facilities_management_beta_procurement_building_path(@procurement_building), class: 'govuk-link--no-visited-state' %>
 </div>

--- a/app/views/facilities_management/beta/procurement_buildings/_ppm_standards.html.erb
+++ b/app/views/facilities_management/beta/procurement_buildings/_ppm_standards.html.erb
@@ -57,7 +57,7 @@
     <% end %>
   <% end %>
   <div class="govuk-grid-row govuk-!-margin-top-9">
-    <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4' %>
+    <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4', 'aria-label': t('.save_and_return_to_service_information') %>
   </div>
   <%= link_to t('.back_to_service_information'), facilities_management_beta_procurement_building_path(@procurement_building), class: 'govuk-link--no-visited-state' %>
 </div>

--- a/app/views/facilities_management/beta/procurement_buildings/_volume.html.erb
+++ b/app/views/facilities_management/beta/procurement_buildings/_volume.html.erb
@@ -28,7 +28,7 @@
           <% end %>
         <% end %>
         <div class="govuk-grid-row govuk-!-margin-top-9">
-          <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4' %>
+          <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4', 'aria-label': t('.save_and_return_to_service_information') %>
         </div>
         <%= link_to t('.back_to_service_information'), facilities_management_beta_procurement_building_path(@procurement_building), class: 'govuk-link--no-visited-state' %>
       </div>

--- a/app/views/facilities_management/beta/procurement_buildings_services/_day_section.html.erb
+++ b/app/views/facilities_management/beta/procurement_buildings_services/_day_section.html.erb
@@ -64,7 +64,7 @@
         </div>
       </div>
       <% if day == :monday %>
-        <button id="copy_details" class="govuk-button govuk-button--secondary" style="margin-bottom:0;" onclick="return false;"><%=t('.copy_details') %></button>
+        <button id="copy_details" class="govuk-button govuk-button--secondary" style="margin-bottom:0;" onclick="return false;" aria-label="<%=t('.copy_details') %>"><%=t('.copy_details') %></button>
       <% end %>
     </div>
   <% end %>

--- a/app/views/facilities_management/beta/procurement_buildings_services/_lifts.html.erb
+++ b/app/views/facilities_management/beta/procurement_buildings_services/_lifts.html.erb
@@ -23,7 +23,7 @@
     </div>
     <%= button_to "Add new lift (#{99 - index} remaining)", 'addnewlift', class: 'govuk-button govuk-button--secondary addliftbtn' %>
     <div class="govuk-grid-row govuk-!-margin-top-5">
-      <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4', data: {disable_with: false} %>
+      <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4', data: {disable_with: false}, 'aria-label': t('.save_and_return_to_service_information') %>
     </div>
     <%= link_to t('.back_to_service_information'), facilities_management_beta_procurement_building_path(@procurement_building), class: 'govuk-link--no-visited-state' %>
   </div>

--- a/app/views/facilities_management/beta/procurement_buildings_services/_service_hours.html.erb
+++ b/app/views/facilities_management/beta/procurement_buildings_services/_service_hours.html.erb
@@ -19,7 +19,7 @@
     </div>
   </div>
   <div class="govuk-grid-row govuk-!-margin-top-9">
-    <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4', data: { disable_with:false } %>
+    <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4', data: { disable_with:false }, 'aria-label': t('.save_and_return_to_service_information') %>
   </div>
   <%= link_to t('.back_to_service_information'), facilities_management_beta_procurement_building_path(@procurement_building), class: 'govuk-link--no-visited-state' %>
 <% end %>

--- a/app/views/facilities_management/beta/procurement_buildings_services/show.html.erb
+++ b/app/views/facilities_management/beta/procurement_buildings_services/show.html.erb
@@ -11,7 +11,7 @@
       <%= f.hidden_field :step, value: @partial_prefix %>
       <%= render partial: "#{@partial_prefix}", locals: {f: f} %>
       <div class="govuk-grid-row govuk-!-margin-top-9">
-        <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4', data: { disable_with:false } %>
+        <%= f.submit t('.save_and_return_to_service_information'), class: 'govuk-button govuk-button--primary govuk-!-margin-left-3 govuk-!-margin-bottom-4', data: { disable_with:false }, 'aria-label': t('.save_and_return_to_service_information') %>
       </div>
       <%= link_to t('.back_to_service_information'), facilities_management_beta_procurement_building_path(@procurement_building), class: 'govuk-link--no-visited-state' %>
   <% end %>

--- a/app/views/facilities_management/beta/procurements/_call_off_extensions.html.erb
+++ b/app/views/facilities_management/beta/procurements/_call_off_extensions.html.erb
@@ -55,7 +55,7 @@
             <%= f.hidden_field :call_off_extension_4, value: !@procurement.optional_call_off_extensions_4.nil? || @procurement.errors[:optional_call_off_extensions_4].any? %>
             <button id="fm-ext4-remove-btn" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" aria-hidden='true', tabindex='-1'>Remove</button>
           </div>
-          <button id="fm-add-contract-ext-btn" class="govuk-button govuk-button--secondary govuk-!-margin-left-3 govuk-!-margin-top-3">+
+          <button id="fm-add-contract-ext-btn" class="govuk-button govuk-button--secondary govuk-!-margin-left-3 govuk-!-margin-top-3" aria-label="<%= t('.add_extension_period') %>">+
             <%= t('.add_extension_period') %>
           </button>
         </div>

--- a/app/views/facilities_management/beta/procurements/_continue_button_footer.html.erb
+++ b/app/views/facilities_management/beta/procurements/_continue_button_footer.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-!-margin-top-6">
   <% if @delete %>
-    <%= link_to 'Confirm delete', facilities_management_beta_procurement_path(@procurement), method: 'delete', class: "govuk-button govuk-button--warning" %>
-    <%= link_to 'Cancel',  facilities_management_beta_procurements_url, class: "govuk-button govuk-button--secondary govuk-!-margin-left-3" %>
+    <%= link_to 'Confirm delete', facilities_management_beta_procurement_path(@procurement), method: 'delete', class: "govuk-button govuk-button--warning", 'aria-label': 'Confirm delete' %>
+    <%= link_to 'Cancel',  facilities_management_beta_procurements_url, class: "govuk-button govuk-button--secondary govuk-!-margin-left-3", 'aria-label': 'Cancel' %>
   <% else %>
-    <%= f.submit 'Continue', class: 'govuk-button', data: { disable_with: false }, name: 'continue_to_results'%>
-    <%= link_to 'Return to procurements dashboard', facilities_management_beta_procurements_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3' %>
+    <%= f.submit 'Continue', class: 'govuk-button', data: { disable_with: false }, name: 'continue_to_results', 'aria-label': 'Continue' %>
+    <%= link_to 'Return to procurements dashboard', facilities_management_beta_procurements_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3', 'aria-label': 'Return to procurements dashboard' %>
   <%end %>
 </div>
 

--- a/app/views/facilities_management/beta/procurements/_edit_procurement.html.erb
+++ b/app/views/facilities_management/beta/procurements/_edit_procurement.html.erb
@@ -6,9 +6,9 @@
       </div>
       <%= render partial: 'facilities_management/beta/procurements/show_procurement', locals: { form: f, delete: @delete, change: @change }%>
     <% end %>
-    <%= f.submit t('.save_and_continue'), class: 'govuk-button' %>
-    <%= f.submit t('.save_for_later'), name: 'save_for_later', class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3' %>
+    <%= f.submit t('.save_and_continue'), class: 'govuk-button', 'aria-label': 'Save and continue' %>
+    <%= f.submit t('.save_for_later'), name: 'save_for_later', class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3', 'aria-label': 'Save for later' %>
     <br />
-    <%= link_to t('.cancel_and_return'), facilities_management_beta_procurements_url, class: "govuk_link"%>
+    <%= link_to t('.cancel_and_return'), facilities_management_beta_procurements_url, class: "govuk_link", 'aria-label': 'Cancel and return' %>
     <br />
 <% end %>

--- a/app/views/facilities_management/beta/procurements/_further_competition.html.erb
+++ b/app/views/facilities_management/beta/procurements/_further_competition.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_page_content(@page_description, @page_data[:model_object], false, true, false) do |pd| %>  
   <%= render :partial => 'facilities_management/beta/procurements/further_competition/further_competition_partial', locals: { post: pd } %>
   <%= form_for @page_data[:model_object], url: facilities_management_beta_procurement_path(@procurement.id), method: :patch, html: { specialvalidation: false, novalidate: true, multipart: true } do |f| %>
-    <%= link_to(pd.navigation_details.primary_text, new_facilities_management_beta_procurement_copy_procurement_path(procurement_id: @page_data[:model_object].id), role: 'button', class: 'govuk-button') %> <br/>
-    <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-caption-m') %>
+    <%= link_to(pd.navigation_details.primary_text, new_facilities_management_beta_procurement_copy_procurement_path(procurement_id: @page_data[:model_object].id), role: 'button', class: 'govuk-button', 'aria-label': pd.navigation_details.primary_text) %> <br/>
+    <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-caption-m', 'aria-label': pd.navigation_details.return_text) %>
   <% end %>
 <% end %>

--- a/app/views/facilities_management/beta/procurements/_no_buildings.html.erb
+++ b/app/views/facilities_management/beta/procurements/_no_buildings.html.erb
@@ -5,6 +5,6 @@
   <p class="govuk-heading-s">Buildings can be added in your 'manage buildings' area.</p>
 </div>
 <div class="govuk-grid-row govuk-!-margin-top-9">
-  <%= link_to 'Go to manage buildings', facilities_management_beta_buildings_path, class: 'govuk-button' %>
-  <%= link_to 'Return to procurements dashboard', facilities_management_beta_procurements_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3' %>
+  <%= link_to 'Go to manage buildings', facilities_management_beta_buildings_path, class: 'govuk-button', 'aria-label': 'Go to manage buildings' %>
+  <%= link_to 'Return to procurements dashboard', facilities_management_beta_procurements_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3', 'aria-label': 'Return to procurements dashboard' %>
 </div>

--- a/app/views/facilities_management/beta/procurements/_services.html.erb
+++ b/app/views/facilities_management/beta/procurements/_services.html.erb
@@ -79,7 +79,7 @@
           <div>
             <h3 class="govuk-heading-m" data-txt01="<%= t('.services_selected') %>" data-txt02="<%= t('.no_services_selected') %>">
               <span id="selected-services-count">0</span> <span><%= t('.services_selected') %></span></h3>
-            <a class="govuk-!-padding-left-2 remove-link" role="button" href="#"><%= t('.remove_all') %></a><br />
+            <a class="govuk-!-padding-left-2 remove-link" role="button" href="#" aria-label="<%= t('.remove_all') %>"><%= t('.remove_all') %></a><br />
             <ul style="margin-top:10px;" class="govuk-list"></ul>
           </div>
         </div>

--- a/app/views/facilities_management/beta/procurements/contracts/closed/index.html.erb
+++ b/app/views/facilities_management/beta/procurements/contracts/closed/index.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: "contract_closed" if @contract.closed? %>
 <%= render partial: "contract_signed" if @contract.aasm_state == "signed" %>
 
-<%= link_to t('.return_text'), facilities_management_beta_procurements_path,  class: "govuk-button govuk-button--secondary govuk-!-margin-top-2 govuk-!-margin-bottom-2" %>
+<%= link_to t('.return_text'), facilities_management_beta_procurements_path,  class: "govuk-button govuk-button--secondary govuk-!-margin-top-2 govuk-!-margin-bottom-2", 'aria-label': "#{t('.return_text')}" %>

--- a/app/views/facilities_management/beta/procurements/contracts/edit.html.erb
+++ b/app/views/facilities_management/beta/procurements/contracts/edit.html.erb
@@ -10,21 +10,21 @@
         <% when 'withdraw' %>
             <%= render partial: 'closing_direct_award_offer', :locals=>{:f=>f} %>
             <div class= 'govuk-!-margin-top-5'>
-                <%= f.submit(value:"Close this procurement", class: 'govuk-!-margin-right-4 govuk-button govuk-button--warning', data: { disable_with: false }, name: :close_procurement) %>
-                <%= link_to(pd.navigation_details.secondary_text, facilities_management_beta_procurement_contract_path(@procurement), role: 'button', class: 'govuk-button govuk-button--secondary') %> <br />
+                <%= f.submit(value:"Close this procurement", class: 'govuk-!-margin-right-4 govuk-button govuk-button--warning', data: { disable_with: false }, name: :close_procurement, 'aria-label': "Close this procurement") %>
+                <%= link_to(pd.navigation_details.secondary_text, facilities_management_beta_procurement_contract_path(@procurement), role: 'button', class: 'govuk-button govuk-button--secondary', 'aria-label': "#{pd.navigation_details.secondary_text}") %> <br />
             </div>
         <% when 'next_supplier' %>
             <%= render partial: 'next_supplier', :locals=>{:f=>f} %>
             <div class= 'govuk-!-margin-top-5'>
-                <%= f.submit(value:"Confirm and send offer to supplier", class: 'govuk-!-margin-right-4 govuk-button', data: { disable_with: false }, name: :send_contract_to_next_supplier) %>
-                <%= link_to(pd.navigation_details.secondary_text, facilities_management_beta_procurement_contract_path(@procurement), role: 'button', class: 'govuk-button govuk-button--secondary') %> <br />
+                <%= f.submit(value:"Confirm and send offer to supplier", class: 'govuk-!-margin-right-4 govuk-button', data: { disable_with: false }, name: :send_contract_to_next_supplier, 'aria-label': "Confirm and send offer to supplier" ) %>
+                <%= link_to(pd.navigation_details.secondary_text, facilities_management_beta_procurement_contract_path(@procurement), role: 'button', class: 'govuk-button govuk-button--secondary', 'aria-label': "#{pd.navigation_details.secondary_text}") %> <br />
                 <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19') %>
             </div>
         <% else %>
             <%= render partial: 'confirmation_of_signed_contract', :locals=>{:f=>f} %>
             <div class= 'govuk-!-margin-top-5'>
-                <%= f.submit(value:"Save and continue", class: 'govuk-!-margin-right-4 govuk-button', data: { disable_with: false }, name: :sign_procurement) %>
-                <%= link_to(pd.navigation_details.secondary_text, facilities_management_beta_procurement_contract_path(@procurement), role: 'button', class: 'govuk-button govuk-button--secondary') %> <br />
+                <%= f.submit(value:"Save and continue", class: 'govuk-!-margin-right-4 govuk-button', data: { disable_with: false }, name: :sign_procurement, 'aria-label': "Save and continue") %>
+                <%= link_to(pd.navigation_details.secondary_text, facilities_management_beta_procurement_contract_path(@procurement), role: 'button', class: 'govuk-button govuk-button--secondary', 'aria-label': "#{pd.navigation_details.secondary_text}") %> <br />
             </div>
         <% end %>
     <% end %>

--- a/app/views/facilities_management/beta/procurements/contracts/sent/_no_suppliers.html.erb
+++ b/app/views/facilities_management/beta/procurements/contracts/sent/_no_suppliers.html.erb
@@ -24,5 +24,5 @@
 </div>
 
 <div class="govuk-!-margin-bottom-4">
-  <%= link_to("Return to procurement dashboard", facilities_management_beta_procurements_path, role: 'button', class: 'govuk-link govuk-!-font-size-19') %>
+  <%= link_to("Return to procurement dashboard", facilities_management_beta_procurements_path, role: 'button', class: 'govuk-link govuk-!-font-size-19', 'aria-label': "Return to procurement dashboard") %>
 </div>

--- a/app/views/facilities_management/beta/procurements/contracts/sent/_sent.html.erb
+++ b/app/views/facilities_management/beta/procurements/contracts/sent/_sent.html.erb
@@ -36,4 +36,4 @@
 
   <p><%= t('.further_information') %></p>
 
-  <%= link_to "Return to procurements dashboard", facilities_management_beta_procurements_path,  class: "govuk-button govuk-button--secondary govuk-!-margin-top-2" %>
+  <%= link_to "Return to procurements dashboard", facilities_management_beta_procurements_path,  class: "govuk-button govuk-button--secondary govuk-!-margin-top-2", 'aria-label': "Return to procurements dashboard" %>

--- a/app/views/facilities_management/beta/procurements/contracts/show.html.erb
+++ b/app/views/facilities_management/beta/procurements/contracts/show.html.erb
@@ -33,34 +33,34 @@
             <% case  @contract.aasm_state %>
             <% when 'sent' %>
                 <div class= 'govuk-!-margin-top-5'>
-                    <%= link_to(pd.navigation_details.secondary_text, edit_facilities_management_beta_procurement_contract_path(id: @contract.id, name: 'withdraw'), role: 'button', class: 'govuk-button govuk-button--warning') %> <br />
-                    <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19') %>
+                    <%= link_to(pd.navigation_details.secondary_text, edit_facilities_management_beta_procurement_contract_path(id: @contract.id, name: 'withdraw'), role: 'button', class: 'govuk-button govuk-button--warning', 'aria-label': "#{pd.navigation_details.secondary_text}") %> <br />
+                    <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19', 'aria-label': "#{pd.navigation_details.return_text}") %>
                 </div>
             <% when 'signed' %>
-                <%= link_to(pd.navigation_details.secondary_text, new_facilities_management_beta_procurement_copy_procurement_path(id: @procurement.id, contract_id: @contract.id), role: 'button', class: 'govuk-button govuk-button--secondary') %> <br />
-                <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19') %>
+                <%= link_to(pd.navigation_details.secondary_text, new_facilities_management_beta_procurement_copy_procurement_path(id: @procurement.id, contract_id: @contract.id), role: 'button', class: 'govuk-button govuk-button--secondary', 'aria-label': "#{pd.navigation_details.secondary_text}") %> <br />
+                <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19', 'aria-label': "#{pd.navigation_details.return_text}") %>
             <% when 'not_signed', 'declined' , 'expired' %>
                 <div class= 'govuk-!-margin-top-5'>
                 <% if @contract.last_offer? %>
                     <%= form_for @contract, url: facilities_management_beta_procurement_contract_path, method: :put do |f| %>
-                        <%= f.submit(value: pd.navigation_details.primary_text, class: 'govuk-!-margin-right-4 govuk-button', data: { disable_with: false }, name: :send_contract_to_next_supplier) %>
+                        <%= f.submit(value: pd.navigation_details.primary_text, class: 'govuk-!-margin-right-4 govuk-button', data: { disable_with: false }, name: :send_contract_to_next_supplier, 'aria-label': "#{pd.navigation_details.primary_text}") %>
                     <% end %>
                 <% else %>
-                    <%= link_to(pd.navigation_details.primary_text, edit_facilities_management_beta_procurement_contract_path(id: @contract.id, name: 'next_supplier'), role: 'button', class: 'govuk-button govuk-!-margin-right-4') %>
+                    <%= link_to(pd.navigation_details.primary_text, edit_facilities_management_beta_procurement_contract_path(id: @contract.id, name: 'next_supplier'), role: 'button', class: 'govuk-button govuk-!-margin-right-4', 'aria-label': "#{pd.navigation_details.primary_text}") %>
                 <% end %>
-                    <%= link_to(pd.navigation_details.secondary_text, edit_facilities_management_beta_procurement_contract_path(id: @contract.id, name: 'withdraw'), role: 'button', class: 'govuk-button govuk-button--warning') %> <br />
-                    <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19') %>
+                    <%= link_to(pd.navigation_details.secondary_text, edit_facilities_management_beta_procurement_contract_path(id: @contract.id, name: 'withdraw'), role: 'button', class: 'govuk-button govuk-button--warning', 'aria-label': "#{pd.navigation_details.secondary_text}") %> <br />
+                    <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19', 'aria-label': "#{pd.navigation_details.return_text}") %>
                 </div>
             <% else %>
                 <div class= 'govuk-!-margin-top-5'>
-                    <%= link_to(pd.navigation_details.primary_text, edit_facilities_management_beta_procurement_contract_path(id: @contract.id, name: 'signed'), role: 'button', class: 'govuk-button govuk-!-margin-right-4') %>
-                    <%= link_to(pd.navigation_details.secondary_text, edit_facilities_management_beta_procurement_contract_path(id: @contract.id, name: 'withdraw'), role: 'button', class: 'govuk-button govuk-button--warning') %> <br />
-                    <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19') %>
+                    <%= link_to(pd.navigation_details.primary_text, edit_facilities_management_beta_procurement_contract_path(id: @contract.id, name: 'signed'), role: 'button', class: 'govuk-button govuk-!-margin-right-4', 'aria-label': "#{pd.navigation_details.primary_text}") %>
+                    <%= link_to(pd.navigation_details.secondary_text, edit_facilities_management_beta_procurement_contract_path(id: @contract.id, name: 'withdraw'), role: 'button', class: 'govuk-button govuk-button--warning', 'aria-label': "#{pd.navigation_details.secondary_text}") %> <br />
+                    <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19', 'aria-label': "#{pd.navigation_details.return_text}") %>
                 </div>
             <% end %>
         <% else %>
-            <%= link_to(pd.navigation_details.secondary_text, new_facilities_management_beta_procurement_copy_procurement_path(id: @procurement.id, contract_id: @contract.id), role: 'button', class: 'govuk-button govuk-button--secondary') %> <br />
-            <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19') %>
+            <%= link_to(pd.navigation_details.secondary_text, new_facilities_management_beta_procurement_copy_procurement_path(id: @procurement.id, contract_id: @contract.id), role: 'button', class: 'govuk-button govuk-button--secondary', 'aria-label': "#{pd.navigation_details.secondary_text}") %> <br />
+            <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19', 'aria-label': "#{pd.navigation_details.return_text}") %>
         <% end %>
     <% end %>
 <% end %>

--- a/app/views/facilities_management/beta/procurements/copy_procurement/new.html.erb
+++ b/app/views/facilities_management/beta/procurements/copy_procurement/new.html.erb
@@ -19,7 +19,7 @@
                 You have 100 characters remaining
             </span>
         </div>
-        <%= f.submit pd.navigation_details.primary_text, { class: 'govuk-button govuk-!-margin-right-4', contract_id: find_contract_id } %>
-        <%= link_to pd.navigation_details.secondary_text, pd.navigation_details.secondary_url, class: 'govuk-button govuk-button--secondary' %>
+        <%= f.submit pd.navigation_details.primary_text, { class: 'govuk-button govuk-!-margin-right-4', contract_id: find_contract_id, 'aria-label': "#{pd.navigation_details.primary_text}" } %>
+        <%= link_to pd.navigation_details.secondary_text, pd.navigation_details.secondary_url, class: 'govuk-button govuk-button--secondary', 'aria-label': "#{pd.navigation_details.secondary_text}" %>
     <% end %>
 <% end %>

--- a/app/views/facilities_management/beta/procurements/da_buyer/_closing_direct_award_offer.html.erb
+++ b/app/views/facilities_management/beta/procurements/da_buyer/_closing_direct_award_offer.html.erb
@@ -16,8 +16,8 @@
             <div class="govuk-body">
                 Closed procurements can be viewed in the closed section of your procurements dashboard, where you have the option to create a copy of the requirements for use in a new/similar procurement, or further competition.    
             </div>
-            <%= govuk_button(f, pd.navigation_details.primary_text, options = { submit: true, button: :warning, class: 'govuk-!-margin-right-4'}) %>
-            <%= govuk_button(f, pd.navigation_details.secondary_text, options = { submit: true, button: :secondary }) %>
+            <%= govuk_button(f, pd.navigation_details.primary_text, options = { submit: true, button: :warning, class: 'govuk-!-margin-right-4', 'aria-label': "#{pd.navigation_details.primary_text}"}) %>
+            <%= govuk_button(f, pd.navigation_details.secondary_text, options = { submit: true, button: :secondary, 'aria-label': "#{pd.navigation_details.secondary_text}" }) %>
         </div>
     <% end %>
 <% end %>

--- a/app/views/facilities_management/beta/procurements/da_buyer/_contract_details.html.erb
+++ b/app/views/facilities_management/beta/procurements/da_buyer/_contract_details.html.erb
@@ -4,10 +4,10 @@
 
   <div class="govuk-!-margin-top-5">
     <%= form_for @page_data[:model_object], url: facilities_management_beta_procurement_path(@procurement.id), method: :put, html: { specialvalidation: false, novalidate: true, multipart: true } do |f| %>
-      <%= f.submit @page_description.navigation_details.primary_text, class: 'govuk-button govuk-!-margin-right-4', data: { disable_with: false }, name: 'continue_to_review_and_generate'%>
-      <%= f.submit @page_description.navigation_details.secondary_text, class: ' govuk-button govuk-button--secondary', data: {disable_with: false }, name: 'continue_to_results' %>
+      <%= f.submit @page_description.navigation_details.primary_text, class: 'govuk-button govuk-!-margin-right-4', data: { disable_with: false }, name: 'continue_to_review_and_generate', 'aria-label': "#{@page_description.navigation_details.primary_text}" %>
+      <%= f.submit @page_description.navigation_details.secondary_text, class: ' govuk-button govuk-button--secondary', data: {disable_with: false }, name: 'continue_to_results', 'aria-label': "#{@page_description.navigation_details.secondary_text}" %>
       </br>
-      <%= link_to @page_description.navigation_details.return_text, facilities_management_beta_procurements_path, role: 'button', class: 'govuk-link govuk-!-font-size-19' %>
+      <%= link_to @page_description.navigation_details.return_text, facilities_management_beta_procurements_path, role: 'button', class: 'govuk-link govuk-!-font-size-19', 'aria-label': "#{@page_description.navigation_details.return_text}" %>
   </div>
   <%end %>
 <%end %>

--- a/app/views/facilities_management/beta/procurements/da_buyer/_contract_signed.html.erb
+++ b/app/views/facilities_management/beta/procurements/da_buyer/_contract_signed.html.erb
@@ -20,6 +20,6 @@
             Start date: <%= @page_data[:start_date] %> <br />
             End date: <%= @page_data[:end_date] %>
         </div>
-        <%= f.submit(pd.navigation_details.secondary_text, class: 'govuk-button govuk-button--secondary', data: { disable_with: false }, name: 'commit') %>
+        <%= f.submit(pd.navigation_details.secondary_text, class: 'govuk-button govuk-button--secondary', data: { disable_with: false }, name: 'commit', 'aria-label': "#{@page_description.navigation_details.secondary_text}") %>
     <% end %>
 <% end %>

--- a/app/views/facilities_management/beta/procurements/da_buyer/_contract_summary.html.erb
+++ b/app/views/facilities_management/beta/procurements/da_buyer/_contract_summary.html.erb
@@ -15,10 +15,10 @@
             </strong>
         </div>
         <div>
-            <%= link_to pd.navigation_details.secondary_text, pd.navigation_details.secondary_url, class: 'govuk-button govuk-button--warning govuk-!-margin-top-6' %>
+            <%= link_to pd.navigation_details.secondary_text, pd.navigation_details.secondary_url, class: 'govuk-button govuk-button--warning govuk-!-margin-top-6', 'aria-label': "#{pd.navigation_details.secondary_text}" %>
         </div>
         <div>
-            <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19 govuk-link--no-visited-state') %>
+            <%= link_to(pd.navigation_details.return_text, pd.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19 govuk-link--no-visited-state', 'aria-label': "#{pd.navigation_details.return_text}") %>
         </div>
     <% end %>
 

--- a/app/views/facilities_management/beta/procurements/da_buyer/_review_and_generate_documents.html.erb
+++ b/app/views/facilities_management/beta/procurements/da_buyer/_review_and_generate_documents.html.erb
@@ -10,7 +10,7 @@
             </h1>
             <%= render partial: 'facilities_management/beta/procurements/da_buyer/procurement_requirements' %>
             
-            <%= f.submit('Change requirements', class: 'govuk-button govuk-button--warning', data: { disable_with: false }, name: :change_requirements) %>
+            <%= f.submit('Change requirements', class: 'govuk-button govuk-button--warning', data: { disable_with: false }, name: :change_requirements, 'aria-label': "Change requirements") %>
         </div>
     
         <div>
@@ -19,7 +19,7 @@
             </h1>
             <%= render partial: 'facilities_management/beta/procurements/da_buyer/contract_details_summary' %>
             
-            <%= f.submit('Change contract details', class: 'govuk-button govuk-button--secondary', data: { disable_with: false }, name: :change_contract_details) %>
+            <%= f.submit('Change contract details', class: 'govuk-button govuk-button--secondary', data: { disable_with: false }, name: :change_contract_details, 'aria-label': "Change contract details") %>
         </div>
         
         <div>

--- a/app/views/facilities_management/beta/procurements/da_buyer/_review_contract.html.erb
+++ b/app/views/facilities_management/beta/procurements/da_buyer/_review_contract.html.erb
@@ -106,7 +106,7 @@
             </ul>
           <% end %>
 
-          <%= link_to t('.download_documents.title'), facilities_management_beta_procurement_documents_zip_path(procurement_id: @procurement.id, contract_id: @procurement.first_unsent_contract.id), class: 'govuk-button govuk-button--secondary' %>
+          <%= link_to t('.download_documents.title'), facilities_management_beta_procurement_documents_zip_path(procurement_id: @procurement.id, contract_id: @procurement.first_unsent_contract.id), class: 'govuk-button govuk-button--secondary', 'aria-label': "#{t('.download_documents.title')}"  %>
         </div>
 
 
@@ -117,7 +117,7 @@
 
         <strong><p><%= t('.change_requirements.guidance') %></strong>
         <div>
-          <%= f.submit(t('.change_requirements.title'), class: 'govuk-button govuk-button--warning', data: { disable_with: false }, name: :continue_to_review_and_generate) %>
+          <%= f.submit(t('.change_requirements.title'), class: 'govuk-button govuk-button--warning', data: { disable_with: false }, name: :continue_to_review_and_generate, 'aria-label': "#{t('.change_requirements.title')}") %>
         </div>
         <strong><p><%= t('.change_schedule.guidance') %></strong>
 

--- a/app/views/facilities_management/beta/procurements/edit.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit.html.erb
@@ -51,17 +51,17 @@
       <% if @procurement.detailed_search? || @procurement.quick_search? %>
         <div class="govuk-!-margin-top-5">
           <% if @delete %>
-            <%= link_to t('.confirm_delete'), facilities_management_beta_procurement_path(@procurement), :method => 'delete', class: "govuk-button govuk-button--warning" %>
-            <%= link_to t('.cancel'), facilities_management_beta_procurements_url, class: "govuk-button govuk-button--secondary govuk-!-margin-left-3" %>
+            <%= link_to t('.confirm_delete'), facilities_management_beta_procurement_path(@procurement), :method => 'delete', class: "govuk-button govuk-button--warning", 'aria-label': t('.confirm_delete')  %>
+            <%= link_to t('.cancel'), facilities_management_beta_procurements_url, class: "govuk-button govuk-button--secondary govuk-!-margin-left-3", 'aria-label': t('.cancel') %>
           <% elsif %w[regions services].include? params[:step] %>
-            <%= f.submit t('.save_and_continue'), class: 'govuk-button', data: { disable_with: false }, name: @procurement.detailed_search? ? 'next_step' : 'start_detailed_search' %>
-            <%= f.submit t('.save_and_return_to_detailed_summary'), class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3', data: { disable_with: false } if @procurement.detailed_search? %>
+            <%= f.submit t('.save_and_continue'), class: 'govuk-button', 'aria-label': "#{t('.save_and_continue')}", data: { disable_with: false }, name: @procurement.detailed_search? ? 'next_step' : 'start_detailed_search' %>
+            <%= f.submit t('.save_and_return_to_detailed_summary'), class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3', 'aria-label': "#{t('.save_and_return_to_detailed_summary')}", data: { disable_with: false } if @procurement.detailed_search? %>
           <% elsif params[:step] == 'building_services' %>
-            <%= f.submit t('.save_and_return_to_detailed_summary'), class: 'govuk-button', data: { disable_with: false } if @procurement.detailed_search? %>
+            <%= f.submit t('.save_and_return_to_detailed_summary'), class: 'govuk-button', 'aria-label': "#{t('.save_and_return_to_detailed_summary')}", data: { disable_with: false } if @procurement.detailed_search? %>
           <% else %>
-            <%= f.submit t('.save_and_continue'), class: 'govuk-button', data: { disable_with: false }, name: @procurement.detailed_search? ? 'next_step' : 'start_detailed_search' if @procurement.detailed_search? || @procurement.quick_search? %>
-            <%= f.submit t('.save_and_return_to_detailed_summary'), class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3', data: { disable_with: false } if @procurement.detailed_search? %>
-            <%= f.submit t('.save_for_later'), class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3', data: { disable_with: false } if @procurement.quick_search? %>
+            <%= f.submit t('.save_and_continue'), class: 'govuk-button', 'aria-label': "#{t('.save_and_continue')}", data: { disable_with: false }, name: @procurement.detailed_search? ? 'next_step' : 'start_detailed_search' if @procurement.detailed_search? || @procurement.quick_search? %>
+            <%= f.submit t('.save_and_return_to_detailed_summary'), class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3', 'aria-label': "#{t('.save_and_return_to_detailed_summary')}", data: { disable_with: false } if @procurement.detailed_search? %>
+            <%= f.submit t('.save_for_later'), class: 'govuk-button govuk-button--secondary govuk-!-margin-left-3', 'aria-label': "#{t('.save_for_later')}", data: { disable_with: false } if @procurement.quick_search? %>
           <% end %>
         </div>
         <% if params[:step] && @procurement.detailed_search? && params[:step] != 'building_services' %>
@@ -70,8 +70,8 @@
           </div>
         <% end %>
         <div class="govuk-!-margin-top-3 govuk-!-margin-bottom-7">
-          <%= link_to t('.back_to_detailed_summary'), facilities_management_beta_procurement_path(@procurement), class: 'govuk-link--no-visited-state' if @procurement.detailed_search? %>
-          <%= link_to t('.cancel_and_return'), facilities_management_beta_procurements_path, class: 'govuk-link--no-visited-state' if @procurement.quick_search? %>
+          <%= link_to t('.back_to_detailed_summary'), facilities_management_beta_procurement_path(@procurement), class: 'govuk-link--no-visited-state', 'aria-label': "#{t('.back_to_detailed_summary')}" if @procurement.detailed_search? %>
+          <%= link_to t('.cancel_and_return'), facilities_management_beta_procurements_path, class: 'govuk-link--no-visited-state', 'aria-label': "#{t('.cancel_and_return')}" if @procurement.quick_search? %>
         </div>
       <% end %>
     </div>

--- a/app/views/facilities_management/beta/procurements/edit/_new_authorised_representative_details.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit/_new_authorised_representative_details.html.erb
@@ -43,7 +43,7 @@
                 </div>
               </div>
               <div class="govuk-!-margin-top-1 govuk-!-margin-bottom-2">
-                <a role="button" class="govuk-button govuk-!-margin-bottom-2" id="buyer-details-find-address-btn"><%= 'Find Address' %></a>
+                <a role="button" class="govuk-button govuk-!-margin-bottom-2" id="buyer-details-find-address-btn" aria-label="<%= 'Find Address' %>"><%= 'Find Address' %></a>
               </div>
               <div class="govuk-!-margin-top-0">
                 <%= link_to t('.missing_address'), edit_facilities_management_beta_procurement_path(:step => 'new_authorised_representative_address'), class: "govuk-link--no-visited-state govuk-caption-m", id: 'add_new_authorised_contact_details_adress_1' %>

--- a/app/views/facilities_management/beta/procurements/edit/_new_invoicing_contact_details.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit/_new_invoicing_contact_details.html.erb
@@ -39,7 +39,7 @@
                 </div>
               </div>
               <div class="govuk-!-margin-top-1 govuk-!-margin-bottom-2">
-                <a role="button" class="govuk-button govuk-!-margin-bottom-2" id="buyer-details-find-address-btn"><%= 'Find Address' %></a>
+                <a role="button" class="govuk-button govuk-!-margin-bottom-2" id="buyer-details-find-address-btn" aria-label="Find Address"><%= 'Find Address' %></a>
               </div>
               <div class="govuk-!-margin-top-0">
                 <%= link_to t('.missing_address'), edit_facilities_management_beta_procurement_path(:step => 'new_invoicing_address'), class: "govuk-link--no-visited-state govuk-caption-m", id: 'add_new_invoice_contact_details_address_1' %>

--- a/app/views/facilities_management/beta/procurements/edit/_new_notices_contact_details.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit/_new_notices_contact_details.html.erb
@@ -39,7 +39,7 @@
                 </div>
               </div>
               <div class="govuk-!-margin-top-1 govuk-!-margin-bottom-2">
-                <a role="button" class="govuk-button govuk-!-margin-bottom-2" id="buyer-details-find-address-btn"><%= 'Find Address' %></a>
+                <a role="button" class="govuk-button govuk-!-margin-bottom-2" id="buyer-details-find-address-btn" aria-label="Find Address"><%= 'Find Address' %></a>
               </div>
               <div class="govuk-!-margin-top-0">
                 <%= link_to t('.missing_address'), edit_facilities_management_beta_procurement_path(:step => 'new_notices_address'), class: "govuk-link--no-visited-state govuk-caption-m", id: 'add_new_notices_contact_details_adress_1' %>

--- a/app/views/facilities_management/beta/procurements/edit/_pension_funds.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit/_pension_funds.html.erb
@@ -15,6 +15,6 @@
             <% error_index += 1 %>
         <% end %>
     </div>
-    <%= link_to_add_row("Add another pension fund (#{FacilitiesManagement::Procurement::MAX_NUMBER_OF_PENSIONS - @procurement.procurement_pension_funds.size} remaining)", f, :procurement_pension_funds, class: 'add-pension-button govuk-button govuk-button--secondary govuk-!-margin-bottom-2') %>
+    <%= link_to_add_row("Add another pension fund (#{FacilitiesManagement::Procurement::MAX_NUMBER_OF_PENSIONS - @procurement.procurement_pension_funds.size} remaining)", f, :procurement_pension_funds, class: 'add-pension-button govuk-button govuk-button--secondary govuk-!-margin-bottom-2', 'aria-label': "Add another pension fund" ) %>
     <%= govuk_continuation_buttons(pd, f, false) %>
 <% end %>

--- a/app/views/facilities_management/beta/procurements/edit/_procurement_buildings.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit/_procurement_buildings.html.erb
@@ -46,7 +46,7 @@
         <div>
           <h3 class="govuk-heading-m" data-txt01="<%= t('.buildings_selected') %>" data-txt02="<%= t('.no_buildings_selected') %>">
             <span id="selected-buildings-count">0</span> <span><%= t('.buildings_selected') %></span></h3>
-          <a class="govuk-!-padding-left-2 remove-link" role="button" href="#"><%= t('.remove_all') %></a><br />
+          <a class="govuk-!-padding-left-2 remove-link" role="button" href="#" aria-label="<%= t('.remove_all') %>"><%= t('.remove_all') %></a><br />
           <ul style="margin-top:10px;" class="govuk-list"></ul>
         </div>
       </div>

--- a/app/views/facilities_management/beta/procurements/edit/_procurement_pension_fund.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit/_procurement_pension_fund.html.erb
@@ -23,7 +23,7 @@
         </p>
         <p class="govuk-!-margin-bottom-0">
             <%= ff.number_field :percentage, min: 1, max: 100, class: "pension-percentage govuk-input govuk-input--width-4 #{'govuk-input--error' if !ff.object.errors[:percentage].empty?}", maxlength: '3' %> %
-            <%= link_to 'Remove', '#', class: 'remove-pension-record govuk-button govuk-button--secondary govuk-!-margin-left-4 govuk-!-margin-bottom-0' %>
+            <%= link_to 'Remove', '#', class: 'remove-pension-record govuk-button govuk-button--secondary govuk-!-margin-left-4 govuk-!-margin-bottom-0', 'aria-label': "Remove"%>
             <%= ff.text_field :_destroy, as: :hidden, class: 'pension-destroy-box govuk-visually-hidden', 'tabindex': -1, "aria-label": "destroy" %>
         </p>
     </div>

--- a/app/views/facilities_management/beta/procurements/edit/_services.html.erb
+++ b/app/views/facilities_management/beta/procurements/edit/_services.html.erb
@@ -81,7 +81,7 @@
           <div>
             <h3 class="govuk-heading-m" data-txt01="services selected" data-txt02="no services selected">
               <span id="selected-services-count">0</span> <span>services selected</span></h3>
-            <a class="govuk-!-padding-left-2 remove-link" role="button" href="#">Remove all</a><br/>
+            <a class="govuk-!-padding-left-2 remove-link" role="button" href="#" aria-label="Remove all">Remove all</a><br/>
             <ul style="margin-top:10px;" class="govuk-list"></ul>
           </div>
         </div>

--- a/app/views/facilities_management/beta/procurements/index.html.erb
+++ b/app/views/facilities_management/beta/procurements/index.html.erb
@@ -17,7 +17,7 @@
     <h1 class="govuk-heading-xl"><%= t('.manage_procurements') %></h1>
     <% content_for :page_title, t('.manage_procurements') %>
 
-    <a class="govuk-button govuk-!-margin-top-4  govuk-!-margin-bottom-8 govuk-!-padding-left-5 govuk-!-padding-right-5" href="/facilities-management/choose-services"><%= t('.start_new_search') %></a>
+    <a class="govuk-button govuk-!-margin-top-4  govuk-!-margin-bottom-8 govuk-!-padding-left-5 govuk-!-padding-right-5" href="/facilities-management/choose-services" aria-label="<%= t('.start_new_search') %>" ><%= t('.start_new_search') %></a>
 
     <div class="ccs-info-panel">
       <h1 class="govuk-heading-m"><%= t('.searches_title') %></h1>

--- a/app/views/facilities_management/beta/procurements/new.html.erb
+++ b/app/views/facilities_management/beta/procurements/new.html.erb
@@ -13,10 +13,10 @@
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full"
-        <%= f.submit t('.save_your_search'), data: {disable_with:false}, class: 'govuk-button' %>
-        <%= f.submit t('.save_for_later'), name: 'save_for_later', data: {disable_with:false}, class: 'govuk-button govuk-button--secondary' %>
+        <%= f.submit t('.save_your_search'), data: {disable_with:false}, class: 'govuk-button', 'aria-label': t('.save_your_search') %>
+        <%= f.submit t('.save_for_later'), name: 'save_for_later', data: {disable_with:false}, class: 'govuk-button govuk-button--secondary', 'aria-label': t('.save_for_later') %>
         <br />
-        <%= link_to t('.cancel_text'), facilities_management_beta_procurements_path, class: 'govuk-link govuk-link--no-visited-state' %>
+        <%= link_to t('.cancel_text'), facilities_management_beta_procurements_path, class: 'govuk-link govuk-link--no-visited-state', 'aria-label': t('.cancel_text') %>
       </div>
     </div>
   </div>

--- a/app/views/facilities_management/beta/supplier/contracts/edit.html.erb
+++ b/app/views/facilities_management/beta/supplier/contracts/edit.html.erb
@@ -38,8 +38,8 @@
             </div>
         </div>
         <div class= 'govuk-!-margin-top-5'>
-            <%= f.submit(pd.navigation_details.primary_text, class: 'govuk-button govuk-!-margin-right-4', data: { disable_with: false }, name: [pd.navigation_details.primary_name, 'commit'].find(&:present?)) %>
-            <%= link_to pd.navigation_details.secondary_text, pd.navigation_details.secondary_url, class: 'govuk-button govuk-button--secondary' %>
+            <%= f.submit(pd.navigation_details.primary_text, class: 'govuk-button govuk-!-margin-right-4', 'aria-label': "#{pd.navigation_details.primary_text}", data: { disable_with: false }, name: [pd.navigation_details.primary_name, 'commit'].find(&:present?)) %>
+            <%= link_to pd.navigation_details.secondary_text, pd.navigation_details.secondary_url, class: 'govuk-button govuk-button--secondary', 'aria-label': "#{pd.navigation_details.secondary_text}" %>
         </div>
     <% end %>
 <% end %>

--- a/app/views/facilities_management/beta/supplier/contracts/show.html.erb
+++ b/app/views/facilities_management/beta/supplier/contracts/show.html.erb
@@ -29,13 +29,13 @@
     <% case @contract.aasm_state %>
     <% when 'sent' %>
       <div class='govuk-!-margin-top-5'>
-        <%= link_to(pd.navigation_details.primary_text, edit_facilities_management_beta_supplier_contract_path(@contract.id), role: 'button', class: 'govuk-link govuk-!-font-size-19 govuk-button') %>
+        <%= link_to(pd.navigation_details.primary_text, edit_facilities_management_beta_supplier_contract_path(@contract.id), role: 'button', class: 'govuk-link govuk-!-font-size-19 govuk-button', 'aria-label': "#{pd.navigation_details.primary_text}") %>
         <br/>
-        <%= link_to(pd.navigation_details.return_text, @page_description.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19') %>
+        <%= link_to(pd.navigation_details.return_text, @page_description.navigation_details.return_url, role: 'button', class: 'govuk-link govuk-!-font-size-19', 'aria-label': "#{pd.navigation_details.return_text}") %>
       </div>
     <% else %>
       <div class='govuk-!-margin-top-5'>
-        <%= link_to(pd.navigation_details.secondary_text, @page_description.navigation_details.secondary_url, role: 'button', class: 'govuk-link govuk-!-font-size-19 govuk-button govuk-button--secondary') %>
+        <%= link_to(pd.navigation_details.secondary_text, @page_description.navigation_details.secondary_url, role: 'button', class: 'govuk-link govuk-!-font-size-19 govuk-button govuk-button--secondary', 'aria-label': "#{pd.navigation_details.secondary_text}" ) %>
       </div>
     <% end %>
   </div>

--- a/app/views/facilities_management/beta/supplier/sent/index.html.erb
+++ b/app/views/facilities_management/beta/supplier/sent/index.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: 'accepted_offer' if @contract.aasm_state == 'accepted' %>
 <%= render partial: 'declined_offer' if @contract.aasm_state == 'declined' %>
 
-<%= link_to t('.link_text'), facilities_management_beta_supplier_dashboard_index_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-top-9' %>
+<%= link_to t('.link_text'), facilities_management_beta_supplier_dashboard_index_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-top-9', 'aria-label': "#{t('.link_text')}" %>

--- a/app/views/facilities_management/beta/supplier/sessions/new.html.erb
+++ b/app/views/facilities_management/beta/supplier/sessions/new.html.erb
@@ -47,7 +47,7 @@
 
       </div>
 
-      <%= f.submit t('common.sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= f.submit t('common.sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.sign_in')}" %>
 
     <% end %>
 

--- a/app/views/facilities_management/beta/supplier/users/_new_password_required.html.erb
+++ b/app/views/facilities_management/beta/supplier/users/_new_password_required.html.erb
@@ -80,7 +80,7 @@
 
       <%= hidden_field_tag :challenge_name, params[:challenge_name] %>
 
-      <%= submit_tag t('common.change_password_and_sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.change_password_and_sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.change_password_and_sign_in')}" %>
 
     <% end %>
 

--- a/app/views/facilities_management/beta/supplier/users/_sms_mfa.html.erb
+++ b/app/views/facilities_management/beta/supplier/users/_sms_mfa.html.erb
@@ -58,7 +58,7 @@
 
       <%= hidden_field_tag :challenge_name, params[:challenge_name] %>
 
-      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.continue')}" %>
 
     <% end %>
 

--- a/app/views/facilities_management/beta/users/_new_password_required.html.erb
+++ b/app/views/facilities_management/beta/users/_new_password_required.html.erb
@@ -80,7 +80,7 @@
 
       <%= hidden_field_tag :challenge_name, params[:challenge_name] %>
 
-      <%= submit_tag t('common.change_password_and_sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.change_password_and_sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.change_password_and_sign_in')}"  %>
 
     <% end %>
 

--- a/app/views/facilities_management/beta/users/_sms_mfa.html.erb
+++ b/app/views/facilities_management/beta/users/_sms_mfa.html.erb
@@ -58,7 +58,7 @@
 
       <%= hidden_field_tag :challenge_name, params[:challenge_name] %>
 
-      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.continue')}" %>
 
     <% end %>
 

--- a/app/views/facilities_management/buildings/_building_address.html.erb
+++ b/app/views/facilities_management/buildings/_building_address.html.erb
@@ -9,7 +9,7 @@
       The postcode entered is invalid
     </span>
       <input id="fm-postcode-input" type="text" class="govuk-input govuk-input--width-5 govuk-!-margin-right-3">
-      <a id="fm-post-code-lookup-button" href="#" role="button" class="govuk-button">Find address</a>
+      <a id="fm-post-code-lookup-button" href="#" role="button" class="govuk-button" aria-label="Find address">Find address</a>
     </div>
     <a href="https://www.royalmail.com/find-a-postcode" class="govuk-link--no-visited-state" target="_blank" role="button">Find
       a postcode on Royal Mail's
@@ -22,7 +22,7 @@
         <label id="fm-postcode-label" class="govuk-heading-s"></label>
       </div>
       <div class="govuk-grid-column-one-quarter">
-        <a id="fm-change-postcode" href="#" class="govuk-link--no-visited-state" role="button">Change</a>
+        <a id="fm-change-postcode" href="#" class="govuk-link--no-visited-state" role="button" aria-label="Change">Change</a>
       </div>
     </div>
     <label class="govuk-heading-s govuk-!-margin-bottom-0">Select an address</label>
@@ -35,7 +35,7 @@
       </select>
     </div>
     <div class="govuk-!-margin-top-3">
-      <a id="fm-building-not-found" href="new-building-address" class="govuk-link--no-visited-state" role="button">I
+      <a id="fm-building-not-found" href="new-building-address" class="govuk-link--no-visited-state" role="button" aria-label="building not found">I
         can't find my building's
         address in the list</a>
     </div>

--- a/app/views/facilities_management/buildings/_building_list.html.erb
+++ b/app/views/facilities_management/buildings/_building_list.html.erb
@@ -140,7 +140,7 @@
       <% end %>
     </div>
   </div>
-  <a id="fm-buildings-add-building" href="#" class="govuk-button ccs-no-print govuk-!-margin-3" role="button">+
+  <a id="fm-buildings-add-building" href="#" class="govuk-button ccs-no-print govuk-!-margin-3" role="button" aria-label="add a building">+
     Add a
     building
   </a>

--- a/app/views/facilities_management/buildings/_services.html.erb
+++ b/app/views/facilities_management/buildings/_services.html.erb
@@ -26,7 +26,7 @@
     <%= form_tag '/facilities-management/select-services', id: 'fm-buldings-add-services-continue-link-form', method: :post do %>
       <%= hidden_field_tag 'current_choices', TransientSessionInfo[session.id].to_json %>
 
-      <a onclick="document.getElementById('fm-buldings-add-services-continue-link-form').submit();" id="fm-buldings-add-services-continue-link" href="/facilities-management/select-services" class="govuk-link--no-visited-state  ccs-no-print" role="button">+
+      <a onclick="document.getElementById('fm-buldings-add-services-continue-link-form').submit();" id="fm-buldings-add-services-continue-link" href="/facilities-management/select-services" class="govuk-link--no-visited-state  ccs-no-print" role="button" aria-label="Add new services">+
         Add new services</a>
 
       <!-- submit_tag '+ Add services', class: "govuk-link--no-visited-state ccs-no-print" -->
@@ -37,7 +37,7 @@
     <%= hidden_field_tag 'fm-services', "" %>
     <%= hidden_field_tag 'fm-locations', "" %>
     <div class="govuk-grid-row govuk-!-margin-top-6">
-      <a id="fm-select-services-continue-btn" href="" class="govuk-button ccs-no-print" role="button">Continue</a>
+      <a id="fm-select-services-continue-btn" href="" class="govuk-button ccs-no-print" role="button" aria-label="Continue">Continue</a>
     </div>
   <% end %>
 </div>

--- a/app/views/facilities_management/buildings/building_type.html.erb
+++ b/app/views/facilities_management/buildings/building_type.html.erb
@@ -47,7 +47,7 @@
   <%= form_tag '/facilities-management/buildings/select-services', id: 'fm-building-type-form', method: :post do %>
     <%= hidden_field_tag 'current_choices', TransientSessionInfo[session.id].to_json %>
     <div class="govuk-!-margin-top-6">
-      <a id="fm-building-type-continue" href="#" class="govuk-button ccs-no-print" role="button">Continue</a>
+      <a id="fm-building-type-continue" href="#" class="govuk-button ccs-no-print" role="button" aria-label="Continue">Continue</a>
     </div>
   <% end %>
 </div>

--- a/app/views/facilities_management/buildings/buildings.html.erb
+++ b/app/views/facilities_management/buildings/buildings.html.erb
@@ -17,7 +17,7 @@
              class="govuk-button ccs-no-print" role="button">Continue</a>
           -->
 
-          <%= submit_tag t('common.submit'), class: "govuk-button" %>
+          <%= submit_tag t('common.submit'), class: "govuk-button", 'aria-label': "#{t('common.submit')}" %>
 
         </div>
       <% end %>

--- a/app/views/facilities_management/buildings/manual_address_entry_form.html.erb
+++ b/app/views/facilities_management/buildings/manual_address_entry_form.html.erb
@@ -71,7 +71,7 @@
     <%= form_tag '/facilities-management/buildings/new-building#fm-internal-square-area', id: 'fm-manual-address-entry-form', method: :post do %>
       <%= hidden_field_tag 'current_choices', TransientSessionInfo[session.id].to_json %>
       <div class="govuk-!-margin-top-6">
-          <a id="fm-new-address-continue" href="" class="govuk-button ccs-no-print" role="button">Continue</a>
+          <a id="fm-new-address-continue" href="" class="govuk-button ccs-no-print" role="button" aria-label="Continue">Continue</a>
       </div>
     <% end %>
   </div>

--- a/app/views/facilities_management/buildings/new_building.html.erb
+++ b/app/views/facilities_management/buildings/new_building.html.erb
@@ -14,7 +14,7 @@
       <%= form_tag '/facilities-management/buildings/building-type', id: 'fm-new-building-continue-form', method: :post do %>
         <%= hidden_field_tag 'current_choices', TransientSessionInfo[session.id].to_json %>
         <div class="govuk-!-margin-top-4">
-            <a id="fm-new-building-continue" href="building-type" class="govuk-button ccs-no-print" role="button">Continue</a>
+            <a id="fm-new-building-continue" href="building-type" class="govuk-button ccs-no-print" role="button" aria-label="Continue">Continue</a>
         </div>
       <% end %>
     </div>

--- a/app/views/facilities_management/buildings/units_of_measurement.html.erb
+++ b/app/views/facilities_management/buildings/units_of_measurement.html.erb
@@ -68,7 +68,7 @@
           <hidden id="fm-service-uom-code" name="fm-service-uom-code" value="<%= @service_code %>"></hidden>
           <hidden id="fm-is-lift" name="fm-is-lift" value="<%= @is_lift %>"></hidden>
           <div class="govuk-!-margin-top-8">
-            <a id="fm-unit-of-measurement-submit" type="button" class="govuk-button" role="button">Continue</a>
+            <a id="fm-unit-of-measurement-submit" type="button" class="govuk-button" role="button" aria-label="Continue">Continue</a>
           </div>
         </div>
       <% end %>

--- a/app/views/facilities_management/contract/start_of_contract.html.erb
+++ b/app/views/facilities_management/contract/start_of_contract.html.erb
@@ -60,7 +60,7 @@
 
       <%= hidden_field_tag 'current_choices', TransientSessionInfo[session.id].to_json %>
 
-      <a role='button' class='govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' id='fm-save-contract-start-date-link'>Continue</a>
+      <a role='button' class='govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' id='fm-save-contract-start-date-link' aria-label="Continue">Continue</a>
     <% end %> <!-- </form> -->
   </div>
 </div>

--- a/app/views/facilities_management/home/index.html.erb
+++ b/app/views/facilities_management/home/index.html.erb
@@ -14,7 +14,7 @@
         <%= t('facilities_management.home.startlist').html_safe %>
       </ul>
       <p>
-        <%= link_to t('facilities_management.home.startnow'), '/facilities-management/select-services', role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' %>
+        <%= link_to t('facilities_management.home.startnow'), '/facilities-management/select-services', role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', 'aria-label': "#{t('facilities_management.home.startnow')}" %>
       </p>
     </div>
   </div>

--- a/app/views/facilities_management/journey/choose_locations.html.erb
+++ b/app/views/facilities_management/journey/choose_locations.html.erb
@@ -70,14 +70,14 @@
               </div>
             <% end %>
           <% end %>
-          <%= submit_tag t('common.submit'), class: "govuk-button" %>
+          <%= submit_tag t('common.submit'), class: "govuk-button", 'aria-label': "#{t('common.submit')}" %>
         </div>
         <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
           <div class="basket" id="css-list-basket">
             <div>
               <h3 class="govuk-heading-m" data-txt01="<%= t('.locations_selected') %>" data-txt02="<%= t('.no_locations_selected') %>">
                 <span id="selected-locations-count">0</span> <span><%= t('.locations_selected') %></span></h3>
-              <a class="govuk-!-padding-left-2 remove-link" role="button" href=""><%= t('.remove_all') %></a><br />
+              <a class="govuk-!-padding-left-2 remove-link" role="button" href="" aria-label="<%= t('.remove_all') %>"><%= t('.remove_all') %></a><br />
               <ul style="margin-top:10px;" class="govuk-list"></ul>
             </div>
           </div>

--- a/app/views/facilities_management/journey/choose_services.html.erb
+++ b/app/views/facilities_management/journey/choose_services.html.erb
@@ -96,14 +96,14 @@
           <% params[:region_codes]&.split(" ") do |region_code| %>
             <%= hidden_field_tag "region_codes[]", region_code %>
           <% end %>
-          <%= submit_tag t('common.submit'), class: "govuk-button" %>
+          <%= submit_tag t('common.submit'), class: "govuk-button", 'aria-label': "#{t('common.submit')}" %>
         </div>
         <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
           <div class="basket">
             <div>
               <h3 class="govuk-heading-m" data-txt01="<%= t('.services_selected') %>" data-txt02="<%= t('.no_services_selected') %>">
                 <span id="selected-services-count">0</span> <span><%= t('.services_selected') %></span></h3>
-              <a class="govuk-!-padding-left-2 remove-link" role="button" href="#"><%= t('.remove_all') %></a><br/>
+              <a class="govuk-!-padding-left-2 remove-link" role="button" href="#" aria-label="<%= t('.remove_all') %>"><%= t('.remove_all') %></a><br/>
               <ul style="margin-top:10px;" class="govuk-list"></ul>
             </div>
           </div>

--- a/app/views/facilities_management/long_list/long_list.html.erb
+++ b/app/views/facilities_management/long_list/long_list.html.erb
@@ -38,12 +38,12 @@
 
     <%= form_tag '/facilities-management/standard-contract/questions', id: 'fm-long-list-form', method: :post do %>
       <%= hidden_field_tag 'current_choices', TransientSessionInfo[session.id].to_json %>
-      <a id="fm-suppliers-continue-button" href="#" class="govuk-button ccs-no-print govuk-!-margin-top-4" role="button">Continue</a><br>
+      <a id="fm-suppliers-continue-button" href="#" class="govuk-button ccs-no-print govuk-!-margin-top-4" role="button" aria-label="Continue" >Continue</a><br>
     <% end %>
 
 
     <p>
-      <a id="FM-print-supplier-list" role="button" class="supplier-record__print-option ccs-no-print" href="">Print this
+      <a id="FM-print-supplier-list" role="button" class="supplier-record__print-option ccs-no-print" href="" aria-label="Print this">Print this
         page</a>
     </p>
   </div>

--- a/app/views/facilities_management/registrations/domain_not_on_whitelist.html.erb
+++ b/app/views/facilities_management/registrations/domain_not_on_whitelist.html.erb
@@ -27,7 +27,7 @@
       </li>
     </ul>
 
-    <%= link_to 'Back to create a Buyer account', facilities_management_new_user_registration_path, class: 'govuk-button govuk-!-margin-top-4  govuk-!-margin-bottom-8 govuk-!-padding-left-5 govuk-!-padding-right-5' %>
+    <%= link_to 'Back to create a Buyer account', facilities_management_new_user_registration_path, class: 'govuk-button govuk-!-margin-top-4  govuk-!-margin-bottom-8 govuk-!-padding-left-5 govuk-!-padding-right-5', 'aria-label': "Back to create a Buyer account" %>
 
   </div>
 </div>

--- a/app/views/facilities_management/registrations/new.html.erb
+++ b/app/views/facilities_management/registrations/new.html.erb
@@ -105,7 +105,7 @@
       </fieldset>
       <!-- password end -->
 
-      <%= f.submit t('common.create_account'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7 govuk-!-margin-bottom-8" %>
+      <%= f.submit t('common.create_account'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7 govuk-!-margin-bottom-8", 'aria-label': "#{t('common.create_account')}" %>
 
     <% end %>
 

--- a/app/views/facilities_management/select_locations/select_location.html.erb
+++ b/app/views/facilities_management/select_locations/select_location.html.erb
@@ -58,7 +58,7 @@
       <%= form_tag "/facilities-management/suppliers/long-list?#{request.query_string}", id: 'save-locations-link-form', method: :post do %>
         <%= hidden_field_tag  'postedlocations' %>
         <%= hidden_field_tag 'postedservices' %>
-        <%= link_to 'Continue', '/facilities-management/suppliers/long-list', role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', id: 'save-locations-link', name: 'save-locations-link' %>
+        <%= link_to 'Continue', '/facilities-management/suppliers/long-list', role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', id: 'save-locations-link', name: 'save-locations-link', 'aria-label': "Continue" %>
       <% end %>
     </p>
   </div>

--- a/app/views/facilities_management/select_services/select_services.html.erb
+++ b/app/views/facilities_management/select_services/select_services.html.erb
@@ -18,7 +18,7 @@
               <span class="govuk-accordion__section-button" id="<%= service['code'] %>"><%= service['name'] %></span>
             </h2>
           </div>
-          <div id="<%= service['code'] %>-content" class="govuk-accordion__section-content" aria-labelledby="<%= service['name'] %>">
+          <div id="<%= service['code'] %>-content" class="govuk-accordion__section-content" aria-labelled="<%= service['name'] %>">
             <% filteredCollection = @work_packages.select { |wp| wp['work_package_code'].starts_with?(service['code'])} %>
             <% filteredCollection.each do |workPackage| %>
               <% if workPackage['work_package_code'].start_with?(service['code']) %>
@@ -71,7 +71,7 @@
       <% end %>
     </div>
     <%= form_tag '/facilities-management/buildings/select-locations', id: 'save-services-link-form', method: :post do %>
-      <%= link_to t('common.continue'), "/facilities-management/select-locations?#{request.query_string}", role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', id: 'save-services-link', name: 'save-services-link' %>
+      <%= link_to t('common.continue'), "/facilities-management/select-locations?#{request.query_string}", role: 'button', class: 'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8', id: 'save-services-link', name: 'save-services-link', 'aria-label': "#{t('common.continue')}" %>
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/app/views/facilities_management/sessions/new.html.erb
+++ b/app/views/facilities_management/sessions/new.html.erb
@@ -46,7 +46,7 @@
 
       </div>
 
-      <%= f.submit t('common.sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= f.submit t('common.sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.sign_in')}" %>
 
     <% end %>
 

--- a/app/views/facilities_management/standard_contract_questions/standard_contract_questions.html.erb
+++ b/app/views/facilities_management/standard_contract_questions/standard_contract_questions.html.erb
@@ -18,7 +18,7 @@
     <%= hidden_field_tag 'current_choices', TransientSessionInfo[session.id].to_json %>
 
     <div class="govuk-grid-row govuk-!-margin-top-4">
-      <a id="fm-questions-continue" href="/facilities-management/buildings-list" class="govuk-button ccs-no-print" role="button">Continue</a>
+      <a id="fm-questions-continue" href="/facilities-management/buildings-list" class="govuk-button ccs-no-print" role="button" aria-label="Continue">Continue</a>
     </div>
 
     <!--

--- a/app/views/facilities_management/summary/index.html.erb
+++ b/app/views/facilities_management/summary/index.html.erb
@@ -97,7 +97,7 @@
           </div>
         </fieldset>
       </div>
-      <%= submit_tag t('common.submit'), class: "govuk-button" %>
+      <%= submit_tag t('common.submit'), class: "govuk-button", 'aria-label': "#{t('common.submit')}" %>
 
       <%= hidden_field_tag 'current_choices', TransientSessionInfo[session.id].to_json %>
     </form>
@@ -106,7 +106,7 @@
 
   <div class="govuk-grid-row ccs-no-print">
     <p>
-      <a id="FM-print-supplier-list" role="button" class="supplier-record__print-option ccs-no-print" href="">Print this
+      <a id="FM-print-supplier-list" role="button" class="supplier-record__print-option ccs-no-print" href="" aria-label="Print this">Print this
         page</a>
     </p>
   </div>

--- a/app/views/facilities_management/users/_new_password_required.html.erb
+++ b/app/views/facilities_management/users/_new_password_required.html.erb
@@ -80,7 +80,7 @@
 
       <%= hidden_field_tag :challenge_name, params[:challenge_name] %>
 
-      <%= submit_tag t('common.change_password_and_sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.change_password_and_sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.change_password_and_sign_in')}" %>
 
     <% end %>
 

--- a/app/views/facilities_management/users/_sms_mfa.html.erb
+++ b/app/views/facilities_management/users/_sms_mfa.html.erb
@@ -58,7 +58,7 @@
 
       <%= hidden_field_tag :challenge_name, params[:challenge_name] %>
 
-      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.continue')}" %>
 
     <% end %>
 

--- a/app/views/facilities_management/users/confirm_new.html.erb
+++ b/app/views/facilities_management/users/confirm_new.html.erb
@@ -63,7 +63,7 @@
         </div>
       <% end %>
 
-      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.continue')}" %>
 
     <% end %>
 

--- a/app/views/shared/passwords/_edit.html.erb
+++ b/app/views/shared/passwords/_edit.html.erb
@@ -109,7 +109,7 @@
       <%= hidden_field_tag :user_email_reset_by_CSC, params[:username] %>
       <%= hidden_field_tag :user_email_reset_by_themself, @response.email %>
 
-      <%= submit_tag t('common.reset_password'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.reset_password'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.reset_password')}" %>
 
     <% end %>
 

--- a/app/views/shared/passwords/_new.html.erb
+++ b/app/views/shared/passwords/_new.html.erb
@@ -46,7 +46,7 @@
         <input class="govuk-input govuk-!-width-three-quarters" id="email" name="email" type="email" aria-describedby="email-hint" autocomplete="off" spellcheck="false">
       </div>
 
-      <%= submit_tag t('common.send_reset_email'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.send_reset_email'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.send_reset_email')}" %>
 
     <% end %>
 

--- a/app/views/shared/passwords/_password_reset_success.html.erb
+++ b/app/views/shared/passwords/_password_reset_success.html.erb
@@ -10,7 +10,7 @@
       <%= t('.lead') %>
     </p>
 
-    <%= link_to t('common.sign_in'), local_new_user_session_path, id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+    <%= link_to t('common.sign_in'), local_new_user_session_path, id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.sign_in')}" %>
 
   </div>
 </div>

--- a/app/views/shared/sessions/_new.html.erb
+++ b/app/views/shared/sessions/_new.html.erb
@@ -47,7 +47,7 @@
 
       </div>
 
-      <%= f.submit t('common.sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= f.submit t('common.sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.sign_in')}" %>
 
     <% end %>
 

--- a/app/views/shared/users/_confirm_new.html.erb
+++ b/app/views/shared/users/_confirm_new.html.erb
@@ -63,7 +63,7 @@
         </div>
       <% end %>
 
-      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.continue')}" %>
 
     <% end %>
 

--- a/app/views/shared/users/_new_password_required.html.erb
+++ b/app/views/shared/users/_new_password_required.html.erb
@@ -80,7 +80,7 @@
 
       <%= hidden_field_tag :challenge_name, params[:challenge_name] %>
 
-      <%= submit_tag t('common.change_password_and_sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.change_password_and_sign_in'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.change_password_and_sign_in')}" %>
 
     <% end %>
 

--- a/app/views/shared/users/_sms_mfa.html.erb
+++ b/app/views/shared/users/_sms_mfa.html.erb
@@ -58,7 +58,7 @@
 
       <%= hidden_field_tag :challenge_name, params[:challenge_name] %>
 
-      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7" %>
+      <%= submit_tag t('common.continue'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.continue')}" %>
 
     <% end %>
 


### PR DESCRIPTION
use of aria-label tag on each continuation button within FM, addition of tag in continuation buttons in helper

change of descriptive tag to conform with accessibility

CTA labelling in admin, secondary CTA buttons