### PR TITLE
Change display potential errors for html accessibility

### DIFF
--- a/app/assets/javascripts/facilities_management/beta/procurement/FormValidationComponent.js
+++ b/app/assets/javascripts/facilities_management/beta/procurement/FormValidationComponent.js
@@ -413,7 +413,18 @@ function FormValidationComponent(formDOMObject, validationCallback, thisisspecia
         if (jqueryElementForRequiredMessage.length === 0) {
             var errorCollectionForPropertyAndType = this.findErrorCollection(jQueryElement, errorType, property_name);
             if (errorCollectionForPropertyAndType.length > 0) {
-                jqueryElementForRequiredMessage = errorCollectionForPropertyAndType.find("label[data-validation='" + errorType + "']");
+                if (errorCollectionForPropertyAndType.hasClass('potenital-error')) {
+                  var errorLabel = errorCollectionForPropertyAndType.find("label").get(0);
+                  jqueryElementForRequiredMessage = errorLabel.cloneNode();
+                  jqueryElementForRequiredMessage.setAttribute('data-validation', errorType);
+                  var errorMessage = $(errorLabel).find("span[data-validation='" + errorType + "']").get(0).innerText
+                  var errorMessageElement = document.createElement("span");
+                  errorMessageElement.innerText = errorMessage;
+                  jqueryElementForRequiredMessage.append(errorMessageElement);
+                  jqueryElementForRequiredMessage = $(jqueryElementForRequiredMessage);
+                } else {
+                  jqueryElementForRequiredMessage = errorCollectionForPropertyAndType.find("label[data-validation='" + errorType + "']");
+                }
             }
         }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,17 +103,13 @@ module ApplicationHelper
     (attributes.is_a?(Array) ? attributes.last : attributes).to_s
   end
 
-  # rubocop:disable Metrics/ParameterLists
-  def display_potential_errors(model_object, attributes, form_object_name, error_lookup = nil, error_position = nil, section_name = nil)
+  def display_potential_errors(model_object, attributes, form_object_name, section_name = nil)
     collection = validation_messages(model_object.class.name.underscore.downcase.to_sym, attributes)
 
-    content_tag :div, class: 'error-collection', property_name: property_name(section_name, attributes) do
-      collection.each do |key, val|
-        concat(govuk_validation_error({ model_object: model_object, attribute: attributes.is_a?(Array) ? attributes.last : attributes, error_type: key, text: val, form_object_name: form_object_name }, error_lookup, error_position))
-      end
+    content_tag :div, class: 'error-collection potenital-error', property_name: property_name(section_name, attributes) do
+      multiple_validation_errors(model_object, attributes, form_object_name, collection)
     end
   end
-  # rubocop:enable Metrics/ParameterLists
 
   def model_attribute_has_error(model_object, *attributes)
     result = false

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -48,6 +48,21 @@ module ErrorsHelper
                                                                data: { propertyname: model_data[:attribute].to_s, validation: tag_validation_type }
   end
 
+  def multiple_validation_errors(model_object, attribute, form_object_name, error_collection)
+    content_tag :label, class: "govuk-error-message #{'govuk-visually-hidden' unless model_object.errors.any?}",
+                        for: "#{form_object_name}_#{attribute}",
+                        id: "#{attribute}-error" do
+      error_collection.each do |key, val|
+        tag_validation_type = ERROR_TYPE.include?(key) ? ERROR_TYPE[key] : key
+        concat(content_tag(:span, val, class: "govuk-error-message #{'govuk-visually-hidden' unless attribute_has_errors(model_object, attribute, key)}", data: { propertyname: attribute.to_s, validation: tag_validation_type }))
+      end
+    end
+  end
+
+  def attribute_has_errors(model_object, attribute, error_type)
+    model_object.errors.details[attribute][0]&.dig(:error) == error_type
+  end
+
   # looks up the locals data for validation messages
   def validation_messages(model_object_sym, attribute_sym = nil)
     translation_key = "activerecord.errors.models.#{model_object_sym.downcase}.attributes"

--- a/app/views/facilities_management/procurement_buildings_services/_day_section.html.erb
+++ b/app/views/facilities_management/procurement_buildings_services/_day_section.html.erb
@@ -2,7 +2,7 @@
   <%= govuk_fieldset_with_optional_error service_hours, :service_hours, day.to_sym do %>
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><%= day.to_s.humanize %></legend>
     <div class="govuk-form-group <%= 'govuk-form-group--error' if service_choice.errors.any? %>" data-propertyname="<%= day %>_service_choice">
-      <%= display_potential_errors service_choice, :service_choice, f.object_name, nil, nil, day %>
+      <%= display_potential_errors service_choice, :service_choice, f.object_name, day %>
       <div class="govuk-radios govuk-radios--conditional" data-module="radios">
         <%= display_error(f.object, day.to_sym) %>
         <div class="govuk-radios__item">
@@ -21,7 +21,7 @@
           <%= govuk_fieldset_with_optional_error service_choice, :start_time do %>
             <legend style="padding-left: 0 !important">Start</legend>
             <div class="govuk-form-group <%= 'govuk-form-group--error' if model_attribute_has_error(service_choice, :start_time) %>" data-propertyname="<%= day %>_start_time">
-              <%= display_potential_errors service_choice, :start_time, f.object_name, nil, nil, day %>
+              <%= display_potential_errors service_choice, :start_time, f.object_name, day %>
               <div class="govuk-date-input">
                 <%= f.hidden_field :start_time, class: "#{day}_start_time govuk-visually-hidden", id: "start_time"  %>
                 <div class="govuk-date-input__item">
@@ -43,7 +43,7 @@
           <%= govuk_fieldset_with_optional_error service_choice, :end_time do %>
             <legend style="padding-left: 0 !important">End</legend>
             <div class="govuk-form-group <%= 'govuk-form-group--error' if model_attribute_has_error(service_choice, :end_time) %>" data-propertyname="<%= day %>_end_time">
-              <%= display_potential_errors service_choice, :end_time, f.object_name, nil, nil, day %>
+              <%= display_potential_errors service_choice, :end_time, f.object_name, day %>
               <div class="govuk-date-input">
                 <%= f.hidden_field :end_time, class: "#{day}_end_time govuk-visually-hidden", id: "end_time" %>
                 <div class="govuk-date-input__item">


### PR DESCRIPTION
- Change display potential errors back end component
- Update form validator for display_potential_errors

Display potential errors created many error labels that had the same ID. Under the rules for accessibility this is not allowed. Therefore I have updated this method so that the ID's are uniq. This also required a change to the form validator to make sure it gets the right message when in use. This change should lead to no noticeable difference from before.