### PR TITLE
Feature/fmfr 224 fix

### DIFF
--- a/app/models/concerns/procurement_validator.rb
+++ b/app/models/concerns/procurement_validator.rb
@@ -196,7 +196,7 @@ module ProcurementValidator
         # at least one service per building
         errors.add(:base, :services_not_present) && (return false) if pb.procurement_building_services.none?
         # services valid
-        pb.errors.add(:base, :services_invalid) unless pb.valid?(:procurement_building_services)
+        pb.errors.add(:base, :services_invalid) && errors.add(:base, '') unless pb.valid?(:procurement_building_services)
       end
     end
 

--- a/spec/models/facilities_management/procurement_spec.rb
+++ b/spec/models/facilities_management/procurement_spec.rb
@@ -389,6 +389,13 @@ RSpec.describe FacilitiesManagement::Procurement, type: :model do
         expect(procurement.valid_on_continue?).to eq false
       end
     end
+
+    context 'when a building has services that require questions' do
+      it 'is in the array' do
+        procurement_building = create(:facilities_management_procurement_building, procurement: procurement, service_codes: ['C.5', 'E.4', 'K.8'])
+        expect(procurement.valid_on_continue?).to eq false
+      end
+    end
   end
 
   describe '#update_building_services' do


### PR DESCRIPTION
Adding an empty error message to the procurement building when a service is invalid