### PR TITLE
updates copy changes to reflect sketch

### DIFF
--- a/app/views/facilities_management/procurements/_choose_contract_value.html.erb
+++ b/app/views/facilities_management/procurements/_choose_contract_value.html.erb
@@ -30,8 +30,15 @@
           </div>
         <% end %>
       <% end %>
-      <p class='govuk-body-m'>
-        <%= t('.not_able_to_select_range') %>
+      <div class="govuk-warning-text govuk-!-width-two-thirds">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+            <%= t('.not_able_to_select_range') %>
+        </strong>
+      </div>
+      <p class='govuk-body-m govuk-!-width-two-thirds'>
+        <%= t('.change_requirements_text') %>
       </p>
     <% else %>
       <div class='govuk-body-l govuk-!-width-three-quarters'>
@@ -97,14 +104,16 @@
         <%= f.hidden_field(:lot_number, value: '1c') %>
       <% end %>
       <% unless @procurement.lot_number == '1c' %>
-        <div class="govuk-warning-text govuk-!-width-two-thirds">
-          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-            <span class="govuk-warning-text__assistive">Warning</span>
-              <%= t('.not_able_to_select_range') %>
-          </strong>
-        </div>
-      <% end %>
+      <div class="govuk-warning-text govuk-!-width-two-thirds">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+            <%= t('.not_able_to_select_range') %>
+        </strong>
+      </div>
+      <p class='govuk-body-m govuk-!-width-two-thirds'>
+        <%= t('.change_requirements_text') %>
+      </p>
     <% end %>
     <%= govuk_continuation_buttons(pd, f) %>
   <% end %>

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -760,6 +760,7 @@ en:
         description: Including this in your contract gives you the option to extend the end date of the agreement. Call-off contracts can be let for a maximum period of 10 years, inclusive of mobilisation period and all call-off extensions.
       choose_contract_value:
         can_you_estimate_cost: Can you estimate if adding the cost of these services will move your estimated contract cost into a different value band than the one currently shown?
+        change_requirements_text: If you wish to change your requirements, click the 'Change requirements' button below. Any changes may result in a different outcome.
         contract_value_heading: When calculating your total contract value, we have not been been able to include pricing for some of your services which have very customer specific pricing. The services not included are listed below.
         description_html: This will help us place your requirement in the correct sub-lot. <br> NB. The value ranges are total contract values for the full term contract for the services you have selected.
         heading: Looking at the options below, can you select the correct value range based on your budget, and expected cost of the contract?


### PR DESCRIPTION
warning text wasn't shown except in one case, added additional description text above continuation buttons. 