### PR TITLE
clicking link on email will now go to the right place for supplier

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,12 +20,19 @@ class ApplicationController < ActionController::Base
     when 'management_consultancy'
       management_consultancy_gateway_url
     when 'facilities_management'
-      facilities_management_gateway_url
+      session[:return_to] = request.fullpath
+      facilities_management_url_for_user_type
     when 'legal_services'
       legal_services_gateway_url
     else
       facilities_management_url
     end
+  end
+
+  def facilities_management_url_for_user_type
+    return facilities_management_supplier_new_user_session_url if controller_path.split('/')[1] == 'supplier' && controller_path.split('/')[2] == 'contracts'
+
+    facilities_management_gateway_url
   end
 
   delegate :ccs_homepage_url, to: Marketplace

--- a/app/controllers/facilities_management/sessions_controller.rb
+++ b/app/controllers/facilities_management/sessions_controller.rb
@@ -7,11 +7,13 @@ module FacilitiesManagement
     end
 
     def after_sign_in_path_for(resource)
+      return session[:return_to] unless session[:return_to].nil?
+
       stored_location_for(resource) || facilities_management_path
     end
 
     def after_sign_out_path_for(_resource)
-      facilities_management_path
+      facilities_management_new_user_session_path
     end
 
     def new_session_path

--- a/app/controllers/facilities_management/supplier/sessions_controller.rb
+++ b/app/controllers/facilities_management/supplier/sessions_controller.rb
@@ -6,6 +6,8 @@ class FacilitiesManagement::Supplier::SessionsController < Base::SessionsControl
   end
 
   def after_sign_in_path_for(resource)
+    return session[:return_to] unless session[:return_to].nil?
+
     stored_location_for(resource) || facilities_management_supplier_path
   end
 

--- a/app/views/facilities_management/procurements/contracts/sent/_sent.html.erb
+++ b/app/views/facilities_management/procurements/contracts/sent/_sent.html.erb
@@ -22,6 +22,7 @@
   <br>
 
   <p class=" govuk-!-font-weight-bold"><%= t('.declines_header') %></p>
+
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-0 govuk-!-padding-0 govuk-!-padding-left-7">
     <li class="govuk-!-margin-top-2 govuk-!-margin-bottom-2"><%= t('.declines_list_1') %></li>
     <li class="govuk-!-margin-top-2 govuk-!-margin-bottom-2"><%= t('.declines_list_2') %></li>
@@ -31,6 +32,7 @@
       <span> <%= t('.declines_list_2_sub_3') %> </span><br>
       <span> <%= t('.declines_list_2_sub_4') %> </span>
     </div>
+  </ul>
   <br>
 
   <p><%= t('.further_information') %></p>

--- a/app/views/facilities_management/procurements/edit/_procurement_buildings.html.erb
+++ b/app/views/facilities_management/procurements/edit/_procurement_buildings.html.erb
@@ -28,7 +28,6 @@
                     <legend class="govuk-fieldset__legend">
                       <%= procurement_building.object.name %>
                     </legend>
-                    <br />
                     <span class="govuk-hint govuk-!-margin-bottom-0"><%= procurement_building.object.full_address %></span>
                   <% end %>
                 </div>

--- a/app/views/facilities_management/procurements/edit/_services.html.erb
+++ b/app/views/facilities_management/procurements/edit/_services.html.erb
@@ -40,7 +40,7 @@
                                                 id: "facilities_management_procurement_service_codes_#{work_package['code'].gsub('.', '-')}",) %>
                               <label style="padding-top:0"
                                      class="govuk-label govuk-checkboxes__label"
-                                     for="<%= "service_#{work_package['code'].gsub('.', '-')}" %>">
+                                     for="<%= "facilities_management_procurement_service_codes_#{work_package['code'].gsub('.', '-')}" %>">
                                 <%= work_package['name'] %>
                                 <br/>
                                 <span style="font-weight:lighter;" id='<%= "#{work_package['code']}_description"%>'><%= work_package['description'] %></span>


### PR DESCRIPTION
fix the layout on contract sent page, select building and checkbox for select service

buyer sign out button go to the sign in page and not start page
supplier clicking email link should get them to the right page