### PR TITLE
ensure that services ending with double digit codes can be found

### DIFF
--- a/app/services/management_consultancy/supplier_spreadsheet_creator.rb
+++ b/app/services/management_consultancy/supplier_spreadsheet_creator.rb
@@ -40,7 +40,7 @@ class ManagementConsultancy::SupplierSpreadsheetCreator
   def add_audit_trail(sheet)
     services = []
     @params['services'].each do |service|
-      if service =~ /^MCF\d[.]\d+[.]\d+[.]\d$/
+      if service =~ /^MCF\d[.]\d+[.]\d+[.]\d+$/
         subservice =  ManagementConsultancy::Subservice.find_by(code: service)
         parent_service = ManagementConsultancy::Service.find_by(code: subservice.service)
         services << "#{parent_service.name} - #{subservice.name}"


### PR DESCRIPTION
The issue lay with the regex to identify if the spreadsheet was dealing
with a service or a subservice, eg MCF2.3.1 is a service but MCF2.3.1.1
is a subservice. Unfortunately the regex ending for checking ended with a d
rather than a d+ so it was only checking for single digits. The check
can now check for subservices ending with double digits as well