### PR TITLE
hotfix/Update-method-causing-500

### DIFF
--- a/app/helpers/facilities_management/summary_helper.rb
+++ b/app/helpers/facilities_management/summary_helper.rb
@@ -100,16 +100,6 @@ module FacilitiesManagement::SummaryHelper
   end
 
   def calculate_uom_value(val)
-    uom_value = nil
-    if val[:uom_value].is_a? Numeric
-      uom_value = val[:uom_value].to_f
-    elsif val[:uom_value].is_a? String # rspec cases use string for the value
-      uom_value = val[:uom_value].to_f
-    elsif val[:uom_value][:monday][:uom].is_a? Numeric
-      uom_value = 0
-      Date::DAYNAMES.each { |day| uom_value += val[:uom_value][day.downcase.to_sym][:uom] }
-      uom_value = (uom_value * 52).round(2) # for each week in the year
-    end
-    uom_value
+    val[:uom_value].is_a?(Numeric) || val[:uom_value].is_a?(String) ? val[:uom_value].to_f : nil
   end
 end

--- a/spec/helpers/facilities_management/summary_helper_spec.rb
+++ b/spec/helpers/facilities_management/summary_helper_spec.rb
@@ -16,31 +16,11 @@ RSpec.describe FacilitiesManagement::SummaryHelper, type: :helper do
       end
     end
 
-    context 'when uom is the service hours for each work day' do
-      it 'will return the addition of all the values * 52' do
+    context 'when uom is not a String or Numeric' do
+      it 'will return nil' do
         val = {}
         val[:uom_value] = {}
-        value = 1
-        Date::DAYNAMES.each do |day|
-          val[:uom_value][day.downcase.to_sym] = {}
-          val[:uom_value][day.downcase.to_sym][:uom] = value
-          value += 1
-        end
-        result_value = (1 + 2 + 3 + 4 + 5 + 6 + 7) * 52
-        expect(calculate_uom_value(val)).to eq result_value
-      end
-
-      it 'will round value to 2 digits' do
-        val = {}
-        val[:uom_value] = {}
-        value = 1
-        Date::DAYNAMES.each do |day|
-          val[:uom_value][day.downcase.to_sym] = {}
-          val[:uom_value][day.downcase.to_sym][:uom] = value
-          value += 1
-        end
-        val[:uom_value][:sunday][:uom] = 2.56789
-        expect(calculate_uom_value(val)).to eq(((2.56789 + 2 + 3 + 4 + 5 + 6 + 7) * 52).round(2))
+        expect(calculate_uom_value(val)).to be nil
       end
     end
   end


### PR DESCRIPTION
> - Remove unused parts of method
> - Update tests

The only way this could have happened is if the external area was nil because all the other options would have lead to a number being input into the method. By removing a case that doesn't exist we will no longer have the error.