### PR TITLE
FMFR-399 - automatically log out user when session expires

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,10 @@ gem 'json-jwt', '>= 1.11.0'
 
 # for authentication
 gem 'devise', '~> 4.7.1'
+
+# for timing out when session expires
+gem 'auto-session-timeout', '~> 0.9.6'
+
 # for cognito
 gem 'aws-sdk-cognitoidentityprovider', '~> 1.23.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     arel (9.0.0)
     ast (2.4.1)
     attr_required (1.0.1)
+    auto-session-timeout (0.9.6)
     aws-eventstream (1.1.0)
     aws-partitions (1.318.0)
     aws-sdk-cognitoidentityprovider (1.23.0)
@@ -533,6 +534,7 @@ DEPENDENCIES
   activerecord-import (~> 0.15.0)
   activerecord-postgis-adapter (>= 5.2.2)
   amoeba (>= 3.1.0)
+  auto-session-timeout (~> 0.9.6)
   aws-sdk-cognitoidentityprovider (~> 1.23.0)
   aws-sdk-s3 (~> 1)
   axlsx!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery with: :exception
   before_action :authenticate_user!
+  auto_session_timeout Devise.timeout_in
 
   rescue_from CanCan::AccessDenied do
     redirect_to not_permitted_path(service: request.path_parameters[:controller].split('/').first)

--- a/app/controllers/base/sessions_controller.rb
+++ b/app/controllers/base/sessions_controller.rb
@@ -1,8 +1,8 @@
 module Base
   class SessionsController < Devise::SessionsController
     skip_forgery_protection
-    before_action :authenticate_user!, except: %i[new create destroy]
-    before_action :authorize_user, except: %i[new create destroy]
+    before_action :authenticate_user!, except: %i[new create destroy active timeout]
+    before_action :authorize_user, except: %i[new create destroy active timeout]
 
     def new
       @result = Cognito::SignInUser.new(nil, nil, nil)
@@ -32,6 +32,20 @@ module Base
       super
     end
 
+    def active
+      render_session_status
+    end
+
+    def timeout
+      session[:return_to] = params[:url]
+
+      begin
+        redirect_to session_expired_sign_in_path
+      rescue ActionController::RoutingError
+        redirect_to facilities_management_new_user_session_path(expired: true)
+      end
+    end
+
     protected
 
     def after_sign_in_path_for(resource)
@@ -40,6 +54,14 @@ module Base
 
     def after_sign_out_path_for(_resource)
       gateway_url
+    end
+
+    def session_expired_sign_in_path
+      split_url = params[:url].split('/')
+      service = split_url[1]
+      service_type ||= split_url[2] if split_url[2] == 'supplier' || split_url[2] == 'admin'
+
+      '/' + [service, service_type, 'sign-in'].compact.join('/') + '?expired=true'
     end
 
     def authorize_user

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,10 @@
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
+    <% if current_user %>
+      <%= auto_session_timeout_js %>
+    <% end %>
+
     <div id="wrapper">
       <a href="#main-content" class="govuk-skip-link"><%= t('.skip') %></a>
       <header id="main-header" class="govuk-header" role="banner" data-module="header">

--- a/app/views/shared/sessions/_new.html.erb
+++ b/app/views/shared/sessions/_new.html.erb
@@ -1,3 +1,4 @@
+<%= warning_text(t('.session_expired')) if params[:expired] == 'true' %>
 <% unless local_header_text.nil? %>
   <%= content_for :page_title, local_header_text %>
   <h1 class="govuk-heading-xl">
@@ -10,6 +11,7 @@
     <%= render partial: 'shared/error_summary', locals: { errors: @result.errors } %>
 
     <%= form_for resource, as: resource_name, url: local_new_user_session_path, method: :post, html: { specialvalidation: true, novalidate: true, class: 'ccs-form', id: 'cop_sign_in_form'} do |f| %>
+      <input type="hidden" name="expired" value="<%= params[:expired]%>"/>
       <div class="govuk-form-group govuk-!-margin-bottom-4 <%= 'govuk-form-group--error' if @result.errors[:email].any? %>">
         <label class="govuk-label govuk-label--m govuk-!-margin-bottom-0" for="email">
           <%=  t('.email_address')%>

--- a/config/initializers/ext.rb
+++ b/config/initializers/ext.rb
@@ -1,1 +1,2 @@
 require((Dir.glob(Rails.root) + ['/lib/ext/ruby/gov_uk_date_fields/form_fields/generate_input_fields.rb']).join)
+require((Dir.glob(Rails.root) + ['/lib/ext/ruby/auto_session_timeout_helper.rb']).join)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1033,6 +1033,7 @@ en:
         enter_your_password: Enter your password
         please_enter_a_valid_email_address: You must provide your email address in the correct format, like name@example.com
         problems_signing_in: Problems signing in
+        session_expired: Sorry, your session has timed out due to 30 minutes of inactivity. To continue using this service, you need to sign in again.
     tags:
       cannot_start: cannot start yet
       completed: completed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,9 @@ Rails.application.routes.draw do
         concerns :authenticatable
       end
     end
+
+    get 'active'  => 'base/sessions#active'
+    get 'timeout' => 'base/sessions#timeout'
   end
 
   namespace 'supply_teachers', path: 'supply-teachers' do

--- a/lib/ext/ruby/auto_session_timeout_helper.rb
+++ b/lib/ext/ruby/auto_session_timeout_helper.rb
@@ -1,0 +1,30 @@
+module AutoSessionTimeoutHelper
+  def auto_session_timeout_js(options = {})
+    frequency = options[:frequency] || 60
+    attributes = options[:attributes] || {}
+    code = <<~JS
+      function PeriodicalQuery() {
+        var request = new XMLHttpRequest();
+        request.onload = function (event) {
+          var status = event.target.status;
+          var response = event.target.response;
+          if (status === 200 && (response === false || response === 'false' || response === null)) {
+            window.location.href = timout_url;
+          }
+          };
+          request.open('GET', '#{active_path}', true);
+          request.responseType = 'json';
+          request.send();
+          setTimeout(PeriodicalQuery, (#{frequency} * 1000));
+        }
+
+      var current_url = encodeURIComponent(window.location.pathname +  window.location.search)
+      var timout_url = '#{timeout_path}' + '?url=' + current_url;
+
+      setTimeout(PeriodicalQuery, (#{frequency} * 1000));
+    JS
+    javascript_tag(code, attributes)
+  end
+end
+
+ActionView::Base.send :include, AutoSessionTimeoutHelper

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,7 @@ end
 RSpec.configure do |config|
   config.include Warden::Test::Helpers
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
   config.extend ControllerMacros, type: :controller
   config.include SpreadsheetImportHelper, type: :service
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'layouts/application.html.erb' do
+RSpec.describe 'layouts/application.html.erb', type: :view do
   before do
     view.extend(ApplicationHelper)
     allow(view).to receive(:user_signed_in?).and_return(false)


### PR DESCRIPTION
> - Add gem to check for session timeout
> - Refreshes page of user has timed out
> - Add copy for the page when session expires
> - Make it redirect to correct sign in url
> - Adjust the code to work better
> - Small fix for tests

For the issue of auto logging out, googling lead me to the 'auto-session-timeout' gem which does almost everything we need. The only issue was for when it times out we want it to return the user to the correct log in and tell them that the session has expired and when they log in again they should be redirected to where they were. To do this I added a monkey patch which sends the current url as param to the timeout request. The controller can then extract the relevant information it needs from the request to redirect the user to the correct page.