### PR TITLE
FMFR-437 Reduce time taken to check for unpriced services for procurement

### DIFF
--- a/app/services/facilities_management/assessed_value_calculator.rb
+++ b/app/services/facilities_management/assessed_value_calculator.rb
@@ -14,7 +14,7 @@ class FacilitiesManagement::AssessedValueCalculator
   def sorted_list
     suppliers = @report.selected_suppliers(@report.current_lot).map { |s| { supplier_name: s['data']['supplier_name'], supplier_id: s['data']['supplier_id'] } }
 
-    if @lot_number == '1a'
+    if @lot_number == '1a' && @procurement.eligible_for_da?
       suppliers.each do |supplier|
         @report.calculate_services_for_buildings supplier[:supplier_name]
         supplier.merge!(da_value: @report.direct_award_value)


### PR DESCRIPTION
The contract value page was timing out because the method for checking which services were unpriced was checking every procurement building service. For 1000 buildings with all services selected, this meant checking 112 000 services, just to get 33 service names. By plucking out the codes, service standards and names first, and then condensing them down to the unique ones, we get down to 112 services to check. This method then creates new ProcurementBuildingService objects in memory so we can use the methods on them to check which are unpriced. The objects do not get saved, so they don't need to be valid.