### PR TITLE
Feature/fmfr 224 performance fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -140,6 +140,7 @@ group :development, :test do
   gem 'poltergeist', '>= 1.18.1'
   gem 'wdm', '>= 0.1.0', platforms: %i[x64_mingw]
   gem 'tzinfo-data', platforms: %i[x64_mingw]
+  gem 'bullet', require: true
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,9 @@ GEM
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.0.1)
     cancan (1.6.10)
     capybara (3.32.2)
@@ -492,6 +495,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     uk_postcode (2.1.3)
     unicode-display_width (1.6.1)
+    uniform_notifier (1.13.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
@@ -533,6 +537,7 @@ DEPENDENCIES
   aws-sdk-s3 (~> 1)
   axlsx!
   bootsnap (>= 1.1.0)
+  bullet
   byebug
   cancan (~> 1.6.10)
   capybara (>= 3.32.2)

--- a/app/helpers/facilities_management/procurements_helper.rb
+++ b/app/helpers/facilities_management/procurements_helper.rb
@@ -131,7 +131,7 @@ module FacilitiesManagement::ProcurementsHelper
   def procurement_buildings_missing_regions
     return false unless @procurement.detailed_search? || @procurement.detailed_search_bulk_upload?
 
-    @procurement.active_procurement_buildings.any? { |procurement_building| procurement_building.building.address_region.nil? }
+    @procurement.active_procurement_buildings.includes(:building).any? { |procurement_building| procurement_building.building.address_region.nil? }
   end
 
   def buildings_with_missing_regions

--- a/app/models/facilities_management/procurement.rb
+++ b/app/models/facilities_management/procurement.rb
@@ -260,19 +260,11 @@ module FacilitiesManagement
     end
 
     def valid_on_continue?
-      valid?(:all) && valid_services? && valid_buildings?
-    end
-
-    def valid_services?
-      procurement_building_services.any? && active_procurement_buildings.all? { |p| p.valid?(:procurement_building_services) && p.valid?(:buildings_and_services) }
-    end
-
-    def valid_buildings?
-      active_procurement_buildings.all? { |pb| pb.valid?(:gia) && pb.valid?(:external_area) }
+      valid?(:all) && active_procurement_buildings.all?(&:valid_on_continue?)
     end
 
     def buildings_standard
-      active_procurement_buildings.map { |pb| pb.building.building_standard }.include?('NON-STANDARD') ? 'NON-STANDARD' : 'STANDARD'
+      active_procurement_buildings.includes(:building).any? { |pb| pb.building.building_standard == 'NON-STANDARD' } ? 'NON-STANDARD' : 'STANDARD'
     end
 
     def services_standard
@@ -282,7 +274,7 @@ module FacilitiesManagement
 
     def priced_at_framework
       # if one service is not priced at framework, returns false
-      procurement_building_services.reject(&:special_da_service?).map { |pbs| pbs.service_missing_framework_price?(rate_model) }.all?(false)
+      procurement_building_services.reject(&:special_da_service?).none? { |pbs| pbs.service_missing_framework_price?(rate_model) }
     end
 
     SEARCH = %i[quick_search detailed_search detailed_search_bulk_upload choose_contract_value results].freeze
@@ -491,7 +483,7 @@ module FacilitiesManagement
     end
 
     def copy_procurement_buildings_gia
-      procurement_buildings.each(&:set_gia)
+      ActiveRecord::Base.transaction { active_procurement_buildings.includes(:building).find_each(&:set_gia) }
     end
 
     def save_data_for_procurement
@@ -505,7 +497,7 @@ module FacilitiesManagement
     def set_suppliers_for_procurement
       procurement_suppliers.destroy_all
       assessed_value_calculator.sorted_list.each do |supplier_data|
-        procurement_suppliers.create(supplier_id: CCS::FM::Supplier.supplier_name(supplier_data[0].to_s).id, direct_award_value: supplier_data[1])
+        procurement_suppliers.create!(supplier_id: CCS::FM::Supplier.supplier_name(supplier_data[0].to_s).id, direct_award_value: supplier_data[1])
       end
     end
 

--- a/app/models/facilities_management/procurement_building_service.rb
+++ b/app/models/facilities_management/procurement_building_service.rb
@@ -11,7 +11,7 @@ module FacilitiesManagement
     belongs_to :procurement_building, class_name: 'FacilitiesManagement::ProcurementBuilding', foreign_key: :facilities_management_procurement_building_id, inverse_of: :procurement_building_services
 
     # Lookup data for 'constants' are taken from this service object
-    services_and_questions = ServicesAndQuestions.new
+    services_and_questions = ServicesAndQuestions
 
     # validates on :volume service question
     validate :validate_volume, on: :volume # this validator will valid the appropriate field for the given service

--- a/app/services/facilities_management/services_and_questions.rb
+++ b/app/services/facilities_management/services_and_questions.rb
@@ -1,17 +1,17 @@
 class FacilitiesManagement::ServicesAndQuestions
-  def initialize
-    @context_questions = define_context_questions
-    @service_collection = gather_services
+  def self.context_questions
+    @context_questions ||= define_context_questions
   end
 
-  attr_accessor :service_collection
-  attr_accessor :context_questions
+  def self.service_collection
+    @service_collection ||= gather_services
+  end
 
   # Reduces the set of service declarations into a single hash for the given service code
-  def service_detail(code)
+  def self.service_detail(code)
     result = { code: code, context: {}, questions: [] }
 
-    @service_collection.select { |x| x[:code] == code }.each do |svc|
+    service_collection.select { |x| x[:code] == code }.each do |svc|
       result[:context].merge! svc[:context]
       result[:questions] |= svc[:questions]
     end
@@ -19,17 +19,15 @@ class FacilitiesManagement::ServicesAndQuestions
     result
   end
 
-  def get_codes_by_context(context)
-    @service_collection.select { |svc| svc[:context].include?(context.to_sym) }.map { |svc| svc[:code] }
+  def self.get_codes_by_context(context)
+    service_collection.select { |svc| svc[:context].include?(context.to_sym) }.map { |svc| svc[:code] }
   end
 
-  def codes
-    @service_collection.map { |sc| sc[:code] }
+  def self.codes
+    service_collection.map { |sc| sc[:code] }
   end
 
-  private
-
-  def define_context_questions
+  def self.define_context_questions
     { lifts: %i[lift_data].freeze,
       ppm_standards: %i[service_standard].freeze,
       building_standards: %i[service_standard].freeze,
@@ -38,12 +36,12 @@ class FacilitiesManagement::ServicesAndQuestions
       service_hours: %i[service_hours].freeze }
   end
 
-  def gather_services
-    service_hours_questions = @context_questions[:service_hours]
-    cleaning_questions = @context_questions[:cleaning_standards]
-    ppm_questions = @context_questions[:ppm_standards]
+  def self.gather_services
+    service_hours_questions = context_questions[:service_hours]
+    cleaning_questions = context_questions[:cleaning_standards]
+    ppm_questions = context_questions[:ppm_standards]
 
-    [{ code: 'C.5', context: { lifts: @context_questions[:lifts] }, questions: context_questions[:lifts] },
+    [{ code: 'C.5', context: { lifts: context_questions[:lifts] }, questions: context_questions[:lifts] },
      { code: 'C.5', context: { ppm_standards: ppm_questions }, questions: context_questions[:lifts] + ppm_questions },
      { code: 'E.4', context: { volume: [:no_of_appliances_for_testing] }, questions: [:no_of_appliances_for_testing] },
      { code: 'G.1', context: { volume: [:no_of_building_occupants], cleaning_standards: cleaning_questions }, questions: %i[no_of_building_occupants] + cleaning_questions },

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,4 +46,11 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # enable to find N+1 queries in specs
+  # config.after_initialize do
+  #   Bullet.enable = true
+  #   Bullet.bullet_logger = true
+  #   Bullet.raise = true
+  # end
 end

--- a/db/migrate/20200820120625_add_indexes_on_fm_models.rb
+++ b/db/migrate/20200820120625_add_indexes_on_fm_models.rb
@@ -1,0 +1,9 @@
+class AddIndexesOnFmModels < ActiveRecord::Migration[5.2]
+  def change
+    add_index :facilities_management_procurement_buildings, :building_id, name: 'index_fm_procurement_buildings_on_building_id'
+    add_index :facilities_management_procurement_buildings, :active, name: 'index_fm_procurement_buildings_on_active'
+    add_index :facilities_management_procurement_buildings, :service_codes, name: 'index_fm_procurement_buildings_on_service_codes'
+    add_index :facilities_management_procurement_building_services, :code, name: 'index_fm_procurement_building_services_on_code'
+    add_index :fm_rates, %i[code standard]
+  end
+end

--- a/db/migrate/20200825134101_add_procurement_ref_to_procurement_building_services.rb
+++ b/db/migrate/20200825134101_add_procurement_ref_to_procurement_building_services.rb
@@ -1,0 +1,7 @@
+class AddProcurementRefToProcurementBuildingServices < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :facilities_management_procurement_building_services, :facilities_management_procurement, foreign_key: true, type: :uuid,
+                                                                                                            index: { name: 'index_fm_procurement_building_services_on_fm_procurement_id' }
+    add_index :facilities_management_procurement_building_services, %i[facilities_management_procurement_id facilities_management_procurement_building_id], name: 'idx_fm_pbs_fm_p_fm_pb'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -99,7 +99,11 @@ ActiveRecord::Schema.define(version: 2020_08_27_112653) do
     t.string "lift_data", default: [], array: true
     t.bigint "service_hours"
     t.text "detail_of_requirement"
+    t.uuid "facilities_management_procurement_id"
+    t.index ["code"], name: "index_fm_procurement_building_services_on_code"
     t.index ["facilities_management_procurement_building_id"], name: "index_fm_procurements_on_fm_procurement_building_id"
+    t.index ["facilities_management_procurement_id", "facilities_management_procurement_building_id"], name: "idx_fm_pbs_fm_p_fm_pb"
+    t.index ["facilities_management_procurement_id"], name: "index_fm_procurement_building_services_on_fm_procurement_id"
   end
 
   create_table "facilities_management_procurement_buildings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -123,7 +127,10 @@ ActiveRecord::Schema.define(version: 2020_08_27_112653) do
     t.jsonb "building_json"
     t.text "description"
     t.bigint "external_area"
+    t.index ["active"], name: "index_fm_procurement_buildings_on_active"
+    t.index ["building_id"], name: "index_fm_procurement_buildings_on_building_id"
     t.index ["facilities_management_procurement_id"], name: "index_fm_procurements_on_fm_procurement_id"
+    t.index ["service_codes"], name: "index_fm_procurement_buildings_on_service_codes"
   end
 
   create_table "facilities_management_procurement_contact_details", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -341,6 +348,7 @@ ActiveRecord::Schema.define(version: 2020_08_27_112653) do
     t.boolean "direct_award"
     t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.index ["code", "standard"], name: "index_fm_rates_on_code_and_standard"
     t.index ["code"], name: "index_fm_rates_on_code"
   end
 
@@ -719,6 +727,7 @@ ActiveRecord::Schema.define(version: 2020_08_27_112653) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "facilities_management_buyer_details", "users"
   add_foreign_key "facilities_management_procurement_building_services", "facilities_management_procurement_buildings"
+  add_foreign_key "facilities_management_procurement_building_services", "facilities_management_procurements"
   add_foreign_key "facilities_management_procurement_buildings", "facilities_management_procurements"
   add_foreign_key "facilities_management_procurement_contact_details", "facilities_management_procurements"
   add_foreign_key "facilities_management_procurement_pension_funds", "facilities_management_procurements"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+#
+#
+## Supply teachers seeds
 
 holborn = SupplyTeachers::Supplier.create!(name: 'Holborn')
 holborn.branches.create!(
@@ -85,3 +88,73 @@ liverpool.rates.create!(
   term: 'twelve_weeks',
   mark_up: 0.32
 )
+
+# Facilities Management seeds
+# Seeds are created against the last user created in the database
+# Creates a procurement in detailed_search state with all services
+if ENV["fm"]
+  user = User.last
+  wk_codes = FacilitiesManagement::StaticData.services.map{|s| s['code']}
+  services = FacilitiesManagement::StaticData.work_packages.select!{|wc| wc if wc['code'] != "G.1" && wk_codes.include?(wc['work_package_code'])}
+  service_codes = services.map{|s| s['code']}
+
+  procurement = FacilitiesManagement::Procurement.create!(
+    user_id: user.id,
+    aasm_state: "detailed_search",
+    service_codes: service_codes,
+    region_codes: ["UKC1"],
+    contract_name: Faker::Name.unique.name + "'s Procurement",
+    estimated_annual_cost: 34689000,
+    tupe: true,
+    initial_call_off_period: 2,
+    initial_call_off_start_date: DateTime.now + 2.months,
+    initial_call_off_end_date: nil,
+    mobilisation_period: 4,
+    optional_call_off_extensions_1: 2,
+    optional_call_off_extensions_2: 2,
+    estimated_cost_known: true,
+    mobilisation_period_required: true,
+    extensions_required: true,
+    da_journey_state: "pricing")
+
+  # creates 1000 buildings
+  (0..999).each do |index|
+    postcode = 'WC2A 1AA'
+    street_address = '75 Chancery Lane'
+    town = 'London'
+    building = FacilitiesManagement::Building.create!(user: user,
+                                                     user_email: user.email,
+                                                     building_name: Faker::Name.unique.name + "'s Building",
+                                                     address_line_1: street_address,
+                                                     address_town: town,
+                                                     address_postcode: postcode,
+                                                     external_area: rand(200..4000),
+                                                     gia: rand(200..4000),
+                                                     building_type: 'General office - Customer Facing',
+                                                     security_type: 'Baseline personnel security standard (BPSS)')
+    region = Postcode::PostcodeCheckerV2.find_region postcode.delete(' ')
+    building.address_region_code = region[0]['code']
+    building.address_region = region[0]['region']
+    building.populate_json_attribute
+    building.save
+    procurement_building = FacilitiesManagement::ProcurementBuilding.create!(
+      procurement: procurement,
+      building_id: building.id,
+      service_codes: service_codes,
+      active: true)
+    procurement_building.procurement_building_services.each do |pbs|
+      pbs.update(
+        service_standard: 'A',
+        no_of_appliances_for_testing: rand(200..2000),
+        no_of_building_occupants: rand(200..2000),
+        no_of_consoles_to_be_serviced: rand(200..2000),
+        tones_to_be_collected_and_removed: rand(200..2000),
+        no_of_units_to_be_serviced: rand(200..2000),
+        lift_data: ["25", "12", "64"],
+        service_hours: rand(200..2000),
+        detail_of_requirement: 'test'
+      )
+    end
+    puts "Building ##{index} created"
+  end
+end

--- a/spec/factories/facilities_management_procurement.rb
+++ b/spec/factories/facilities_management_procurement.rb
@@ -4,13 +4,13 @@ FactoryBot.define do
     estimated_cost_known { 12345 }
     tupe { false }
     initial_call_off_period { 1 }
+    initial_call_off_start_date { Time.zone.now + 6.months }
     service_codes { ['C.1', 'C.2'] }
     association :user
     procurement_buildings { build_list :facilities_management_procurement_building, 1 }
   end
 
   factory :facilities_management_procurement_with_extension_periods, parent: :facilities_management_procurement do
-    initial_call_off_start_date { Time.zone.now + 6.months }
     mobilisation_period_required { true }
     mobilisation_period { 4 }
     extensions_required { true }

--- a/spec/models/facilities_management/procurement_dates_spec.rb
+++ b/spec/models/facilities_management/procurement_dates_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::Procurement, type: :model do
-  subject(:procurement) { build(:facilities_management_procurement, contract_name: 'contract_period_test', user: user) }
+  subject(:procurement) { build(:facilities_management_procurement, initial_call_off_start_date: nil, contract_name: 'contract_period_test', user: user) }
 
   let(:user) { build(:user) }
 

--- a/spec/models/facilities_management/procurement_spec.rb
+++ b/spec/models/facilities_management/procurement_spec.rb
@@ -1266,12 +1266,13 @@ RSpec.describe FacilitiesManagement::Procurement, type: :model do
     end
   end
 
-  describe '.valid_buildings?' do
+  describe '.valid_on_continue?' do
     context 'when the building is missing gia' do
       it 'is not valid' do
         procurement.active_procurement_buildings.first.update(service_codes: ['C.1'])
         procurement.active_procurement_buildings.first.building.update(gia: 0)
-        expect(procurement.send(:valid_buildings?)).to eq false
+        procurement.reload
+        expect(procurement.valid_on_continue?).to eq false
       end
     end
 
@@ -1279,14 +1280,17 @@ RSpec.describe FacilitiesManagement::Procurement, type: :model do
       it 'is not valid' do
         procurement.active_procurement_buildings.first.update(service_codes: ['G.5'])
         procurement.active_procurement_buildings.first.building.update(external_area: 0)
-        expect(procurement.send(:valid_buildings?)).to eq false
+        procurement.reload
+        expect(procurement.valid_on_continue?).to eq false
       end
     end
 
     context 'when the building is not missing gia or external_area' do
       it 'is valid' do
         procurement.active_procurement_buildings.first.update(service_codes: ['C.1', 'G.5'])
-        expect(procurement.send(:valid_buildings?)).to eq true
+        procurement.procurement_building_services.update(service_standard: 'A')
+        procurement.reload
+        expect(procurement.valid_on_continue?).to eq true
       end
     end
   end

--- a/spec/models/facilities_management/summary_report_procurements_spec.rb
+++ b/spec/models/facilities_management/summary_report_procurements_spec.rb
@@ -1404,6 +1404,10 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
         end.last.data['supplier_name']
       end
 
+      before do
+        procurement_building_service.procurement_building.set_gia
+      end
+
       it 'shows suppliers that do provide the service in UKH1 region' do
         expect(report.selected_suppliers(report.current_lot).map { |s| s.data['supplier_name'] }.include?(supplier_name)).to eq true
       end
@@ -1438,6 +1442,10 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
               ([procurement_building_service.code] - l['services']).any?
           end
         end.last.data['supplier_name']
+      end
+
+      before do
+        procurement_building_service.procurement_building.set_gia
       end
 
       it 'shows suppliers that do provide the specific service' do
@@ -1502,7 +1510,12 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
         end.last.data['supplier_name']
       end
 
+      before do
+        procurement.active_procurement_buildings.each(&:set_gia)
+      end
+
       it 'shows suppliers that do provide the specific service' do
+        report = described_class.new(procurement.id)
         expect(report.selected_suppliers(report.current_lot).map { |s| s.data['supplier_name'] }.include?(supplier_name)).to eq true
       end
 
@@ -1549,11 +1562,17 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
         end.last.data['supplier_name']
       end
 
+      before do
+        procurement.active_procurement_buildings.each(&:set_gia)
+      end
+
       it 'shows suppliers that do provide the specific service' do
+        report = described_class.new(procurement.id)
         expect(report.selected_suppliers(report.current_lot).map { |s| s.data['supplier_name'] }.include?(supplier_name)).to eq true
       end
 
       it 'does not show the suppliers that do not provide the specific service' do
+        report = described_class.new(procurement.id)
         expect(report.selected_suppliers(report.current_lot).map { |s| s.data['supplier_name'] }.include?(supplier_name_no_service)).to eq false
       end
     end
@@ -1586,6 +1605,10 @@ RSpec.describe FacilitiesManagement::SummaryReport, type: :model do
                 ([procurement_building_service.code] - l['services']).empty?)
           end
         end.first.data['supplier_name']
+      end
+
+      before do
+        procurement_building_service.procurement_building.set_gia
       end
 
       it 'shows suppliers that do provide the service in lot1b' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,18 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  # finds N+1 queries
+  # if Bullet.enable?
+  #   config.before do
+  #     Bullet.start_request
+  #   end
+  #
+  #   config.after do
+  #     Bullet.perform_out_of_channel_notifications if Bullet.notification?
+  #     Bullet.end_request
+  #   end
+  # end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/services/facilities_management/further_competition_spreadsheet_creator_spec.rb
+++ b/spec/services/facilities_management/further_competition_spreadsheet_creator_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe FacilitiesManagement::FurtherCompetitionSpreadsheetCreator do
 
     # rubocop:disable RSpec/MultipleExpectations
     it 'Verify Shortlist headers' do
+      procurement_with_buildings.procurement_buildings.each(&:set_gia)
       expect(wb.sheet('Shortlist').row(1)).to eq ['Reference number:', nil]
       expect(wb.sheet('Shortlist').row(2)).to eq ['Date/time production of this document:', nil]
       expect(wb.sheet('Shortlist').row(4)).to eq ['Cost and sub-lot recommendation', nil]


### PR DESCRIPTION
- Added seed data for FM that creates a procurement for the last user on the system with 1000 buildings and all services attached to them
- Optimised queries by creating database indexes and references
- Added eager loading to avoid N+1 queries
- Refactored procurement validator to not iterate through buildings multiple times
- Improved performance of the freezing of the building data by skipping callbacks
- Optimised some methods to be more efficient
- Removed unnecessary looping
- Fixed summary report to use the frozen region rather than building region
- ServicesAndQuestions does not need to initialize, so removed the initializer and switched all methods to class methods
- Added bullet gem that looks for N+1 queries (commented out for specs)