### PR TITLE
FMFR-990 - Fix issue with migrations

### DIFF
--- a/db/migrate/20210715113720_drop_facilities_management_regions.rb
+++ b/db/migrate/20210715113720_drop_facilities_management_regions.rb
@@ -1,0 +1,7 @@
+class DropFacilitiesManagementRegions < ActiveRecord::Migration[6.0]
+  def up
+    drop_table :facilities_management_regions if ActiveRecord::Base.connection.table_exists? 'facilities_management_regions'
+  end
+
+  def down; end
+end


### PR DESCRIPTION
This fixes an issue with deployments. Some tables in the production environments have the table `:facilities_management_regions`. This table is not present in the dev environment so we need to add an extra migration which will delete the table if it is present.