### PR TITLE
FM-1178 Contract start date error message

### DIFF
--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -154,7 +154,7 @@ en:
               not_a_date: Initial call-off period end date is not a valid date
             initial_call_off_period:
               blank: Enter initial call-off period
-              greater_than_or_equal_to: Enter initial call-off period
+              greater_than_or_equal_to: Initial call-off period must be between 1 and 7 years
               less_than_or_equal_to: Initial call-off period must be between 1 and 7 years
               not_a_number: Enter initial call-off period
               not_an_integer: Initial call-off period must be a whole number

--- a/spec/models/facilities_management/procurement_pension_fund_spec.rb
+++ b/spec/models/facilities_management/procurement_pension_fund_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe FacilitiesManagement::ProcurementPensionFund, type: :model do
 
       context 'when the percentage has more than 4 decimal places' do
         it 'is expected to not be valid' do
-          pension_fund.percentage = rand(0.0...100.0).round(5)
+          pension_fund.percentage = "#{rand(99)}.#{(0...5).map { rand(49..57).chr }.join}".to_f
           expect(pension_fund.valid?).to eq false
         end
       end


### PR DESCRIPTION
when user enters 0 for initial start date, correct error message is shown