### PR TITLE
FMFR-726 - Fix issue with failing deployments

### DIFF
--- a/pipeline_pre_build_tests.sh
+++ b/pipeline_pre_build_tests.sh
@@ -26,6 +26,7 @@ sudo -u postgres createuser --superuser root; sudo -u postgres createdb root
 #    service postgresql start 11
 #    sudo -u postgres createuser --superuser root; sudo -u postgres createdb root
 
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 curl -sL https://deb.nodesource.com/setup_8.x | bash -
 apt-get install -y nodejs
 alias node=nodejs


### PR DESCRIPTION
- Add key in script so Nodejs can install

One of the dependancies used in the instillation for nodejs had an update on Friday 19th March which caused the issue. I added this line to the script as it added the missing key which was stopping the instillation. I've tested this in sandbox and it deploys successfully.