### PR TITLE
FMFR-872 - Update the survey links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,13 +17,7 @@ module ApplicationHelper
   end
 
   def feedback_email_link
-    return link_to(t('common.feedback'), Marketplace.supply_teachers_survey_link, target: '_blank', rel: 'noopener', class: 'govuk-link') if controller.class.try(:module_parent_name) == 'SupplyTeachers'
-
-    return link_to(t('common.feedback'), 'https://www.smartsurvey.co.uk/s/BGBL4/', target: '_blank', rel: 'noopener', class: 'govuk-link') if controller.class.try(:module_parent_name) == 'LegalServices'
-
-    return link_to(t('common.feedback'), 'https://www.smartsurvey.co.uk/s/MIIJB/', target: '_blank', rel: 'noopener', class: 'govuk-link') if controller.class.try(:module_parent_name) == 'ManagementConsultancy'
-
-    link_to(t('common.feedback'), 'https://www.smartsurvey.co.uk/s/J1VQQI/', target: '_blank', rel: 'noopener', class: 'govuk-link')
+    link_to(t('common.feedback'), Marketplace.fm_survey_link, target: '_blank', rel: 'noopener', class: 'govuk-link')
   end
 
   def support_email_link(label)

--- a/config/application.rb
+++ b/config/application.rb
@@ -77,8 +77,8 @@ module Marketplace
     'info@crowncommercial.gov.uk'
   end
 
-  def self.supply_teachers_survey_link
-    'https://www.smartsurvey.co.uk/s/S4MVR/'
+  def self.fm_survey_link
+    ENV['FM_SURVEY_LINK']
   end
 
   def self.support_telephone_number

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'layouts/application.html.erb', type: :view do
+  let(:support_link_feedback_address) { 'https://www.smartsurvey.co.uk/s/J1VQQI/' }
+
   before do
     view.extend(ApplicationHelper)
     allow(view).to receive(:user_signed_in?).and_return(false)
@@ -13,6 +15,7 @@ RSpec.describe 'layouts/application.html.erb', type: :view do
     cookies[:crown_marketplace_google_analytics_enabled] = 'true'
     allow(cookies.class).to receive(:new).and_return(cookies)
     allow(Marketplace).to receive(:google_analytics_tracking_id).and_return('123')
+    allow(Marketplace).to receive(:fm_survey_link).and_return(support_link_feedback_address)
   end
 
   describe 'feedback links' do
@@ -33,14 +36,11 @@ RSpec.describe 'layouts/application.html.erb', type: :view do
         .and_return(feedback_email_address)
       allow(Marketplace).to receive(:support_email_address)
         .and_return(support_email_address)
-      allow(Marketplace).to receive(:support_link_feedback_address)
-        .and_return(support_email_address)
     end
 
     context 'when feedback email address is present' do
       let(:feedback_email_address) { 'feedback@something.com' }
       let(:support_email_address) { 'support@something.com' }
-      let(:support_link_feedback_address) { 'https://www.smartsurvey.co.uk/s/J1VQQI/' }
 
       it 'displays link to feedback email address in beta banner' do
         render


### PR DESCRIPTION
- Show the survey link

The following environment variable needs to be created:
`/Environment/ccs/cmp/FM_SURVEY_LINK=https://crowncommercial.qualtrics.com/jfe/form/SV_50aDjt8zNRa47Cm`
