### PR TITLE
FMFR-1129 - Remove email from URL

### DIFF
--- a/app/controllers/base/registrations_controller.rb
+++ b/app/controllers/base/registrations_controller.rb
@@ -56,5 +56,11 @@ module Base
         render :new, erorr: result.error
       end
     end
+
+    def after_sign_up_path_for(resource)
+      cookies[:confirmation_email] = { value: resource.email, expires: 20.minutes, httponly: true }
+
+      service_after_sign_up_path
+    end
   end
 end

--- a/app/controllers/base/sessions_controller.rb
+++ b/app/controllers/base/sessions_controller.rb
@@ -91,5 +91,11 @@ module Base
         render :new
       end
     end
+
+    def challenge_path
+      cookies[:session] = { value: @result.session, expires: 20.minutes, httponly: true }
+
+      service_challenge_path
+    end
   end
 end

--- a/app/controllers/base/users_controller.rb
+++ b/app/controllers/base/users_controller.rb
@@ -11,6 +11,8 @@ module Base
     def confirm
       @result = Cognito::ConfirmSignUp.call(params[:email], params[:confirmation_code])
       if @result.success?
+        cookies.delete :confirmation_email
+
         sign_in_user(@result.user)
       else
         render :confirm_new
@@ -41,7 +43,8 @@ module Base
 
     def new_challenge_path
       cookies[:session] = @challenge.new_session
-      users_challenge_path(challenge_name: @challenge.new_challenge_name, username: params[:username])
+
+      new_service_challenge_path
     end
 
     def find_and_sign_in_user

--- a/app/controllers/crown_marketplace/sessions_controller.rb
+++ b/app/controllers/crown_marketplace/sessions_controller.rb
@@ -1,8 +1,7 @@
 class CrownMarketplace::SessionsController < Base::SessionsController
   protected
 
-  def challenge_path
-    cookies[:session] = { value: @result.session, expires: 20.minutes, httponly: true }
+  def service_challenge_path
     crown_marketplace_users_challenge_path(challenge_name: @result.challenge_name, username: @result.cognito_uuid)
   end
 

--- a/app/controllers/crown_marketplace/users_controller.rb
+++ b/app/controllers/crown_marketplace/users_controller.rb
@@ -1,8 +1,7 @@
 class CrownMarketplace::UsersController < Base::UsersController
   private
 
-  def new_challenge_path
-    cookies[:session] = @challenge.new_session
+  def new_service_challenge_path
     crown_marketplace_users_challenge_path(challenge_name: @challenge.new_challenge_name, username: params[:username])
   end
 

--- a/app/controllers/facilities_management/rm3830/admin/sessions_controller.rb
+++ b/app/controllers/facilities_management/rm3830/admin/sessions_controller.rb
@@ -4,8 +4,7 @@ module FacilitiesManagement
       class SessionsController < Base::SessionsController
         protected
 
-        def challenge_path
-          cookies[:session] = { value: @result.session, expires: 20.minutes, httponly: true }
+        def service_challenge_path
           facilities_management_rm3830_admin_users_challenge_path(challenge_name: @result.challenge_name, username: @result.cognito_uuid)
         end
 

--- a/app/controllers/facilities_management/rm3830/admin/users_controller.rb
+++ b/app/controllers/facilities_management/rm3830/admin/users_controller.rb
@@ -4,8 +4,7 @@ module FacilitiesManagement
       class UsersController < Base::UsersController
         private
 
-        def new_challenge_path
-          cookies[:session] = @challenge.new_session
+        def new_service_challenge_path
           facilities_management_rm3830_admin_users_challenge_path(challenge_name: @challenge.new_challenge_name, username: params[:username])
         end
 

--- a/app/controllers/facilities_management/rm3830/registrations_controller.rb
+++ b/app/controllers/facilities_management/rm3830/registrations_controller.rb
@@ -7,8 +7,8 @@ module FacilitiesManagement
         :fm_access
       end
 
-      def after_sign_up_path_for(resource)
-        facilities_management_rm3830_users_confirm_path(email: resource.email)
+      def service_after_sign_up_path
+        facilities_management_rm3830_users_confirm_path
       end
 
       def domain_not_on_safelist_path

--- a/app/controllers/facilities_management/rm3830/sessions_controller.rb
+++ b/app/controllers/facilities_management/rm3830/sessions_controller.rb
@@ -3,8 +3,7 @@ module FacilitiesManagement
     class SessionsController < FacilitiesManagement::SessionsController
       protected
 
-      def challenge_path
-        cookies[:session] = { value: @result.session, expires: 20.minutes, httponly: true }
+      def service_challenge_path
         facilities_management_rm3830_users_challenge_path(challenge_name: @result.challenge_name, username: @result.cognito_uuid)
       end
 

--- a/app/controllers/facilities_management/rm3830/supplier/sessions_controller.rb
+++ b/app/controllers/facilities_management/rm3830/supplier/sessions_controller.rb
@@ -1,8 +1,7 @@
 class FacilitiesManagement::RM3830::Supplier::SessionsController < Base::SessionsController
   protected
 
-  def challenge_path
-    cookies[:session] = { value: @result.session, expires: 20.minutes, httponly: true }
+  def service_challenge_path
     facilities_management_rm3830_supplier_users_challenge_path(challenge_name: @result.challenge_name, username: @result.cognito_uuid)
   end
 

--- a/app/controllers/facilities_management/rm3830/supplier/users_controller.rb
+++ b/app/controllers/facilities_management/rm3830/supplier/users_controller.rb
@@ -1,8 +1,7 @@
 class FacilitiesManagement::RM3830::Supplier::UsersController < Base::UsersController
   private
 
-  def new_challenge_path
-    cookies[:session] = @challenge.new_session
+  def new_service_challenge_path
     facilities_management_rm3830_supplier_users_challenge_path(challenge_name: @challenge.new_challenge_name, username: params[:username])
   end
 

--- a/app/controllers/facilities_management/rm3830/users_controller.rb
+++ b/app/controllers/facilities_management/rm3830/users_controller.rb
@@ -3,8 +3,7 @@ module FacilitiesManagement
     class UsersController < Base::UsersController
       private
 
-      def new_challenge_path
-        cookies[:session] = @challenge.new_session
+      def new_service_challenge_path
         facilities_management_rm3830_users_challenge_path(challenge_name: @challenge.new_challenge_name, username: params[:username])
       end
 

--- a/app/views/home/cookie_policy.html.erb
+++ b/app/views/home/cookie_policy.html.erb
@@ -147,6 +147,11 @@
           <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_2.purpose') %></td>
           <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_2.expires') %></td>
         </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_3.name') %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_3.purpose') %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_3.expires') %></td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/app/views/shared/users/_confirm_new.html.erb
+++ b/app/views/shared/users/_confirm_new.html.erb
@@ -9,7 +9,7 @@
     </h1>
 
     <p class="govuk-body-l">
-      <%= t('.lead_start') %> <span class="ccs-email-example"><%= params[:email] %></span> <%= t('.lead_end') %>
+      <%= t('.lead_start') %> <span class="ccs-email-example"><%= cookies[:confirmation_email] %></span> <%= t('.lead_end') %>
     </p>
 
     <%= form_tag confirm_path, class: 'ccs-form', id: 'cop_confirmation_code', specialvalidation: true, novalidate: true, method: :post do %>
@@ -23,8 +23,8 @@
         <%= text_field_tag :confirmation_code, nil, class: "govuk-input govuk-!-width-one-third", id: 'confirmation', type: 'number' %>
       </div>
 
-      <% if params[:email] %>
-        <%= hidden_field_tag :email, params[:email] %>
+      <% if cookies[:confirmation_email] %>
+        <%= hidden_field_tag :email, cookies[:confirmation_email] %>
       <% else %>
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @result.errors[:email].any? %>">
           <label class="govuk-label" for="email">
@@ -40,7 +40,7 @@
 
     <% end %>
 
-    <% if params[:email] %>
+    <% if cookies[:confirmation_email] %>
       <p class="govuk-body govuk-!-margin-bottom-7">
         <%= t('.resend_the_confirmation_email_html', link: resend_path) %>
       </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,6 +441,10 @@ en:
         expires: 20 minutes
         name: session
         purpose: This cookie holds the session id when a user is challenged while logging in
+      reg_and_sign_in_cookie_3:
+        expires: 20 minutes
+        name: confirmation_email
+        purpose: This cookie holds the email of the user when activating their account
       reg_and_sign_in_cookies: These cookies are sometimes required to complete the regestration and sign in process.
       we_do_not_let: We do not allow Google to use or share the data about how you use this site.
       what_are_cookies: Crown Marketplace puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site. Find out more about the cookies we use, what they’re for and when they expire.


### PR DESCRIPTION
- Move shared logic into shared controller
- Hide email param from URL by putting it in the cookies
- Move shared logic into shared controller (again)

From an ITHC, we had already changed the email in one place to be stored in the browser cookies.
I have extended this to the email that is still shown too.

I will do tests in sandbox first before merging this branch.