### PR TITLE
FMFR-177 -  progress summary of procurement's Service 

### DIFF
--- a/app/controllers/facilities_management/procurement_buildings_controller.rb
+++ b/app/controllers/facilities_management/procurement_buildings_controller.rb
@@ -5,6 +5,8 @@ module FacilitiesManagement
     before_action :set_building_data
     before_action :set_back_path
     before_action :set_service_question, only: %i[edit update]
+    before_action :set_volume_procurement_building_services, only: :show
+    before_action :set_standards_procurement_building_services, only: :show
 
     def show; end
 
@@ -35,6 +37,18 @@ module FacilitiesManagement
 
     def set_service_question
       @service_question = params[:service_question]
+    end
+
+    def set_volume_procurement_building_services
+      @volume_procurement_building_services = @procurement_building.sorted_procurement_building_services.map do |procurement_building_service|
+        procurement_building_service.required_volume_contexts.map do |context|
+          { procurement_building_service: procurement_building_service, context: context[1].first }
+        end
+      end.flatten
+    end
+
+    def set_standards_procurement_building_services
+      @standards_procurement_building_services = @procurement_building.sorted_procurement_building_services.select(&:requires_service_standard?)
     end
 
     def update_missing_region

--- a/app/helpers/facilities_management/procurement_buildings_helper.rb
+++ b/app/helpers/facilities_management/procurement_buildings_helper.rb
@@ -3,9 +3,9 @@ module FacilitiesManagement::ProcurementBuildingsHelper
     object_value == value
   end
 
-  def cell_class(qa_h)
+  def cell_class(context, answer)
     css_class = ['govuk-table__cell', 'govuk-!-padding-right-2']
-    css_class << 'govuk-border-bottom_none' if qa_h[:question] == :service_hours && qa_h[:answer].present?
+    css_class << 'govuk-border-bottom_none' if context == :service_hours && answer.present?
     css_class.join(' ')
   end
 
@@ -36,6 +36,20 @@ module FacilitiesManagement::ProcurementBuildingsHelper
       'volumes'
     else
       'area'
+    end
+  end
+
+  def procurement_building_status
+    if @procurement_building.complete?
+      [:blue, 'COMPLETE']
+    else
+      [:red, 'INCOMPLETE']
+    end
+  end
+
+  def services_with_contexts(volume_procurement_building_services)
+    volume_procurement_building_services.each do |service_with_context|
+      yield(service_with_context[:procurement_building_service], service_with_context[:context])
     end
   end
 end

--- a/app/models/facilities_management/procurement.rb
+++ b/app/models/facilities_management/procurement.rb
@@ -459,7 +459,7 @@ module FacilitiesManagement
     end
 
     def procurement_buildings_status
-      procurement_buildings.any? ? :completed : :not_started
+      active_procurement_buildings.any? ? :completed : :not_started
     end
 
     def buildings_and_services_status
@@ -470,9 +470,8 @@ module FacilitiesManagement
 
     def service_requirements_status
       return :cannot_start unless buildings_and_services_status == :completed
-      return :completed if procurement_building_services.any? && procurement_building_services.none? { |pbs| pbs.uval.nil? }
 
-      :incomplete
+      active_procurement_buildings.all?(&:complete?) ? :completed : :incomplete
     end
 
     private

--- a/app/services/facilities_management/services_and_questions.rb
+++ b/app/services/facilities_management/services_and_questions.rb
@@ -34,7 +34,7 @@ class FacilitiesManagement::ServicesAndQuestions
       ppm_standards: %i[service_standard].freeze,
       building_standards: %i[service_standard].freeze,
       cleaning_standards: %i[service_standard].freeze,
-      volume: %i[no_of_appliances_for_testing no_of_building_occupants no_of_consoles_to_be_serviced tones_to_be_collected_and_removed].freeze,
+      volume: %i[no_of_appliances_for_testing no_of_building_occupants no_of_consoles_to_be_serviced tones_to_be_collected_and_removed no_of_units_to_be_serviced].freeze,
       service_hours: %i[service_hours].freeze }
   end
 

--- a/app/views/facilities_management/procurement_buildings/show.html.erb
+++ b/app/views/facilities_management/procurement_buildings/show.html.erb
@@ -1,76 +1,121 @@
-<%= content_for :page_title, t('.heading') %>
-<div class="govuk-body building-services govuk-grid-row">
-  <div class="govuk-!-width-three-quarters">
-    <%= link_to 'Back', facilities_management_procurement_path(@procurement_building.procurement.id), class: 'govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-6' %>
-    <span class="govuk-caption-m"><%= @procurement_building.procurement.contract_name %>
-      - <%= @procurement_building.name %></span>
-    <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
-
-    <table class="govuk-table govuk-!-margin-bottom-6 govuk-!-font-size-16">
-      <thead>
-        <tr>
-          <td class="govuk-table__header govuk-!-font-weight-bold" style="width: 30%"></td>
-          <td class="govuk-table__header govuk-!-font-weight-bold" style="width: 30%"></td>
-          <td class="govuk-table__header govuk-!-font-weight-bold" style="width: 30%"></td>
-          <td class="govuk-table__header govuk-!-font-weight-bold" style="width: 10%"></td>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header govuk-table__cell govuk-!-padding-right-2"><%= t('.gia') %></th>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.gia-summary') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= @building.gia %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"></td>
-        </tr>
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header govuk-table__cell govuk-!-padding-right-2"><%= t('.service') %></th>
-          <td class="govuk-table__cell govuk-!-padding-right-2"></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.volume_required_html') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"></td>
-        </tr>
-        <% @procurement_building.procurement_building_services.has_service_questions.each_with_index do |service, index| %>
-          <% service.answer_store[:questions].each_with_index do |qa_h, i| %>
-            <tr class="govuk-table__row">
-              <% if i == 0 %>
-                <th class="govuk-table__header <%= cell_class(qa_h) %>"> <%= "#{index + 1}. #{service.name}" %> </th>
-              <% else %>
-                <td class="govuk-table__header <%= cell_class(qa_h) %>"></td>
-              <% end %>
-              <td class="<%= cell_class(qa_h) %>"><%= t(".#{qa_h[:question].to_s}") %></td>
-              <td class="<%= cell_class(qa_h) %>">
-                <%= service.service_hours if qa_h[:question] == :service_hours && qa_h[:answer].present? %>
-                <%= qa_h[:answer].map(&:to_i).reduce(:+) if qa_h[:question] == :lift_data %>
-                <%= 'Standard ' if qa_h[:answer].present? && qa_h[:question] == :service_standard %><%= qa_h[:answer].to_s unless %i[lift_data service_hours].include? qa_h[:question] %>
-              </td>
-              <td class="<%= cell_class(qa_h)%>">
-                <% link_text = 'Change' %>
-                <% link_text = 'Answer question' if qa_h[:answer].blank? || qa_h[:answer].try(:invalid?) %>
-                <%= link_to link_text, edit_facilities_management_procurement_buildings_service_path(service, service_question: get_service_question(qa_h[:question])) %>
-              </td>
-            </tr>
-            <% if qa_h[:question] == :service_hours && qa_h[:answer].present? %>
-              <tr class="govuk-table__row">
-                <td class="govuk-table__header govuk-table__cell govuk-!-padding-right-2" colspan=2></td>
-                <td class="govuk-table__cell govuk-!-padding-right-2 govuk-!-padding-top-0" colspan=2>
-                    <details class="govuk-details govuk-!-font-size-16" data-module="govuk-details">
-                      <summary class="govuk-details__summary">
-                        <span class="govuk-details__summary-text">
-                          <%= t('.detail_of_requirement') %>
-                        </span>
-                      </summary>
-                      <div class="govuk-details__text govuk-!-padding-bottom-0 govuk-!-padding-top-0">
-                        <%= simple_format service.detail_of_requirement, class: 'govuk-!-font-size-16'%>
-                      </div>
-                    </details>
-                </td>
-              </tr>
-            <% end %>
-          <% end %>
-        <% end %>
-      </tbody>
-    </table>
-    <div class="govuk-!-margin-top-7 govuk-!-margin-bottom-0">
-      <%= link_to t('.back_to_detailed_summary'), facilities_management_procurement_path(@procurement_building.procurement), class: 'govuk-link--no-visited-state' %>
-    </div>
+<%= govuk_page_header(LayoutHelper::HeadingDetail.new(@procurement_building.name, @procurement_building.procurement.contract_name, nil, nil, nil)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">
+      <%= t('.heading') %>
+    </h2>
+    <span class="govuk-body ccs-font-weight-semi-bold">
+      <%= t('.status') %> <span class=govuk-!-padding-left-2><%= govuk_tag_with_text(*procurement_building_status) %></span>
+    </span>
   </div>
 </div>
+
+<div class="govuk-grid-row govuk-!-margin-top-4">
+  <div class="govuk-grid-column-full govuk-body">
+    <%= t('.help_line_1') %><br/>
+    <%= t('.help_line_2') %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full govuk-body">
+    <%= t('.list_title') %>
+    <ol class="govuk-list govuk-list--number govuk-!-margin-top-2">
+      <li> <%= t('.list_item_1') %> </li>
+      <li> <%= t('.list_item_2') %> </li>
+    </ol>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">
+      <%= t('.service_volumes') %>
+    </h2>
+  </div>
+</div>
+<hr class="govuk-section-break govuk-section-break--visible">
+<table class="govuk-table govuk-!-width-full">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 35%"><%= t('.service_name') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 40%"><%= t('.unit_of_measure_title') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 15%"><%= t('.volume_required') %></th>
+      <td class="govuk-table__header govuk-!-font-weight-bold" style="width: 10%"></td>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% services_with_contexts(@volume_procurement_building_services) do |service, context| %>
+      <% cell_classes = cell_class(context, service.uval)%>
+      <tr class="govuk-table__row">
+        <td class="<%= cell_classes %>"><%= service.name %></td>
+        <td class="<%= cell_classes %>"><%= t(".unit_of_measure.#{context}") %></td>
+        <% if service.send(context).blank? %>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= link_to t('.answer_question'), edit_facilities_management_procurement_buildings_service_path(service, service_question: get_service_question(context)) %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"></td>
+        <% else %>
+          <% case context %>
+          <% when :lift_data, :service_hours %>
+            <td class="<%= cell_classes %>"><%= service.uval %></td>
+          <% else %>
+            <td class="govuk-table__cell govuk-!-padding-right-2"><%= service.send(context) %></td>
+          <% end %>
+          <td class="<%= cell_classes %>"><%= link_to t('.change'), edit_facilities_management_procurement_buildings_service_path(service, service_question: get_service_question(context)) %></td>
+        <% end %>
+      </tr>
+      <% if context == :service_hours && service.uval.present? %>
+        <tr class="govuk-table__row">
+          <td class=" govuk-table__cell govuk-!-padding-right-2" colspan=2></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2 govuk-!-padding-top-0" colspan=2>
+            <details class="govuk-details govuk-!-font-size-16" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  <%= t('.detail_of_requirement') %>
+                </span>
+              </summary>
+              <div class="govuk-details__text govuk-!-padding-bottom-0 govuk-!-padding-top-0">
+                <%= simple_format service.detail_of_requirement, class: 'govuk-!-font-size-16'%>
+              </div>
+            </details>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">
+      <%= t('.service_standards') %>
+    </h2>
+  </div>
+</div>
+<hr class="govuk-section-break govuk-section-break--visible">
+<table class="govuk-table govuk-!-width-full">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 35%"><%= t('.service_name') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 40%"><%= t('.description') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 15%"><%= t('.standard') %></th>
+      <td class="govuk-table__header govuk-!-font-weight-bold" style="width: 10%"></td>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @standards_procurement_building_services.each do |service| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-padding-right-2"><%= service.name %></td>
+        <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.the_standard_required') %></td>
+        <% if service.service_standard.nil?%>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= link_to t('.answer_question'), edit_facilities_management_procurement_buildings_service_path(service, service_question: 'service_standards') %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"></td>
+        <% else %>
+          <td class="govuk-table__cell govuk-!-padding-right-2"> <%= "Standard #{service.service_standard}" %> </td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= link_to t('.change'), edit_facilities_management_procurement_buildings_service_path(service, service_question: 'service_standards') %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to t('.return_to_requirements'), facilities_management_procurement_summary_path(@procurement_building.procurement, summary: 'service_requirements'), class: 'govuk-link govuk-link--no-visited-state govuk-!-font-size-19'%>

--- a/app/views/facilities_management/procurements/summary/_service_requirements.html.erb
+++ b/app/views/facilities_management/procurements/summary/_service_requirements.html.erb
@@ -1,1 +1,20 @@
 <p>Will be completed as part of ticket FMFR-176</p>
+
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 50%">Name</th>
+        <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 25%">Status</th>
+        <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 25%"></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @procurement.active_procurement_buildings.each do |procurement_building| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= procurement_building.name %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= govuk_tag(procurement_building.complete? ? :completed : :incomplete) %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= link_to 'Answer questions', facilities_management_procurement_building_path(procurement_building) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -687,26 +687,34 @@ en:
         we_use_your_buildings: We use your buildings’ address to assess the region that your building is located in. This helps us shortlist the suppliers who can deliver your services to your exact locations.
       show:
         answer_question: Answer question
-        back_to_detailed_summary: Back to detailed search summary
+        change: Change
+        description: Description
         detail_of_requirement: Detail of requirement
-        gia: Gross internal area (GIA)
-        gia-summary: The gross internal area of the building (in square meters)
         heading: Service requirements
-        lift_data: Total number of lift entrances
-        no_of_appliances_for_testing: The number of appliances to be tested per annum
-        no_of_building_occupants: The number of building occupants
-        no_of_consoles_to_be_serviced: The number of consoles to be serviced per annum
-        no_of_hours_of_service_provision: The number of hours of service provision per annum
-        no_of_units_to_be_serviced: The number of units to be serviced per annum
-        service: Service
-        service_hour_question: The number of hours of service provision per annum
-        service_hours: Number of hours per year
-        service_standard: The service standard required
-        size_of_external_area: The size of the external area (in square metres)
-        tones_to_be_collected_and_removed: The number of tonnes to be collected and removed per annum
-        total_floors_per_lift: Total number of lift entrances
-        volume_required_heading: Volume required (per annum)
-        volume_required_html: "<b>Volume required <br> (per annum)</b>"
+        help_line_1: We need to understand more about the services that you require in this building. Please complete any missing information, and check that you are happy with any pre-populated volumes.
+        help_line_2: The status indicator above will confirm when all questions have been answered for this building - you can then click on the 'return to service requirement summary' hyperlink at the bottom of the page.
+        list_item_1: Service volumes - this is where you can check or input the volume required for each service.
+        list_item_2: Service standards - this is where you can select the standard of service required.
+        list_title: 'All the services that you require for this building are listed below, split into two sections:'
+        return_to_requirements: Return to requirements
+        service_name: Service name
+        service_standards: 2. Service standards
+        service_volumes: 1. Service volumes
+        standard: Standard
+        status: 'Status:'
+        the_standard_required: The service standard required
+        unit_of_measure:
+          external_area: External area - number of square metres
+          gia: Gross Internal Area - number of square metres
+          lift_data: Total number of lift entrances
+          no_of_appliances_for_testing: Number of appliances to be tested per annum
+          no_of_building_occupants: The number of building occupants
+          no_of_consoles_to_be_serviced: Number of consoles per annum
+          no_of_units_to_be_serviced: Number of units per annum
+          service_hours: Total number of hours required per annum
+          tones_to_be_collected_and_removed: Number of tonnes per annum
+        unit_of_measure_title: Unit of measure
+        volume_required: Volume required
       volume:
         question:
           no_of_appliances_for_testing: How many appliances to be tested per annum?

--- a/spec/controllers/facilities_management/procurement_buildings_controller_spec.rb
+++ b/spec/controllers/facilities_management/procurement_buildings_controller_spec.rb
@@ -48,4 +48,26 @@ RSpec.describe FacilitiesManagement::ProcurementBuildingsController, type: :cont
       end
     end
   end
+
+  describe 'methods called on show' do
+    login_fm_buyer_with_details
+
+    before do
+      procurement_building.update(service_codes: %w[C.1 E.4 C.2 C.3 C.4 G.3 C.5 K.4 I.3 O.1 N.1])
+      procurement_building.reload
+      get :show, params: { id: procurement_building.id }
+    end
+
+    context 'when set_standards_procurement_building_services is used' do
+      it 'returns the correct procurement_building_services' do
+        expect(assigns(:standards_procurement_building_services).map(&:code)).to eq %w[C.1 C.2 C.3 C.4 C.5 G.3]
+      end
+    end
+
+    context 'when set_volume_procurement_building_services is used' do
+      it 'returns the correct procurement_building_services' do
+        expect(assigns(:volume_procurement_building_services).map { |service_and_context| service_and_context[:procurement_building_service].code }).to eq %w[C.1 C.2 C.3 C.4 C.5 E.4 G.3 G.3 I.3 K.4]
+      end
+    end
+  end
 end

--- a/spec/helpers/facilities_management/procurement_buildings_helper_spec.rb
+++ b/spec/helpers/facilities_management/procurement_buildings_helper_spec.rb
@@ -65,4 +65,31 @@ RSpec.describe FacilitiesManagement::ProcurementBuildingsHelper, type: :helper d
       end
     end
   end
+
+  describe '#procurement_building_status' do
+    let(:procurement_building) { create(:facilities_management_procurement_building, procurement: procurement) }
+    let(:procurement) { create(:facilities_management_procurement, user: user) }
+    let(:user) { create(:user) }
+
+    before do
+      @procurement_building = procurement_building
+      allow(procurement_building).to receive(:complete?).and_return(answer)
+    end
+
+    context 'when the procurement_building is complete' do
+      let(:answer) { true }
+
+      it 'returns the COMPLETE status' do
+        expect(helper.procurement_building_status).to eq [:blue, 'COMPLETE']
+      end
+    end
+
+    context 'when the procurement_building is not complete' do
+      let(:answer) { false }
+
+      it 'returns the INCOMPLETE status' do
+        expect(helper.procurement_building_status).to eq [:red, 'INCOMPLETE']
+      end
+    end
+  end
 end

--- a/spec/models/facilities_management/procurement_building_service_spec.rb
+++ b/spec/models/facilities_management/procurement_building_service_spec.rb
@@ -752,50 +752,50 @@ RSpec.describe FacilitiesManagement::ProcurementBuildingService, type: :model do
       end
     end
 
-    describe '#requires_ppm_standards?' do
+    describe '# requires_service_standard?' do
       context 'when code requires ppm standards' do
         it 'will be true when C.5' do
           procurement_building_service.code = 'C.5'
-          expect(procurement_building_service.requires_ppm_standards?).to eq true
+          expect(procurement_building_service. requires_service_standard?).to eq true
         end
       end
 
       context 'when code doesn\'t require ppm standards' do
         it 'will be false when K.6' do
           procurement_building_service.code = 'K.6'
-          expect(procurement_building_service.requires_ppm_standards?).to eq false
+          expect(procurement_building_service. requires_service_standard?).to eq false
         end
       end
     end
 
-    describe '#requires_building_standards?' do
+    describe '# requires_service_standard?' do
       context 'when code requires building standards' do
         it 'will be true when C.7' do
           procurement_building_service.code = 'C.7'
-          expect(procurement_building_service.requires_building_standards?).to eq true
+          expect(procurement_building_service. requires_service_standard?).to eq true
         end
       end
 
       context 'when code doesn\'t require building standards' do
         it 'will be false when K.1' do
           procurement_building_service.code = 'K.1'
-          expect(procurement_building_service.requires_building_standards?).to eq false
+          expect(procurement_building_service. requires_service_standard?).to eq false
         end
       end
     end
 
-    describe '#requires_cleaning_standards?' do
+    describe '# requires_service_standard?' do
       context 'when code requires cleaning standards' do
         it 'will be true when G.5' do
           procurement_building_service.code = 'G.5'
-          expect(procurement_building_service.requires_cleaning_standards?).to eq true
+          expect(procurement_building_service. requires_service_standard?).to eq true
         end
       end
 
       context 'when code doesn\'t require cleaning standards' do
         it 'will be false when K.6' do
           procurement_building_service.code = 'K.6'
-          expect(procurement_building_service.requires_cleaning_standards?).to eq false
+          expect(procurement_building_service. requires_service_standard?).to eq false
         end
       end
     end
@@ -1118,6 +1118,54 @@ RSpec.describe FacilitiesManagement::ProcurementBuildingService, type: :model do
       it 'is valid' do
         procurement_building_service.detail_of_requirement = ('a' * 490) + ("\r\n" * 10)
         expect(procurement_building_service.valid?(:service_hours)).to eq true
+      end
+    end
+  end
+
+  describe '#required_volume_contexts' do
+    let(:procurement_building_service) do
+      create(:facilities_management_procurement_building_service,
+             code: code,
+             procurement_building: create(:facilities_management_procurement_building_no_services, procurement: create(:facilities_management_procurement_no_procurement_buildings)))
+    end
+
+    context 'when the service does not have any required contexts' do
+      let(:code) { 'O.1' }
+
+      it 'returns an empty hash' do
+        expect(procurement_building_service.required_volume_contexts).to eq({})
+      end
+    end
+
+    context 'when the service does have one required context' do
+      let(:code) { 'C.5' }
+
+      it 'returns a hash with correct context' do
+        expect(procurement_building_service.required_volume_contexts).to eq lifts: [:lift_data]
+      end
+    end
+
+    context 'when the service requires gia' do
+      let(:code) { 'C.1' }
+
+      it 'returns a hash with correct context' do
+        expect(procurement_building_service.required_volume_contexts).to eq gia: [:gia]
+      end
+    end
+
+    context 'when the service requires external area' do
+      let(:code) { 'G.5' }
+
+      it 'returns a hash with correct context' do
+        expect(procurement_building_service.required_volume_contexts).to eq external_area: [:external_area]
+      end
+    end
+
+    context 'when the service requires a volume and gia' do
+      let(:code) { 'G.3' }
+
+      it 'returns a hash with correct context' do
+        expect(procurement_building_service.required_volume_contexts).to eq(volume: [:no_of_building_occupants], gia: [:gia])
       end
     end
   end

--- a/spec/models/facilities_management/procurement_building_spec.rb
+++ b/spec/models/facilities_management/procurement_building_spec.rb
@@ -522,4 +522,147 @@ RSpec.describe FacilitiesManagement::ProcurementBuilding, type: :model do
       end
     end
   end
+
+  describe '#sorted_procurement_building_services' do
+    context 'when the service codes are put ina random order' do
+      let(:codes) { %w[C.1 E.4 C.2 C.3 C.4 G.3 C.5 C.11 K.4 I.3 O.1 N.1 D.1 E.1 G.1] }
+
+      before do
+        procurement_building.update(service_codes: codes.shuffle)
+        procurement_building.reload
+      end
+
+      it 'returns the procurement_building_services in the work package order' do
+        expect(procurement_building.sorted_procurement_building_services.map(&:code)).to eq %w[C.1 C.2 C.3 C.4 C.11 C.5 D.1 E.1 E.4 G.1 G.3 I.3 K.4 N.1 O.1]
+      end
+    end
+  end
+
+  describe '#complete?' do
+    let(:codes_with_values) do
+      {
+        'C.1': { service_standard: c1_value },
+        'G.3': { service_standard: g3_value1, no_of_building_occupants: g3_value2 },
+        'G.5': { service_standard: g5_value },
+        'C.5': { service_standard: c5_value1, lift_data: c5_value2 },
+        'H.5': { service_hours: h5_value, detail_of_requirement: 'Some details' },
+        'E.4': { no_of_appliances_for_testing: e4_value },
+        'K.1': { no_of_consoles_to_be_serviced: k1_value },
+        'K.2': { tones_to_be_collected_and_removed: k2_value },
+        'K.7': { no_of_units_to_be_serviced: k7_value }
+      }
+    end
+
+    let(:c1_value) { 'A' }
+    let(:g3_value1) { 'B' }
+    let(:g3_value2) { 58 }
+    let(:g5_value) { 'A' }
+    let(:c5_value1) { 'C' }
+    let(:c5_value2) { [1, 2, 3, 4] }
+    let(:h5_value) { 406 }
+    let(:e4_value) { 123 }
+    let(:k1_value) { 234 }
+    let(:k2_value) { 345 }
+    let(:k7_value) { 456 }
+
+    let(:gia) { 100 }
+    let(:external_area) { 200 }
+
+    before do
+      procurement_building.procurement.update(aasm_state: 'detailed_search')
+      service_codes = codes_with_values.map { |key, _| key.to_s }
+      procurement_building.update(service_codes: service_codes)
+      procurement_building.reload
+      procurement_building.procurement_building_services.each do |pbs|
+        pbs.update(codes_with_values[pbs.code.to_sym])
+      end
+      procurement_building.building.update(gia: gia, external_area: external_area)
+    end
+
+    context 'when a service requires gia and gia is zero' do
+      let(:gia) { 0 }
+
+      it 'returns false' do
+        expect(procurement_building.complete?).to eq false
+      end
+    end
+
+    context 'when a service requires external_area and external_area is zero' do
+      let(:external_area) { 0 }
+
+      it 'returns false' do
+        expect(procurement_building.complete?).to eq false
+      end
+    end
+
+    context 'when a service requires lift_data and lift_data is empty' do
+      let(:c5_value2) { [] }
+
+      it 'returns false' do
+        expect(procurement_building.complete?).to eq false
+      end
+    end
+
+    context 'when a service requires service_hours and service_hours is nil' do
+      let(:h5_value) { nil }
+
+      it 'returns false' do
+        expect(procurement_building.complete?).to eq false
+      end
+    end
+
+    context 'when a service requires a no_of_appliances_for_testing and no_of_appliances_for_testing is nil' do
+      let(:e4_value) { nil }
+
+      it 'returns false' do
+        expect(procurement_building.complete?).to eq false
+      end
+    end
+
+    context 'when a service requires a no_of_building_occupants and no_of_building_occupants is nil' do
+      let(:g3_value2) { nil }
+
+      it 'returns false' do
+        expect(procurement_building.complete?).to eq false
+      end
+    end
+
+    context 'when a service requires a no_of_consoles_to_be_serviced and no_of_consoles_to_be_serviced is nil' do
+      let(:k1_value) { nil }
+
+      it 'returns false' do
+        expect(procurement_building.complete?).to eq false
+      end
+    end
+
+    context 'when a service requires a tones_to_be_collected_and_removed and tones_to_be_collected_and_removed is nil' do
+      let(:k2_value) { nil }
+
+      it 'returns false' do
+        expect(procurement_building.complete?).to eq false
+      end
+    end
+
+    context 'when a service requires a no_of_units_to_be_serviced and no_of_units_to_be_serviced is nil' do
+      let(:k7_value) { nil }
+
+      it 'returns false' do
+        expect(procurement_building.complete?).to eq false
+      end
+    end
+
+    context 'when a service requires a service_standard and service_standard is nil' do
+      let(:c1_value) { nil }
+
+      it 'returns false' do
+        expect(procurement_building.complete?).to eq false
+      end
+    end
+
+    context 'when all service questions are answered' do
+      it 'returns true' do
+        expect(procurement_building.complete?).to eq true
+      end
+    end
+  end
 end

--- a/spec/models/facilities_management/procurement_spec.rb
+++ b/spec/models/facilities_management/procurement_spec.rb
@@ -1375,6 +1375,10 @@ RSpec.describe FacilitiesManagement::Procurement, type: :model do
 
     let(:procurement_building1) { build(:facilities_management_procurement_building) }
     let(:procurement_building2) { build(:facilities_management_procurement_building) }
+
+    before do
+      procurement.update(aasm_state: 'detailed_search')
+    end
   end
 
   describe '.buildings_and_services_status' do
@@ -1441,12 +1445,21 @@ RSpec.describe FacilitiesManagement::Procurement, type: :model do
     context 'when Assigning services to buildings task is COMPLETED' do
       before do
         allow(procurement).to receive(:buildings_and_services_status).and_return(:completed)
+
+        procurement_building1.procurement_building_services.delete_all
+        procurement_building2.procurement_building_services.delete_all
+
+        procurement_building1.update(service_codes: ['C.1'])
+        procurement_building2.update(service_codes: ['G.5'])
+
+        procurement_building1.procurement_building_services.first.update(service_standard: 'A')
+        procurement_building2.procurement_building_services.first.update(service_standard: 'A')
       end
 
       context 'when all the buildings service requirements have not yet been COMPLETED' do
         before do
-          procurement_building1.update(gia: nil)
-          procurement_building2.update(gia: nil)
+          procurement_building1.building.update(gia: 0)
+          procurement_building2.building.update(external_area: 0)
         end
 
         it 'shown with the INCOMPLETE status label' do


### PR DESCRIPTION
> - Initial layout for the service standard questions
> - Add the service volumes table
> - Sort the services by there workpackage code
> - Complete copy of the page
> - Move the text to a translation file
> - Add tests for the procurement controller
> - Add tests for procurement_buildings_helper
> - Update tests for new method
> - Add tests for the required_volume_contexts
> - Add tests for the completeness of the procurement_building
> - Refactor tests for complete method
> - Update summary page so can link to procurement_buildings