### PR TITLE
login error message changes

### DIFF
--- a/app/services/cognito/sign_in_user.rb
+++ b/app/services/cognito/sign_in_user.rb
@@ -18,9 +18,6 @@ module Cognito
 
     def call
       initiate_auth if valid?
-    rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
-      @error = I18n.t('activemodel.errors.models.user.incorrect_username_or_password')
-      errors.add(:base, @error)
     rescue Aws::CognitoIdentityProvider::Errors::PasswordResetRequiredException => e
       @error = e.message
       errors.add(:base, e.message)
@@ -29,9 +26,12 @@ module Cognito
       @error = e.message
       errors.add(:base, e.message)
       @needs_confirmation = true
-    rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
-      @error = e.message
-      errors.add(:base, e.message)
+    rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
+      @error = I18n.t('facilities_management.users.sign_in_error')
+      errors.add(:base, @error)
+    rescue Aws::CognitoIdentityProvider::Errors::ServiceError
+      @error = I18n.t('facilities_management.users.sign_in_error')
+      errors.add(:base, @error)
     end
 
     def success?

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -1453,6 +1453,7 @@ en:
         create_your_password: Create a password you’ll remember
         heading: Change your password
         intro: This is the first time you’ve signed in to your account. You need to reset your password.
+      sign_in_error: You must provide a correct username or password
       sms_mfa:
         access_code: Access code
         content: It may take a few minutes to arrive.

--- a/spec/services/cognito/sign_in_user_spec.rb
+++ b/spec/services/cognito/sign_in_user_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Cognito::SignInUser do
 
       it 'does returns cognito error' do
         response = described_class.call(email, password, cookies_disabled)
-        expect(response.error).to eq 'Oops'
+        expect(response.error).to eq I18n.t('facilities_management.users.sign_in_error')
       end
     end
 
@@ -114,7 +114,7 @@ RSpec.describe Cognito::SignInUser do
 
       it 'does returns cognito error' do
         response = described_class.call(email, password, cookies_disabled)
-        expect(response.error).to eq I18n.t('activemodel.errors.models.user.incorrect_username_or_password')
+        expect(response.error).to eq I18n.t('facilities_management.users.sign_in_error')
       end
 
       it 'returns need_password_reset false' do


### PR DESCRIPTION
> I did not share code for
 rescue Aws::CognitoIdentityProvider::Errors::UserNotFoundException
 rescue Aws::CognitoIdentityProvider::Errors::ServiceError

as robocop complained about hidden exception order.   

>I ignored the serviceError exception message text  assumed it is a username/password issue as the requirement was for a fixed message.