### PR TITLE
Finding user for auth rather than initialising by email

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -12,8 +12,7 @@ class AuthController < ApplicationController
   protected
 
   def find_or_create(login)
-    user = User.find_or_initialize_by(email: login.email)
-    user.new_record?
+    user = User.find_for_authentication(email: login.email) || User.new(email: login.email)
     user.roles = %i[buyer st_access]
     user.save
     user

--- a/app/services/cognito/update_user.rb
+++ b/app/services/cognito/update_user.rb
@@ -8,7 +8,7 @@ module Cognito
     end
 
     def call
-      @cognito_user_groups = client.admin_list_groups_for_user(user_pool_id: ENV['COGNITO_USER_POOL_ID'], username: user.cognito_uuid)
+      @cognito_user_groups = client.admin_list_groups_for_user(user_pool_id: ENV['COGNITO_USER_POOL_ID'], username: username)
       update_user
     rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
       @error = e.message
@@ -19,6 +19,10 @@ module Cognito
     def update_user
       @user.roles = roles
       @user.save
+    end
+
+    def username
+      user.cognito_uuid || user.email
     end
 
     def roles


### PR DESCRIPTION
Also update user should look for user.email if cognito_uuid is not present (that's in case the user is created from Dfe, but also has a Cognito account)