### PR TITLE
FM-1165 Part 2: Buyer & Contact Details Tabbing and Accessibility

### DIFF
--- a/app/assets/javascripts/common/common.js
+++ b/app/assets/javascripts/common/common.js
@@ -55,6 +55,8 @@ const pageUtils = {
                                 $('#fm-post-code-results-container').removeClass('govuk-visually-hidden');
                                 $('#fm-postcode-lookup-container').addClass('govuk-visually-hidden');
                             }
+
+                            contactDetails.tabIndex(2);
                         }else{
                             pageUtils.showPostCodeError(true, "Address not found, please enter manually");
                         }
@@ -310,6 +312,7 @@ const pageUtils = {
                 $('#fm-postcode-error').text(errorMsg);
                 $('#fm-postcode-error').removeClass('govuk-visually-hidden');
                 $('#fm-postcode-error-form-group').addClass('govuk-form-group--error');
+                contactDetails.tabIndex(1);
             } else {
                 $('#fm-postcode-error').addClass('govuk-visually-hidden');
                 $('#fm-postcode-error-form-group').removeClass('govuk-form-group--error');

--- a/app/assets/javascripts/facilities_management/beta/buyer/buyer_details.js
+++ b/app/assets/javascripts/facilities_management/beta/buyer/buyer_details.js
@@ -16,34 +16,36 @@ $(function () {
 	};
 	
 	$('#buyer-details-find-address-btn').on('click', function (e) {
-		e.preventDefault();
-		
-		let postCode = pageUtils.formatPostCode($('#buyer-details-postcode').val());
-		pageUtils.addressLookUp(postCode, false);
+    e.preventDefault();
 
-		if ($('#fm-postcode-error').hasClass('govuk-visually-hidden')){
-			tabIndex(true);
-		}
-		
+    $('#fm-postcode-error').addClass('govuk-visually-hidden');
+    $('#organisation_address_postcode-error').addClass('govuk-visually-hidden');
+    $('#fm-postcode-error-form-group').removeClass('govuk-form-group--error')
+    $('#fm-post-code-results-container').find('.govuk-form-group--error').removeClass('govuk-form-group--error')
+    $('#buyer-details-postcode').removeClass('govuk-input--error')
+
+    let postCode = pageUtils.formatPostCode($('#buyer-details-postcode').val());
+    pageUtils.addressLookUp(postCode, false);
 	});
 	
 	$('#change-selected-address-link').on('click', function (e) {
 		e.preventDefault();
 		$('#fm-post-code-results-container').addClass('govuk-visually-hidden');
 		$('#selected-address-container').addClass('govuk-visually-hidden');
-		$('#fm-postcode-lookup-container').removeClass('govuk-visually-hidden');
+    $('#fm-postcode-lookup-container').removeClass('govuk-visually-hidden');
+    $('#buyer-details-postcode').removeClass('govuk-input--error')
 		focusElem($('#buyer-details-postcode'));
-		tabIndex(false);
-		document.getElementById("change-selected-address-link").tabIndex = "-1";
+		contactDetails.tabIndex(1);
 	});
 	
 	$('#buyer-details-change-postcode').on('click', function (e) {
 		e.preventDefault();
 		$('#fm-post-code-results-container').addClass('govuk-visually-hidden');
-		$('#fm-postcode-lookup-container').removeClass('govuk-visually-hidden');
+    $('#fm-postcode-lookup-container').removeClass('govuk-visually-hidden');
+    $('#buyer-details-postcode').removeClass('govuk-input--error');
 		focusElem($('#buyer-details-postcode'));
 
-		tabIndex(false);
+		contactDetails.tabIndex(1);
 	});
 	
 	$('#buyer-details-postcode-lookup-results').on('click', function (e) {
@@ -68,6 +70,8 @@ $(function () {
       $("#selected-address-label").text(selectedAddress);
       $("#selected-address-postcode").text(postcode);
       $("#organisation_address").text(selectedAddress);
+
+      contactDetails.tabIndex(3);
     }
 	});
 	
@@ -163,26 +167,92 @@ $(function () {
 			$('#facilities_management_buyer_detail_central_government_false').get(0).setAttribute('checked', 'checked');
 		}
 	}
-
-	function tabIndex(toggle) {
-    if ($('#buyer-details-form').length) {
-      if (toggle) {
-        document.getElementById("buyer-details-postcode").tabIndex = "-1";
-        document.getElementById("add-buyer-address-link-1").tabIndex = "-1";
-        document.getElementById("buyer-details-find-address-btn").tabIndex = "-1";
-  
-        document.getElementById("buyer-details-change-postcode").tabIndex = "0";
-        document.getElementById("buyer-details-postcode-lookup-results").tabIndex = "0";
-        document.getElementById("add-buyer-address-link-2").tabIndex = "0";
-      }else{
-        document.getElementById("buyer-details-postcode").tabIndex = "0";
-        document.getElementById("add-buyer-address-link-1").tabIndex = "0";
-        document.getElementById("buyer-details-find-address-btn").tabIndex = "0";
-  
-        document.getElementById("buyer-details-change-postcode").tabIndex = "-1";
-        document.getElementById("buyer-details-postcode-lookup-results").tabIndex = "-1";
-        document.getElementById("add-buyer-address-link-2").tabIndex = "-1";
-    }
-		}
-	}
 });
+
+const contactDetails = {
+  tabIndex: function (state) {
+    if ($('#buyer-details-form').length || $('#new_invoice_contact_details').length || $('#new_authorised_contact_details').length || $('#new_notices_contact_details').length) {
+      switch(state) {
+        case 1:
+          this.toggleSet1(false)
+          this.toggleSet2(false)
+          document.getElementById("change-selected-address-link").tabIndex = "-1";
+          $('#buyer-details-postcode').focus();
+          break;
+        case 2:
+          this.toggleSet1(true)
+          this.toggleSet2(true)
+          document.getElementById("change-selected-address-link").tabIndex = "-1";
+          $('#buyer-details-postcode-lookup-results').focus();
+          break;
+        case 3:
+          this.toggleSet1(true)
+          this.toggleSet2(false)
+          document.getElementById("change-selected-address-link").tabIndex = "0";
+          $('#change-selected-address-link').focus();
+          break;
+      }
+    }
+  },
+
+  toggleSet1: function (toggle) {
+    if (toggle) {
+
+      document.getElementById("buyer-details-postcode").tabIndex = "-1";
+      document.getElementById("buyer-details-find-address-btn").tabIndex = "-1";
+
+      if ($('#new_invoice_contact_details').length) {
+        document.getElementById("add_new_invoice_contact_details_address_1").tabIndex = "-1";
+      } else if ($('#new_authorised_contact_details').length) {
+        document.getElementById("add_new_authorised_contact_details_address_1").tabIndex = "-1";
+      } else if ( $('#new_notices_contact_details').length) {
+        document.getElementById("add_new_notices_contact_details_address_1").tabIndex = "-1";
+      } else {
+        document.getElementById("add-buyer-address-link-1").tabIndex = "-1";
+      }
+    }else{
+      document.getElementById("buyer-details-postcode").tabIndex = "0";
+      document.getElementById("buyer-details-find-address-btn").tabIndex = "0";
+
+      if ($('#new_invoice_contact_details').length) {
+        document.getElementById("add_new_invoice_contact_details_address_1").tabIndex = "0";
+      } else if ($('#new_authorised_contact_details').length) {
+        document.getElementById("add_new_authorised_contact_details_address_1").tabIndex = "0";
+      } else if ( $('#new_notices_contact_details').length) {
+        document.getElementById("add_new_notices_contact_details_address_1").tabIndex = "0";
+      } else {
+        document.getElementById("add-buyer-address-link-1").tabIndex = "0";
+      }
+    }
+  },
+
+  toggleSet2: function (toggle) {
+    if (toggle) {
+      document.getElementById("buyer-details-change-postcode").tabIndex = "0";
+      document.getElementById("buyer-details-postcode-lookup-results").tabIndex = "0";
+
+      if ($('#new_invoice_contact_details').length) {
+        document.getElementById("add_new_invoice_contact_details_address_2").tabIndex = "0";
+      } else if ($('#new_authorised_contact_details').length) {
+        document.getElementById("add_new_authorised_contact_details_address_2").tabIndex = "0";
+      } else if ( $('#new_notices_contact_details').length) {
+        document.getElementById("add_new_notices_contact_details_address_2").tabIndex = "0";
+      } else {
+        document.getElementById("add-buyer-address-link-2").tabIndex = "0";
+      }
+    }else{
+      document.getElementById("buyer-details-change-postcode").tabIndex = "-1";
+      document.getElementById("buyer-details-postcode-lookup-results").tabIndex = "-1";
+
+      if ($('#new_invoice_contact_details').length) {
+        document.getElementById("add_new_invoice_contact_details_address_2").tabIndex = "-1";
+      } else if ($('#new_authorised_contact_details').length) {
+        document.getElementById("add_new_authorised_contact_details_address_2").tabIndex = "-1";
+      } else if ( $('#new_notices_contact_details').length) {
+        document.getElementById("add_new_notices_contact_details_address_2").tabIndex = "-1";
+      } else {
+        document.getElementById("add-buyer-address-link-2").tabIndex = "-1";
+      }
+    }
+  }
+}

--- a/app/assets/javascripts/facilities_management/beta/procurement/ContractDetails.js
+++ b/app/assets/javascripts/facilities_management/beta/procurement/ContractDetails.js
@@ -1,11 +1,11 @@
 $(function () {
     if (typeof(Storage) !== "undefined") {
         let formContactDetails = document.getElementById('new_invoice_contact_details');
-        let formContactDetailsAddress = document.getElementById('new_invoice_contact_details_adress');
+        let formContactDetailsAddress = document.getElementById('new_invoice_contact_details_address');
         let formAuthorisedRep = document.getElementById('new_authorised_contact_details');
-        let formAuthorisedRepAddress = document.getElementById('new_authorised_contact_details_adress');
+        let formAuthorisedRepAddress = document.getElementById('new_authorised_contact_details_address');
         let formNoticeDetails = document.getElementById('new_notices_contact_details');
-        let formNoticeDetailsAddress = document.getElementById('new_notices_contact_details_adress');
+        let formNoticeDetailsAddress = document.getElementById('new_notices_contact_details_address');
 
         if (formContactDetails && window.sessionStorage.contactDetails) {
             fillInDetails(formContactDetails);
@@ -23,17 +23,17 @@ $(function () {
                 getDetails(formContactDetails);
             });
         } else if (formAuthorisedRep) {
-            $('#add_new_authorised_contact_details_adress_1').on('click', function(e) {
+            $('#add_new_authorised_contact_details_address_1').on('click', function(e) {
                 getDetails(formAuthorisedRep);
             });
-            $('#add_new_authorised_contact_details_adress_2').on('click', function(e) {
+            $('#add_new_authorised_contact_details_address_2').on('click', function(e) {
                 getDetails(formAuthorisedRep);
             });
         } else if (formNoticeDetails) {
-            $('#add_new_notices_contact_details_adress_1').on('click', function(e) {
+            $('#add_new_notices_contact_details_address_1').on('click', function(e) {
                 getDetails(formNoticeDetails);
             });
-            $('#add_new_notices_contact_details_adress_2').on('click', function(e) {
+            $('#add_new_notices_contact_details_address_2').on('click', function(e) {
                 getDetails(formNoticeDetails);
             });
         } else if (!(formContactDetailsAddress || formAuthorisedRepAddress || formNoticeDetailsAddress)) {
@@ -95,21 +95,15 @@ $(function () {
         return [nameElem, jobTitleElem, emailElem, telephoneNumberElem];
     }
 
-    function makeElementFocusableOnExpand(index) {
-      var contractDetails = [$($('#invoice-detail-summary').children().get(0)), $($('#notice-detail-summary').children().get(0)), $($('#authorised-detail-summary').children().get(0))]
+    $('.govuk-details__summary').on('click', function(e) {
+      var links = $(e.currentTarget).next().find('a');
+      removeTabIndex = e.currentTarget.getAttribute('aria-expanded') === 'false'
+      for (var i = 0; i < links.length; i++) {
+        removeTabIndexOnLinks(links[i], removeTabIndex)
+      }
+    });
 
-      $(contractDetails[index].children().get(0)).on('click', function(e) {
-        var email = $(contractDetails[index].children().get(1)).children().get(0);
-        var currentTabindex = email.getAttribute('tabindex');
-        if (currentTabindex === null) {
-          email.setAttribute('tabindex', '-1');
-        } else {
-          email.removeAttribute('tabindex');
-        }
-      });
-    }
-
-    for (var i = 0; i < 3; i++) {
-      makeElementFocusableOnExpand(i);
+    function removeTabIndexOnLinks(e, state) {
+      state ? e.removeAttribute('tabindex') : e.setAttribute('tabindex', -1)
     }
 });

--- a/app/controllers/facilities_management/procurements_controller.rb
+++ b/app/controllers/facilities_management/procurements_controller.rb
@@ -934,7 +934,7 @@ module FacilitiesManagement
         new_authorised_representative_details: {
           back_url: edit_facilities_management_procurement_path(id: @procurement.id, step: 'authorised_representative'),
           page_title: 'New authorised representative details',
-          continuation_text: 'Continue',
+          continuation_text: 'Save and return',
           return_url: edit_facilities_management_procurement_path(id: @procurement.id, step: 'authorised_representative'),
           return_text: 'Return to authorised representative details',
         },

--- a/app/views/facilities_management/buyer_details/edit.html.erb
+++ b/app/views/facilities_management/buyer_details/edit.html.erb
@@ -57,12 +57,12 @@
 
         <div id="fm-postcode-error-form-group" class="govuk-form-group govuk-!-margin-top-4 <%= "govuk-form-group--error" if f.object.errors[:organisation_address_postcode].any? %>" data-propertyname="organisation_address_postcode">
           <div class="">
-            <div id="fm-postcode-lookup-container" class="<%= ' govuk-visually-hidden' if f.object.organisation_address_line_1.present? %>">
+            <div id="fm-postcode-lookup-container" class="<%= ' govuk-visually-hidden' if f.object.organisation_address_line_1.present? && f.object.organisation_address_postcode.present? %>">
               <div class="govuk-grid-row ">
                 <div class="govuk-grid-column-one-half">
                   <%= f.label :organisation_address_postcode, t('.postcode'), class: 'govuk-label govuk-!-margin-bottom-1', for: 'buyer-details-postcode' %>
                   <div class="govuk-error-message" id="fm-postcode-error"></div>
-                  <%= display_errors(f.object, :organisation_address_postcode) %>
+                  <%= display_errors(f.object, :organisation_address_postcode) if f.object.organisation_address_postcode.blank? %>
                   <% input_index = f.object.organisation_address_line_1.present? ? -1 : 0 %>
                   <%= f.text_field :organisation_address_postcode, class: 'govuk-input fm-postcode-input govuk-!-margin-bottom-4 govuk-!-width-full', id: 'buyer-details-postcode', maxlength: 10, required: true, tabindex: "#{input_index}"  %>
                 </div>
@@ -82,23 +82,27 @@
                   <p id="fm-postcode-label" class="govuk-body"><%= f.object.organisation_address_postcode %></p>
                 </div>
                 <div class="govuk-grid-column-one-quarter">
-                  <a id="buyer-details-change-postcode" href="" tabindex="-1" class="govuk-link--no-visited-state"><%= t('.change') %></a>
+                  <% postcode_index = f.object.organisation_address_postcode.present? && !f.object.organisation_address_line_1.present? ? 0 : -1 %>
+                  <a id="buyer-details-change-postcode" href="" tabindex=<%= postcode_index %> class="govuk-link--no-visited-state"><%= t('.change') %></a>
                 </div>
               </div>
-              <label class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-margin-top-4" for="buyer-details-postcode-lookup-results"><%= t('.select_an_addr') %></label>
-              <div id="fm-address-error-form-group" class="govuk-form-group govuk-!-margin-bottom-0">
-                  <span id="fm-address-error" class="govuk-error-message govuk-visually-hidden">
-                    <%= t('.no_addr_selected') %>
-                  </span>
-                <select class="govuk-select govuk-!-width-full" tabindex="-1" id="buyer-details-postcode-lookup-results" name="buyer-details-postcode-lookup-results">
-                  <option value="status-option" selected><%= t('.no_addr_found') %></option>
-                </select>
-              </div>
-              <div class="govuk-!-margin-top-2">
-                <%= link_to t('.cant_find_addr_in_list'), facilities_management_buyer_detail_edit_address_path(@buyer_detail, update_address: true),  class: "govuk-link--no-visited-state govuk-caption-m", tabindex: "-1", id: 'add-buyer-address-link-2'%>
+              <div class= <%= "govuk-form-group--error" if f.object.errors[:organisation_address_postcode].any? %>>
+                <label class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-margin-top-4" for="buyer-details-postcode-lookup-results"><%= t('.select_an_addr') %></label>
+                <%= display_error(f.object, :organisation_address_postcode) unless f.object.organisation_address_postcode.blank? %>
+                <div id="fm-address-error-form-group" class="govuk-form-group govuk-!-margin-bottom-0">
+                    <span id="fm-address-error" class="govuk-error-message govuk-visually-hidden">
+                      <%= t('.no_addr_selected') %>
+                    </span>
+                  <select class="govuk-select govuk-!-width-full" tabindex=<%= postcode_index %> id="buyer-details-postcode-lookup-results" name="buyer-details-postcode-lookup-results">
+                    <option value="status-option" selected><%= t('.no_addr_found') %></option>
+                  </select>
+                </div>
+                <div class="govuk-!-margin-top-2">
+                  <%= link_to t('.cant_find_addr_in_list'), facilities_management_buyer_detail_edit_address_path(@buyer_detail, update_address: true),  class: "govuk-link--no-visited-state govuk-caption-m", id: 'add-buyer-address-link-2', tabindex: postcode_index%>
+                </div>
               </div>
             </div>
-            <div class="govuk-!-margin-top-3<%= ' govuk-visually-hidden' unless f.object.organisation_address_line_1.present? %>" id="selected-address-container">
+            <div class="govuk-!-margin-top-3<%= ' govuk-visually-hidden' unless f.object.organisation_address_line_1.present? && f.object.organisation_address_postcode.present? %>" id="selected-address-container">
               <label class="govuk-heading-s govuk-!-margin-bottom-1"><%= t('.postcode') %></label>
               <div id="selected-address-postcode" class="govuk-!-margin-bottom-6">
                 <%= f.object.organisation_address_postcode %>
@@ -107,7 +111,7 @@
               <div id="selected-address-label" class="govuk-!-margin-bottom-6">
                 <%= f.object.full_organisation_address if f.object.organisation_address_postcode.present? %>
               </div>
-              <% change_index = f.object.organisation_address_line_1.present? ? 0 : -1 %>
+              <% change_index = f.object.organisation_address_line_1.present? && f.object.organisation_address_postcode.present? ? 0 : -1 %>
               <a id="change-selected-address-link" tabindex=<%="#{change_index}"%> href="" class="govuk-link--no-visited-state"><%= t('.change') %></a>
               <%= f.hidden_field :organisation_address_line_1, id: 'organisation-address-line-1' %>
               <%= f.hidden_field :organisation_address_line_2, id: 'organisation-address-line-2' %>

--- a/app/views/facilities_management/procurements/edit/_new_authorised_representative_address.html.erb
+++ b/app/views/facilities_management/procurements/edit/_new_authorised_representative_address.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_page_content(@page_description, @page_data[:model_object]) do |pd| %>
   <%= f.fields_for :authorised_contact_detail do |ff|%>
     <%= render partial: '/facilities_management/procurements/edit/new_contact_details_address',
-               locals: {f: f, ff: ff, page_id: "new_authorised_contact_details_adress", page_contact: 'authorised_contact_detail'} %>
+               locals: {f: f, ff: ff, page_id: "new_authorised_contact_details_address", page_contact: 'authorised_contact_detail'} %>
   <% end %>
 <% end %>

--- a/app/views/facilities_management/procurements/edit/_new_contact_details.html.erb
+++ b/app/views/facilities_management/procurements/edit/_new_contact_details.html.erb
@@ -33,17 +33,17 @@
         <div class="govuk-grid-row ">
           <div class="govuk-grid-column-one-half">
             <%= ff.label :organisation_address_postcode, 'Postcode', class: 'govuk-label govuk-!-margin-bottom-1', id: "#{page_contact}.organisation_address_postcode#{'-error' if ff.object.errors[:organisation_address_postcode].any?}" %>
-            <% error_id = ff.object.errors[:organisation_address_postcode].any? ? "" : "fm-postcode-error" %>
-            <div class="govuk-error-message" id= <%=error_id%>></div>
+            <div class="govuk-error-message" id="fm-postcode-error"></div>
             <%= display_error(ff.object, :organisation_address_postcode) if ff.object.organisation_address_postcode.blank? %>
-            <%= ff.text_field :organisation_address_postcode, 'aria-label' =>'postcode', class: "govuk-input fm-postcode-input govuk-!-margin-bottom-4 govuk-!-width-full #{'govuk-input--error' if ff.object.errors[:organisation_address_postcode].any? }", id: 'buyer-details-postcode', maxlength: 10 %>
+            <% input_index = ff.object.organisation_address_postcode.present? ? -1 : 0 %>
+            <%= ff.text_field :organisation_address_postcode, 'aria-label' =>'postcode', class: "govuk-input fm-postcode-input govuk-!-margin-bottom-4 govuk-!-width-full #{'govuk-input--error' if ff.object.errors[:organisation_address_postcode].any? }", id: 'buyer-details-postcode', maxlength: 10, tabindex: input_index %>
           </div>
         </div>
         <div class="govuk-!-margin-top-1 govuk-!-margin-bottom-2">
-          <a role="button" class="govuk-button govuk-!-margin-bottom-2" id="buyer-details-find-address-btn" aria-label="<%= t('.find_address') %>"><%= t('.find_address') %></a>
+          <a role="button" class="govuk-button govuk-!-margin-bottom-2" tabindex=<%=input_index %> id="buyer-details-find-address-btn" aria-label="<%= t('.find_address') %>"><%= t('.find_address') %></a>
         </div>
         <div class="govuk-!-margin-top-0">
-          <%= link_to t('.missing_address'), edit_facilities_management_procurement_path(step: address_step), class: "govuk-link--no-visited-state govuk-caption-m", id: "add_new_#{page_contact}s_adress_1" %>
+          <%= link_to t('.missing_address'), edit_facilities_management_procurement_path(step: address_step), class: "govuk-link--no-visited-state govuk-caption-m", id: "add_new_#{page_contact}s_address_1", tabindex: input_index %>
         </div>
       </div>
 
@@ -54,26 +54,28 @@
             <label id="fm-postcode-label" class="govuk-body"><%= ff.object.organisation_address_postcode %></label>
           </div>
           <div class="govuk-grid-column-one-quarter">
-            <a id="buyer-details-change-postcode" href="" class="govuk-link--no-visited-state"><%= t('.change') %></a>
+            <% postcode_index = ff.object.organisation_address_postcode.present? && !ff.object.organisation_address_line_1.present? ? 0 : -1 %>
+            <a id="buyer-details-change-postcode" href="" tabindex=<%= postcode_index %> class="govuk-link--no-visited-state"><%= t('.change') %></a>
           </div>
         </div>
         <div class= <%= "govuk-form-group--error" if ff.object.errors[:organisation_address_postcode].any? %>>
           <label class="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-margin-top-4"><%= t('.choose_address') %></label>
           <%= display_error(ff.object, :organisation_address_postcode) unless ff.object.organisation_address_postcode.blank? %>
           <div id="fm-address-error-form-group" class="govuk-form-group govuk-!-margin-bottom-0">
-            <select class="govuk-select govuk-!-width-full" aria-label="postcode-lookup-results" id="buyer-details-postcode-lookup-results" name="buyer-details-postcode-lookup-results">
+            <select class="govuk-select govuk-!-width-full" tabindex=<%= postcode_index %> aria-label="postcode-lookup-results" id="buyer-details-postcode-lookup-results" name="buyer-details-postcode-lookup-results">
             </select>
           </div>
           <div class="govuk-!-margin-top-2">
-            <%= link_to t('.missing_address'), edit_facilities_management_procurement_path(step: address_step), class: "govuk-link--no-visited-state govuk-caption-m", id: "add_new_#{page_contact}s_adress_2" %>
+            <%= link_to t('.missing_address'), edit_facilities_management_procurement_path(step: address_step), class: "govuk-link--no-visited-state govuk-caption-m", id: "add_new_#{page_contact}s_address_2", tabindex: postcode_index %>
           </div>
         </div>
       </div>
-      <div class="govuk-!-margin-top-3<%= ' govuk-visually-hidden' unless ff.object.organisation_address_line_1.present? %>" id="selected-address-container">
+      <div class="govuk-!-margin-top-3<%= ' govuk-visually-hidden' unless ff.object.organisation_address_line_1.present? && ff.object.organisation_address_postcode.present? %>" id="selected-address-container">
         <div id="selected-address-label" class=" govuk-body govuk-!-margin-bottom-4">
           <%= ff.object.contact_address if ff.object.valid_contact_address? %>
         </div>
-        <a id="change-selected-address-link" href="" class="govuk-link--no-visited-state"><%= t('.change') %></a>
+        <% change_index = ff.object.organisation_address_line_1.present? && ff.object.organisation_address_postcode.present? ? 0 : -1 %>
+        <a id="change-selected-address-link" href="" tabindex=<%="#{change_index}"%> class="govuk-link--no-visited-state"><%= t('.change') %></a>
         <%= ff.hidden_field :organisation_address_line_1, id: 'organisation-address-line-1' %>
         <%= ff.hidden_field :organisation_address_line_2, id: 'organisation-address-line-2' %>
         <%= ff.hidden_field :organisation_address_town, id: 'organisation-address-town' %>

--- a/app/views/facilities_management/procurements/edit/_new_invoicing_address.html.erb
+++ b/app/views/facilities_management/procurements/edit/_new_invoicing_address.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_page_content(@page_description, @page_data[:model_object]) do |pd| %>
   <%= f.fields_for :invoice_contact_detail do |ff|%>
     <%= render partial: '/facilities_management/procurements/edit/new_contact_details_address',
-               locals: {f: f, ff: ff, page_id: "new_invoice_contact_details_adress", page_contact: 'invoice_contact_detail'} %>
+               locals: {f: f, ff: ff, page_id: "new_invoice_contact_details_address", page_contact: 'invoice_contact_detail'} %>
   <% end %>
 <% end %>

--- a/app/views/facilities_management/procurements/edit/_new_notices_address.html.erb
+++ b/app/views/facilities_management/procurements/edit/_new_notices_address.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_page_content(@page_description, @page_data[:model_object]) do |pd| %>
     <%= f.fields_for :notices_contact_detail do |ff|%>
       <%= render partial: '/facilities_management/procurements/edit/new_contact_details_address',
-                 locals: {f: f, ff: ff, page_id: "new_notices_contact_details_adress", page_contact: 'notices_contact_detail'} %>
+                 locals: {f: f, ff: ff, page_id: "new_notices_contact_details_address", page_contact: 'notices_contact_detail'} %>
     <% end %>
 <% end %>


### PR DESCRIPTION
The main focus of this is the tabbing and changing of the focus when entering an address on the Buyer details and the Contact Details changes (Invoice, Authorised and Notice). The main changes are:
- get the focus and tabIndex values to be correct depending on the state of the page
- Update buyer details page so that it has the matching (and hopefully correct) logic
- Fix misspelling of _adress_ to _address_