### PR TITLE
FMFR-201 - Spreadsheet data import - failed

### DIFF
--- a/app/controllers/facilities_management/procurements/spreadsheet_imports_controller.rb
+++ b/app/controllers/facilities_management/procurements/spreadsheet_imports_controller.rb
@@ -4,6 +4,7 @@ module FacilitiesManagement
       include FacilitiesManagement::ControllerLayoutHelper
       before_action :set_procurement
       before_action :authorize_user
+      before_action :set_spreadsheet_import, only: %i[show destroy]
       before_action :redirect_to_requirements
 
       def new
@@ -23,7 +24,12 @@ module FacilitiesManagement
       end
 
       def show
-        @spreadsheet_import = SpreadsheetImport.find(params[:id])
+        initialize_errors if @spreadsheet_import.failed?
+      end
+
+      def destroy
+        @spreadsheet_import.delete
+        redirect_to new_facilities_management_procurement_spreadsheet_import_path(procurement_id: @procurement.id)
       end
 
       private
@@ -32,12 +38,29 @@ module FacilitiesManagement
         @procurement = FacilitiesManagement::Procurement.find(params[:procurement_id])
       end
 
+      def set_spreadsheet_import
+        @spreadsheet_import = SpreadsheetImport.find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        redirect_to new_facilities_management_procurement_spreadsheet_import_path(procurement_id: @procurement.id)
+      end
+
       def spreadsheet_import_params
         params.require(:facilities_management_spreadsheet_import).permit(:spreadsheet_file, :facilities_management_procurement_id)
       end
 
       def redirect_to_requirements
         redirect_to facilities_management_procurement_path(@procurement) unless @procurement.detailed_search_bulk_upload?
+      end
+
+      def initialize_errors
+        @error_lists = {
+          building_errors: @spreadsheet_import.building_errors,
+          service_matrix_errors: @spreadsheet_import.service_matrix_errors,
+          service_volume_errors: @spreadsheet_import.service_volume_errors,
+          lift_errors: @spreadsheet_import.lift_errors,
+          service_hour_errors: @spreadsheet_import.service_hour_errors,
+          other_errors: @spreadsheet_import.import_errors.empty? ? [:other_errors] : []
+        }
       end
 
       protected

--- a/app/helpers/facilities_management/procurements/spreadsheet_imports_helper.rb
+++ b/app/helpers/facilities_management/procurements/spreadsheet_imports_helper.rb
@@ -1,0 +1,14 @@
+module FacilitiesManagement::Procurements::SpreadsheetImportsHelper
+  def error_count(error_list, attribute)
+    case attribute
+    when :building_errors, :service_matrix_errors
+      error_list.sum { |e| e[:errors].count }
+    else
+      error_list.count
+    end
+  end
+
+  def error_message(model, attribute, message)
+    t("facilities_management.procurements.spreadsheet_imports.errors.#{model}.#{attribute}.#{message}")
+  end
+end

--- a/app/models/facilities_management/procurement_building.rb
+++ b/app/models/facilities_management/procurement_building.rb
@@ -13,7 +13,6 @@ module FacilitiesManagement
     validate :service_code_selection, on: :buildings_and_services
     validate :services_valid?, on: :procurement_building_services
     validate :validate_service_requirements, on: :service_requirements
-    validate :services_present?, on: :procurement_building_services_present
     validate :validate_internal_area, on: :gia
     validate :validate_external_area, on: :external_area
 
@@ -104,10 +103,6 @@ module FacilitiesManagement
 
     def cleanup_service_codes
       self.service_codes = service_codes.reject(&:blank?)
-    end
-
-    def services_present?
-      errors.add(:service_codes, :at_least_one, building_name: name) if service_codes.empty?
     end
 
     def validate_service_requirements

--- a/app/models/facilities_management/spreadsheet_import.rb
+++ b/app/models/facilities_management/spreadsheet_import.rb
@@ -10,8 +10,9 @@ module FacilitiesManagement
     validate :spreadsheet_file_ext_validation, on: :upload
     validates :spreadsheet_file, antivirus: { message: :malicious }, on: :upload
     validates :spreadsheet_file, size: { less_than: 10.megabytes, message: :too_large }, on: :upload
-    validates :spreadsheet_file, content_type: { with: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                                                 message: :wrong_content_type }, on: :upload
+    validates :spreadsheet_file, content_type: { with: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', message: :wrong_content_type }, on: :upload
+
+    serialize :import_errors
 
     aasm do
       state :upload, initial: true
@@ -66,6 +67,129 @@ module FacilitiesManagement
       when 'failed'
         [:red, 'Upload failed']
       end
+    end
+
+    BUILDING_ATTRIBUTES = %i[building_name description address_line_1 address_line_2 address_town address_postcode gia external_area building_type other_building_type security_type other_security_type].freeze
+    SERVICE_MATRIX_ATTRIBUTES = %i[service_codes building].freeze
+
+    def building_errors
+      (1..errors_from_import.count).map do |index|
+        BUILDING_ATTRIBUTES.map do |attribute|
+          building_error(index, attribute)
+        end.compact
+      end.flatten(1)
+    end
+
+    def service_matrix_errors
+      (1..errors_from_import.count).map do |index|
+        SERVICE_MATRIX_ATTRIBUTES.map do |attribute|
+          service_matrix_error(index, attribute)
+        end.compact
+      end.flatten(1)
+    end
+
+    def service_volume_errors
+      (1..errors_from_import.count).map do |index|
+        service_volume_codes_with_attributes.map do |code, attribute|
+          service_error(index, code, attribute, false)
+        end.compact
+      end.flatten(1)
+    end
+
+    def lift_errors
+      (1..errors_from_import.count).map do |index|
+        lift_error(index)
+      end.compact
+    end
+
+    def service_hour_errors
+      (1..errors_from_import.count).map do |index|
+        service_hour_codes_with_attributes.map do |code, attributes|
+          attributes.map { |attribute| service_error(index, code, attribute) }.compact
+        end.compact.flatten(1)
+      end.flatten(1)
+    end
+
+    private
+
+    def building_error(building_index, attribute)
+      error_details = error_detail(building_index, :building_errors, attribute)
+
+      return unless error_details
+
+      error_hash("Building #{building_index}", nil, attribute, error_types(error_details))
+    end
+
+    def service_matrix_error(building_index, attribute)
+      error_details = error_detail(building_index, :procurement_building_errors, attribute)
+
+      return unless error_details
+
+      error_hash(error_building_name(building_index), nil, attribute, error_types(error_details))
+    end
+
+    def service_error(building_index, code, attribute, error_required = true)
+      error_details = service_error_detail(building_index, code)
+
+      return unless error_details && error_details[attribute]
+
+      error_list = error_required ? error_types(error_details[attribute]) : nil
+
+      error_hash(error_building_name(building_index), service_name(code), attribute, error_list)
+    end
+
+    def lift_error(building_index)
+      error_details = service_error_detail(building_index, 'C.5')
+
+      return unless error_details&.any?
+
+      if error_details.key?(:lifts)
+        error_hash(error_building_name(building_index), service_name('C.5'), :lifts, nil)
+      else
+        error_hash(error_building_name(building_index), service_name('C.5'), :number_of_floors, nil)
+      end
+    end
+
+    def error_hash(building_name, service_name, attribute, errors)
+      { building_name: building_name, service_name: service_name, attribute: attribute, errors: errors }.compact
+    end
+
+    def errors_from_import
+      @errors_from_import ||= import_errors
+    end
+
+    def error_building_name(building_index)
+      errors_from_import[:"Building #{building_index}"][:building_name]
+    end
+
+    def error_detail(building_index, model, attribute)
+      errors_from_import[:"Building #{building_index}"][model][attribute]
+    end
+
+    def service_error_detail(building_index, code)
+      errors_from_import[:"Building #{building_index}"][:procurement_building_services_errors][code.to_sym]
+    end
+
+    def error_types(error_details)
+      error_details.map { |e| e[:error] }.uniq
+    end
+
+    def service_name(code)
+      work_packages ||= FacilitiesManagement::StaticData.work_packages
+
+      work_packages.find { |wp| wp['code'] == code }['name']
+    end
+
+    def service_volume_codes_with_attributes
+      FacilitiesManagement::ServicesAndQuestions.get_codes_by_context(:volume).map do |code|
+        [code, FacilitiesManagement::ServicesAndQuestions.service_detail(code)[:context][:volume].first]
+      end.to_h
+    end
+
+    def service_hour_codes_with_attributes
+      FacilitiesManagement::ServicesAndQuestions.get_codes_by_context(:service_hours).map do |code|
+        [code, %i[service_hours detail_of_requirement]]
+      end.to_h
     end
   end
 end

--- a/app/views/facilities_management/procurements/spreadsheet_imports/_failed.html.erb
+++ b/app/views/facilities_management/procurements/spreadsheet_imports/_failed.html.erb
@@ -1,2 +1,57 @@
-Your upload has failed.
-<%= link_to t('.procurement_link'), facilities_management_procurement_path(@spreadsheet_import.procurement), class: 'govuk-link govuk-!-font-size-19 govuk-!-margin-top-4' %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters govuk-body-l">
+    <%= t('.description')%>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-body-l">
+    <h2 class="govuk-heading-m">
+      <%= t('.what_next')%>
+    </h2>
+    <p>
+      <%= t('.here_are_steps')%>
+    </p>
+    <ol class="govuk-list govuk-list--number">
+      <li><%= t('.step_1')%></li>
+      <li><%= t('.step_2')%></li>
+      <li><%= t('.step_3')%></li>
+    </ol>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-body-l">
+    <h2 class="govuk-heading-m">
+      <%= t('.list_of_issues')%>
+    </h2>
+    <p class="govuk-hint">
+      <%= t('.hint_text')%>
+    </p>
+  </div>
+</div>
+
+<% @error_lists.each do |attribute, error_list| %>
+  <% if error_list.any? %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full govuk-body-l">
+        <h3 class="govuk-heading-m">
+          <%= t(".title.#{attribute}") %>
+        </h3>
+        <%= govuk_details(pluralize(error_count(error_list, attribute), 'Issue'), false) do %>
+          <%= render(partial: "facilities_management/procurements/spreadsheet_imports/error_partials/#{attribute}", locals: { error_list: error_list }) %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @spreadsheet_import, url: facilities_management_procurement_spreadsheet_import_path, method: :delete, html: { specialvalidation: true, novalidate: true, multipart: true } do |f| %>
+      <%= f.submit t('.start_again'), class: 'govuk-button', 'aria-label': t('.start_again') %>
+      <br/>
+      <%= link_to t('.return_to_procurement_dashboard'), facilities_management_procurements_path, class: 'govuk-link--no-visited-state govuk-!-font-size-19', 'aria-label': t('.return_to_procurement_dashboard') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_building_errors.html.erb
+++ b/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_building_errors.html.erb
@@ -1,0 +1,19 @@
+<hr class="govuk-section-break govuk-section-break--visible">
+<table class="govuk-table ">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 25%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.building_number') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 75%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.error_description') %></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% error_list.each do |errors| %>
+      <% errors[:errors].each do |error|%>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= errors[:building_name] %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= error_message(:building_errors, errors[:attribute], error) %></td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_lift_errors.html.erb
+++ b/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_lift_errors.html.erb
@@ -1,0 +1,19 @@
+<hr class="govuk-section-break govuk-section-break--visible">
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 25%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.building_name') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 30%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.service_name') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 45%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.error_description') %></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% error_list.each do |error| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-padding-right-2"><%= error[:building_name] %></td>
+        <td class="govuk-table__cell govuk-!-padding-right-2"><%= error[:service_name] %></td>
+        <td class="govuk-table__cell govuk-!-padding-right-2"><%= error_message(:lift_errors, error[:attribute], :invalid) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_other_errors.html.erb
+++ b/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_other_errors.html.erb
@@ -1,0 +1,3 @@
+<div class="govuk-!-width-three-quarters">
+  <%= t('.other_description')%>
+</div>

--- a/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_service_hour_errors.html.erb
+++ b/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_service_hour_errors.html.erb
@@ -1,0 +1,19 @@
+<hr class="govuk-section-break govuk-section-break--visible">
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 25%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.building_name') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 30%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.service_name') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 45%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.error_description') %></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% error_list.each do |error| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-padding-right-2"><%= error[:building_name] %></td>
+        <td class="govuk-table__cell govuk-!-padding-right-2"><%= error[:service_name] %></td>
+        <td class="govuk-table__cell govuk-!-padding-right-2"><%= error_message(:service_hour_errors, error[:attribute], error[:errors].first) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_service_matrix_errors.html.erb
+++ b/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_service_matrix_errors.html.erb
@@ -1,0 +1,19 @@
+<hr class="govuk-section-break govuk-section-break--visible">
+<table class="govuk-table ">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 25%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.building_name') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 75%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.error_description') %></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% error_list.each do |errors| %>
+      <% errors[:errors].each do |error|%>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= errors[:building_name] %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= error_message(:service_matrix_errors, errors[:attribute], error) %></td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_service_volume_errors.html.erb
+++ b/app/views/facilities_management/procurements/spreadsheet_imports/error_partials/_service_volume_errors.html.erb
@@ -1,0 +1,19 @@
+<hr class="govuk-section-break govuk-section-break--visible">
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 25%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.building_name') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 30%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.service_name') %></th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 45%"><%= t('facilities_management.procurements.spreadsheet_imports.failed.error_description') %></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% error_list.each do |error| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-padding-right-2"><%= error[:building_name] %></td>
+        <td class="govuk-table__cell govuk-!-padding-right-2"><%= error[:service_name] %></td>
+        <td class="govuk-table__cell govuk-!-padding-right-2"><%= error_message(:service_volume_errors, error[:attribute], :invalid) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/workers/facilities_management/upload_spreadsheet_worker.rb
+++ b/app/workers/facilities_management/upload_spreadsheet_worker.rb
@@ -6,6 +6,8 @@ module FacilitiesManagement
     def perform(id)
       spreadsheet_import = SpreadsheetImport.find(id)
       FacilitiesManagement::SpreadsheetImporter.new(spreadsheet_import).import_data
+    rescue ActiveRecord::RecordNotFound => e
+      logger.error e.message
     end
   end
 end

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -46,7 +46,7 @@ en:
               blank: Town or city name for this building must be 30 characters or less
             building_name:
               blank: Enter a name for your building
-              too_long: Building name must be 25 characters or less
+              too_long: Building name must be 50 characters or less
             building_type:
               blank: You must select a buiding type or describe your own
             description:
@@ -1548,8 +1548,114 @@ en:
         services_and_buildings_template: Services and buildings template
         uploading: Uploading your spreadsheet
       spreadsheet_imports:
+        error_partials:
+          other_errors:
+            other_description: Your spreadsheet is incomplete and not ready for upload. Please refer to the instructions tab within your services and buildings template for further assistance.
+        errors:
+          building_errors:
+            address_line_1:
+              blank: The building address line 1 cannot be blank
+              too_long: The building address line 1 cannot be more than 100 characters
+            address_line_2:
+              too_long: The building address line 2 cannot be more than 100 characters
+            address_postcode:
+              blank: The building postcode is not valid. Enter a valid postcode, like AA1 1AA
+              invalid: The building postcode is not valid. Enter a valid postcode, like AA1 1AA
+              too_short: The building postcode is not valid. Enter a valid postcode, like AA1 1AA
+            address_town:
+              blank: The building town/city cannot be blank
+              too_long: The building town/city cannot be more than 30 characters
+            building_name:
+              taken: The building name cannot be duplicated
+              too_long: The building name cannot be more than 50 characters
+            building_type:
+              blank: The building type must be from the selection
+              inclusion: The building type must be from the selection
+            description:
+              too_long: The building description cannot be more than 50 characters
+            external_area:
+              blank: The building external area must be a number between 1 and 999,999,999
+              combined_area: The building external area must be greater than 0, if the gross internal area is 0
+              not_an_integer: The building external area must be a number between 1 and 999,999,999
+              required: The building external area must be a number between 1 and 999,999,999
+              too_long: The building external area must be a number between 1 and 999,999,999
+            gia:
+              blank: The building gross internal area must be a number between 1 and 999,999,999
+              combined_area: The building town/city cannot be blank
+              not_an_integer: The building gross internal area must be a number between 1 and 999,999,999
+              required: The building gross internal area must be a number between 1 and 999,999,999
+              too_long: The building gross internal area must be a number between 1 and 999,999,999
+            other_building_type:
+              blank: The building type-other cannot be blank
+              too_long: The building type-other cannot be more than 150 characters
+            other_security_type:
+              blank: The building security clearance-other cannot be blank
+              too_long: The building security clearance-other cannot be more than 150 characters
+            security_type:
+              blank: The building security clearance must be from the selection
+              inclusion: The building security clearance must be from the selection
+          lift_errors:
+            lifts:
+              invalid: The number of lifts must be a number between 1 and 40
+            number_of_floors:
+              invalid: The number of floors must be a number between 1 and 999
+          service_hour_errors:
+            detail_of_requirement:
+              blank: The detail of requirement cannot be blank
+              too_long: The detail of requirement cannot be more than 500 characters
+            service_hours:
+              greater_than_or_equal_to: The number of hours required must be a number between 1 and 999,999,999
+              less_than_or_equal_to: The number of hours required must be a number between 1 and 999,999,999
+              not_a_number: The number of hours required must be a number between 1 and 999,999,999
+              not_an_integer: The number of hours required must be a number between 1 and 999,999,999
+          service_matrix_errors:
+            building:
+              external_area_too_small: The building has service(s) that require an external area greater than 0 sqm
+              gia_too_small: The building has service(s) that require a gross internal area greater than 0 sqm
+            service_codes:
+              invalid: The building does not have any services selected
+              invalid_billable: CAFM system, Helpdesk and/or Management of billable works cannot be the only selected services within a building
+              invalid_cafm: CAFM system, Helpdesk and/or Management of billable works cannot be the only selected services within a building
+              invalid_cafm_billable: CAFM system, Helpdesk and/or Management of billable works cannot be the only selected services within a building
+              invalid_cafm_helpdesk: CAFM system, Helpdesk and/or Management of billable works cannot be the only selected services within a building
+              invalid_cafm_helpdesk_billable: CAFM system, Helpdesk and/or Management of billable works cannot be the only selected services within a building
+              invalid_cleaning: "'Mobile cleaning’ and ‘Routine cleaning’ are the same, but differ by delivery method. Please choose one of these services only"
+              invalid_helpdesk: CAFM system, Helpdesk and/or Management of billable works cannot be the only selected services within a building
+              invalid_helpdesk_billable: CAFM system, Helpdesk and/or Management of billable works cannot be the only selected services within a building
+              multiple_standards_for_one_service: The building has multiple service standards selected. Please choose one of these service standards only
+          service_volume_errors:
+            no_of_appliances_for_testing:
+              invalid: The volume must be a number between 1 and 999,999,999
+            no_of_building_occupants:
+              invalid: The building has service(s) that requires the input of the number of building occupants
+            no_of_consoles_to_be_serviced:
+              invalid: The volume must be a number between 1 and 999,999,999
+            no_of_units_to_be_serviced:
+              invalid: The volume must be a number between 1 and 999,999,999
+            tones_to_be_collected_and_removed:
+              invalid: The volume must be a number between 1 and 999,999,999
         failed:
-          procurement_link: Go to procurement
+          building_name: Building name
+          building_number: Building number
+          description: Your service and building information failed to  upload and we have provided a list of  issues to help you to fix these.
+          error_description: Error description
+          here_are_steps: Here are the steps you need to take next.
+          hint_text: The information below is sorted in order of the ‘Services and buildings template’ tabs. If one of the tabs is missing, it means that there are no issues on that tab.
+          list_of_issues: List of issues
+          return_to_procurement_dashboard: Return to procurements dashboard
+          service_name: Service name
+          start_again: Start your upload again
+          step_1: Review all issues listed below
+          step_2: Fix and edit your services and buildings template
+          step_3: Re-upload your file, by clicking on the ‘Start your upload again’ button at the bottom of this page
+          title:
+            building_errors: Building information
+            lift_errors: Service volumes 2
+            other_errors: Other
+            service_hour_errors: Service volumes 3
+            service_matrix_errors: Service matrix
+            service_volume_errors: Service volumes 1
+          what_next: What to do next
         importing:
           dashboard_link: Return to procurements dashboard
           processing: We are processing your file upload.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,7 +135,7 @@ Rails.application.routes.draw do
         get '/documents/call-off-schedule-2', to: 'procurements/contracts/documents#call_off_schedule_2'
       end
       resources :copy_procurement, only: %i[new create], controller: 'procurements/copy_procurement'
-      resources :spreadsheet_imports, only: %i[new create show], controller: 'procurements/spreadsheet_imports'
+      resources :spreadsheet_imports, only: %i[new create show destroy], controller: 'procurements/spreadsheet_imports'
       resources 'edit-buildings', only: %i[show edit update new create], as: 'edit_buildings', controller: 'procurements/edit_buildings' do
         member do
           match 'add_address', via: %i[get post patch]

--- a/db/migrate/20200914124411_add_errors_on_spreadsheet_import.rb
+++ b/db/migrate/20200914124411_add_errors_on_spreadsheet_import.rb
@@ -1,0 +1,5 @@
+class AddErrorsOnSpreadsheetImport < ActiveRecord::Migration[5.2]
+  def change
+    add_column :facilities_management_spreadsheet_imports, :import_errors, :json, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_08_144817) do
+ActiveRecord::Schema.define(version: 2020_09_14_124411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -260,6 +260,7 @@ ActiveRecord::Schema.define(version: 2020_09_08_144817) do
     t.string "spreadsheet_file", limit: 255
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "import_errors", default: {}
     t.index ["facilities_management_procurement_id"], name: "index_fm_procurements_on_fm_spreadsheet_imports_id"
   end
 

--- a/spec/models/facilities_management/building_spec.rb
+++ b/spec/models/facilities_management/building_spec.rb
@@ -142,13 +142,13 @@ RSpec.describe FacilitiesManagement::Building, type: :model do
 
       it 'will have the correct error message' do
         building.valid?(:all)
-        expect(building.errors[:building_name].first).to eq 'Building name must be 25 characters or less'
+        expect(building.errors[:building_name].first).to eq 'Building name must be 50 characters or less'
       end
     end
 
     context 'when the building name is within range' do
       before do
-        building.description = 'a' * 25
+        building.description = 'a' * 50
       end
 
       it 'is valid' do

--- a/spec/models/facilities_management/procurement_building_spec.rb
+++ b/spec/models/facilities_management/procurement_building_spec.rb
@@ -307,18 +307,16 @@ RSpec.describe FacilitiesManagement::ProcurementBuilding, type: :model do
         end
       end
     end
-  end
 
-  describe 'validation on procurement_building_services_present' do
     context 'when there are no services selected' do
       it 'is not valid' do
-        expect(procurement_building.valid?(:procurement_building_services_present)).to be false
+        expect(procurement_building.valid?(:buildings_and_services)).to be false
       end
 
       it 'returns the correct error message' do
-        procurement_building.valid?(:procurement_building_services_present)
+        procurement_building.valid?(:buildings_and_services)
 
-        expect(procurement_building.errors[:service_codes].first).to eq "You must select at least one service for ‘#{procurement_building.building_name}’ building"
+        expect(procurement_building.errors[:service_codes].first).to eq 'You must select at least one service for this building'
       end
     end
 
@@ -326,7 +324,7 @@ RSpec.describe FacilitiesManagement::ProcurementBuilding, type: :model do
       it 'is valid' do
         procurement_building.service_codes << 'C.1'
 
-        expect(procurement_building.valid?(:procurement_building_services_present)).to be true
+        expect(procurement_building.valid?(:buildings_and_services)).to be true
       end
     end
   end


### PR DESCRIPTION
> - Think about how to collect errors
> - Update methods which collect errors
> - Add new column for import errors
> - Add methods to process the building errors
> - Add methods to process the procurement_building errors
> - Add methods to process the volume errors
> - Add methods to process the lift errors
> - Add methods to process the service hour errors
> - Add the page copy and put in translation file
> - Add the initial layout for the error tables
> - Add partials and layout ready for errors
> - Change from using an array to a hash
> - Add the error table for buildings
> - Add error constructions for the service matrix
> - Add error constructions for the first service volume
> - Add error constructions for the service hours
> - Move all text to translation file
> - Update tests for the spreadsheet importer
> - Fix tests that were failing due to error collection
> - Add routing for the failed upload
> - Add error messages that were missing
> - Add some error handling to prevent unnecessary retries
> - Think about catching errors during upload
> - Add tests for spreadsheet_not_present?