### PR TITLE
Only show buildings that require questions in summary

### DIFF
--- a/app/models/facilities_management/procurement_building.rb
+++ b/app/models/facilities_management/procurement_building.rb
@@ -75,6 +75,12 @@ module FacilitiesManagement
       valid?(:buildings_and_services) && valid?(:gia) && valid?(:external_area)
     end
 
+    def requires_service_questions?
+      return true if requires_internal_area? || requires_external_area?
+
+      procurement_building_services.map(&:required_contexts).any?(&:present?)
+    end
+
     private
 
     def service_code_selection
@@ -166,12 +172,6 @@ module FacilitiesManagement
 
     def add_selection_error(index)
       errors.add(:service_codes, SERVICE_SELECTION_INVALID_TYPE[index], building_name: building.building_name, building_id: id)
-    end
-
-    def requires_service_questions?
-      return true if requires_internal_area? || requires_external_area?
-
-      procurement_building_services.map(&:required_contexts).any?(&:present?)
     end
 
     def area_complete?

--- a/app/views/facilities_management/procurements/summary/_service_requirements.html.erb
+++ b/app/views/facilities_management/procurements/summary/_service_requirements.html.erb
@@ -9,7 +9,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% @procurement.active_procurement_buildings.each do |procurement_building| %>
+      <% @procurement.active_procurement_buildings.select(&:requires_service_questions?).each do |procurement_building| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-padding-right-2"><%= procurement_building.name %></td>
           <td class="govuk-table__cell govuk-!-padding-right-2"><%= govuk_tag(procurement_building.complete? ? :completed : :incomplete) %></td>


### PR DESCRIPTION
I realised from my last PR just after I merged it that we were showing buildings that didn't require service questions in the summery. This commit changes it so only buildings that need a service requirement are shown in the list.