### PR TITLE
Fix for border-bottom for table now only removes isolated tr not all cells

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -7974,6 +7974,6 @@ li code, td code, p code {
     background-color: #6F777B !important;
     color: #FFFFFF !important;
 }
-.govuk-table__header, .govuk-border-bottom_none {
+.govuk-border-bottom_none {
     border-bottom: 0px !important;
 }


### PR DESCRIPTION
Fix for now removes bottom-border.