### PR TITLE
BUG - FMFR-1136 Users can't resend confirmation email

### DIFF
--- a/app/assets/stylesheets/govuk-frontend.scss
+++ b/app/assets/stylesheets/govuk-frontend.scss
@@ -17,24 +17,25 @@
   }
 
 .button_as_link {
-  font-size       : 1em;
-  border          : 0;
-  text-decoration : underline;
-  margin         : 1ex 0;
-  color           : $govuk-link-colour;
+  font-size: 1em;
+  border: 0;
+  text-decoration: underline;
+  color: $govuk-link-colour;
   background-color: inherit;
+  padding: 0;
+  margin: 0;
 
   &:link {
-    color : $govuk-link-colour
+    color: $govuk-link-colour
   }
 
   &:visited {
-    color : $govuk-link-visited-colour
+    color: $govuk-link-visited-colour
   }
 
   &:hover:not(:focus),
   &:active:not(:focus) {
-    color : $govuk-link-hover-colour
+    color: $govuk-link-hover-colour
   }
 
   &:hover {

--- a/app/controllers/base/passwords_controller.rb
+++ b/app/controllers/base/passwords_controller.rb
@@ -1,7 +1,7 @@
 module Base
   class PasswordsController < ApplicationController
-    before_action :authenticate_user!, except: %i[new create confirm_new edit update password_reset_success]
-    before_action :authorize_user, except: %i[new create confirm_new edit update password_reset_success]
+    before_action :authenticate_user!, except: %i[new create edit update password_reset_success]
+    before_action :authorize_user, except: %i[new create edit update password_reset_success]
 
     def new
       @response = Cognito::ForgotPassword.new(params[:email])
@@ -10,7 +10,7 @@ module Base
     def create
       @response = Cognito::ForgotPassword.call(params[:email])
       if @response.success?
-        cookies[:reset_email] = { value: params[:email], expires: 20.minutes, httponly: true }
+        cookies[:crown_marketplace_reset_email] = { value: params[:email], expires: 20.minutes, httponly: true }
         redirect_to after_request_password_path
       else
         flash[:error] = @response.error
@@ -19,15 +19,15 @@ module Base
     end
 
     def edit
-      @response = Cognito::ConfirmPasswordReset.new(cookies[:reset_email], params[:password], params[:password_confirmation], params[:confirmation_code])
+      @response = Cognito::ConfirmPasswordReset.new(cookies[:crown_marketplace_reset_email], params[:password], params[:password_confirmation], params[:confirmation_code])
     end
 
     def update
-      email = params[:user_email_reset_by_CSC].blank? ? params[:user_email_reset_by_themself] : params[:user_email_reset_by_CSC]
+      @response = Cognito::ConfirmPasswordReset.call(params[:email], params[:password], params[:password_confirmation], params[:confirmation_code])
 
-      @response = Cognito::ConfirmPasswordReset.call(email, params[:password], params[:password_confirmation], params[:confirmation_code])
       if @response.success?
-        cookies.delete :reset_email
+        cookies.delete :crown_marketplace_reset_email
+
         redirect_to after_password_reset_path
       else
         render :edit, erorr: @response.error
@@ -35,7 +35,5 @@ module Base
     end
 
     def password_reset_success; end
-
-    def confirm_new; end
   end
 end

--- a/app/controllers/base/registrations_controller.rb
+++ b/app/controllers/base/registrations_controller.rb
@@ -58,7 +58,7 @@ module Base
     end
 
     def after_sign_up_path_for(resource)
-      cookies[:confirmation_email] = { value: resource.email, expires: 20.minutes, httponly: true }
+      cookies[:crown_marketplace_confirmation_email] = { value: resource.email, expires: 20.minutes, httponly: true }
 
       service_after_sign_up_path
     end

--- a/app/controllers/base/users_controller.rb
+++ b/app/controllers/base/users_controller.rb
@@ -1,7 +1,7 @@
 module Base
   class UsersController < ApplicationController
-    before_action :authenticate_user!, except: %i[confirm_new confirm challenge_new challenge resend_confirmation_email]
-    before_action :authorize_user, except: %i[confirm_new confirm challenge_new challenge resend_confirmation_email]
+    before_action :authenticate_user!, except: %i[confirm_new confirm resend_confirmation_email challenge_new challenge]
+    before_action :authorize_user, except: %i[confirm_new confirm resend_confirmation_email challenge_new challenge]
     before_action :set_user_phone, only: %i[challenge_new challenge]
 
     def confirm_new
@@ -11,12 +11,18 @@ module Base
     def confirm
       @result = Cognito::ConfirmSignUp.call(params[:email], params[:confirmation_code])
       if @result.success?
-        cookies.delete :confirmation_email
+        cookies.delete :crown_marketplace_confirmation_email
 
         sign_in_user(@result.user)
       else
         render :confirm_new
       end
+    end
+
+    def resend_confirmation_email
+      result = Cognito::ResendConfirmationCode.call(params[:email])
+
+      redirect_to confirm_user_registration_path, error: result.error
     end
 
     def challenge_new
@@ -33,22 +39,19 @@ module Base
       end
     end
 
-    def resend_confirmation_email
-      result = Cognito::ResendConfirmationCode.call(params[:email])
-
-      redirect_to confirm_user_registration_path, error: result.error
-    end
-
     private
 
     def new_challenge_path
-      cookies[:session] = @challenge.new_session
+      cookies[:crown_marketplace_challenge_session] = @challenge.new_session
+      cookies[:crown_marketplace_challenge_username] = @challenge.cognito_uuid
 
       new_service_challenge_path
     end
 
     def find_and_sign_in_user
-      cookies.delete :session
+      cookies.delete :crown_marketplace_challenge_session
+      cookies.delete :crown_marketplace_challenge_username
+
       user = Cognito::CreateUserFromCognito.call(params[:username]).user
       sign_in_user(user)
     end
@@ -59,8 +62,8 @@ module Base
     end
 
     def set_user_phone
-      user_phone_full = User.find_by(cognito_uuid: params[:username]).try(:phone_number) || Cognito::CreateUserFromCognito.call(params[:username]).try(:user).try(:phone_number)
-      @user_phone =   '*' * 9 + user_phone_full[(user_phone_full.length - 3)..user_phone_full.length] if user_phone_full
+      user_phone_full = User.find_by(cognito_uuid: cookies[:crown_marketplace_challenge_username]).try(:phone_number) || Cognito::CreateUserFromCognito.call(cookies[:crown_marketplace_challenge_username]).try(:user).try(:phone_number)
+      @user_phone = '*' * 9 + user_phone_full.last(3) if user_phone_full
     end
   end
 end

--- a/app/controllers/crown_marketplace/passwords_controller.rb
+++ b/app/controllers/crown_marketplace/passwords_controller.rb
@@ -5,10 +5,6 @@ class CrownMarketplace::PasswordsController < Base::PasswordsController
     crown_marketplace_new_user_password_path
   end
 
-  def edit_password_path
-    crown_marketplace_edit_user_password_path
-  end
-
   def after_password_reset_path
     crown_marketplace_password_reset_success_path
   end

--- a/app/controllers/crown_marketplace/sessions_controller.rb
+++ b/app/controllers/crown_marketplace/sessions_controller.rb
@@ -2,7 +2,7 @@ class CrownMarketplace::SessionsController < Base::SessionsController
   protected
 
   def service_challenge_path
-    crown_marketplace_users_challenge_path(challenge_name: @result.challenge_name, username: @result.cognito_uuid)
+    crown_marketplace_users_challenge_path(challenge_name: @result.challenge_name)
   end
 
   def after_sign_in_path_for(resource)
@@ -19,11 +19,11 @@ class CrownMarketplace::SessionsController < Base::SessionsController
     crown_marketplace_new_user_session_path
   end
 
-  def confirm_forgot_password_path(username)
-    crown_marketplace_edit_user_password_path(username: username)
+  def confirm_forgot_password_path
+    crown_marketplace_edit_user_password_path
   end
 
-  def confirm_email_path(email)
-    crown_marketplace_users_confirm_path(email: email)
+  def confirm_email_path
+    crown_marketplace_users_confirm_path
   end
 end

--- a/app/controllers/crown_marketplace/users_controller.rb
+++ b/app/controllers/crown_marketplace/users_controller.rb
@@ -2,7 +2,7 @@ class CrownMarketplace::UsersController < Base::UsersController
   private
 
   def new_service_challenge_path
-    crown_marketplace_users_challenge_path(challenge_name: @challenge.new_challenge_name, username: params[:username])
+    crown_marketplace_users_challenge_path(challenge_name: @challenge.new_challenge_name)
   end
 
   def after_sign_in_path_for(resource)
@@ -10,6 +10,6 @@ class CrownMarketplace::UsersController < Base::UsersController
   end
 
   def confirm_user_registration_path
-    crown_marketplace_users_confirm_path(email: params[:email])
+    crown_marketplace_users_confirm_path
   end
 end

--- a/app/controllers/facilities_management/rm3830/admin/passwords_controller.rb
+++ b/app/controllers/facilities_management/rm3830/admin/passwords_controller.rb
@@ -8,10 +8,6 @@ module FacilitiesManagement
           facilities_management_rm3830_admin_new_user_password_path
         end
 
-        def edit_password_path
-          facilities_management_rm3830_admin_edit_user_password_path
-        end
-
         def after_password_reset_path
           facilities_management_rm3830_admin_password_reset_success_path
         end

--- a/app/controllers/facilities_management/rm3830/admin/sessions_controller.rb
+++ b/app/controllers/facilities_management/rm3830/admin/sessions_controller.rb
@@ -5,7 +5,7 @@ module FacilitiesManagement
         protected
 
         def service_challenge_path
-          facilities_management_rm3830_admin_users_challenge_path(challenge_name: @result.challenge_name, username: @result.cognito_uuid)
+          facilities_management_rm3830_admin_users_challenge_path(challenge_name: @result.challenge_name)
         end
 
         # rubocop:disable Lint/UnusedMethodArgument
@@ -26,12 +26,12 @@ module FacilitiesManagement
           facilities_management_rm3830_admin_new_user_session_path
         end
 
-        def confirm_forgot_password_path(username)
-          facilities_management_rm3830_admin_edit_user_password_path(username: username)
+        def confirm_forgot_password_path
+          facilities_management_rm3830_admin_edit_user_password_path
         end
 
-        def confirm_email_path(email)
-          facilities_management_rm3830_admin_users_confirm_path(email: email)
+        def confirm_email_path
+          facilities_management_rm3830_admin_users_confirm_path
         end
       end
     end

--- a/app/controllers/facilities_management/rm3830/admin/users_controller.rb
+++ b/app/controllers/facilities_management/rm3830/admin/users_controller.rb
@@ -5,7 +5,7 @@ module FacilitiesManagement
         private
 
         def new_service_challenge_path
-          facilities_management_rm3830_admin_users_challenge_path(challenge_name: @challenge.new_challenge_name, username: params[:username])
+          facilities_management_rm3830_admin_users_challenge_path(challenge_name: @challenge.new_challenge_name)
         end
 
         def after_sign_in_path_for(resource)
@@ -13,7 +13,7 @@ module FacilitiesManagement
         end
 
         def confirm_user_registration_path
-          facilities_management_rm3830_admin_users_confirm_path(email: params[:email])
+          facilities_management_rm3830_admin_users_confirm_path
         end
       end
     end

--- a/app/controllers/facilities_management/rm3830/passwords_controller.rb
+++ b/app/controllers/facilities_management/rm3830/passwords_controller.rb
@@ -7,10 +7,6 @@ module FacilitiesManagement
         facilities_management_rm3830_new_user_password_path
       end
 
-      def edit_password_path
-        facilities_management_rm3830_edit_user_password_path
-      end
-
       def after_password_reset_path
         facilities_management_rm3830_password_reset_success_path
       end

--- a/app/controllers/facilities_management/rm3830/sessions_controller.rb
+++ b/app/controllers/facilities_management/rm3830/sessions_controller.rb
@@ -4,7 +4,7 @@ module FacilitiesManagement
       protected
 
       def service_challenge_path
-        facilities_management_rm3830_users_challenge_path(challenge_name: @result.challenge_name, username: @result.cognito_uuid)
+        facilities_management_rm3830_users_challenge_path(challenge_name: @result.challenge_name)
       end
 
       def after_sign_in_path_for(resource)
@@ -23,12 +23,12 @@ module FacilitiesManagement
         facilities_management_rm3830_new_user_session_path
       end
 
-      def confirm_forgot_password_path(username)
-        facilities_management_rm3830_edit_user_password_path(username: username)
+      def confirm_forgot_password_path
+        facilities_management_rm3830_edit_user_password_path
       end
 
-      def confirm_email_path(email)
-        facilities_management_rm3830_users_confirm_path(email: email)
+      def confirm_email_path
+        facilities_management_rm3830_users_confirm_path
       end
 
       def redirect_for_spreadsheet_upload(session_return_path)

--- a/app/controllers/facilities_management/rm3830/supplier/passwords_controller.rb
+++ b/app/controllers/facilities_management/rm3830/supplier/passwords_controller.rb
@@ -5,10 +5,6 @@ class FacilitiesManagement::RM3830::Supplier::PasswordsController < Base::Passwo
     facilities_management_rm3830_supplier_new_user_password_path
   end
 
-  def edit_password_path
-    facilities_management_rm3830_supplier_edit_user_password_path
-  end
-
   def after_password_reset_path
     facilities_management_rm3830_supplier_password_reset_success_path
   end

--- a/app/controllers/facilities_management/rm3830/supplier/sessions_controller.rb
+++ b/app/controllers/facilities_management/rm3830/supplier/sessions_controller.rb
@@ -2,7 +2,7 @@ class FacilitiesManagement::RM3830::Supplier::SessionsController < Base::Session
   protected
 
   def service_challenge_path
-    facilities_management_rm3830_supplier_users_challenge_path(challenge_name: @result.challenge_name, username: @result.cognito_uuid)
+    facilities_management_rm3830_supplier_users_challenge_path(challenge_name: @result.challenge_name)
   end
 
   def after_sign_in_path_for(resource)
@@ -19,11 +19,11 @@ class FacilitiesManagement::RM3830::Supplier::SessionsController < Base::Session
     facilities_management_rm3830_supplier_new_user_session_path
   end
 
-  def confirm_forgot_password_path(username)
-    facilities_management_rm3830_supplier_edit_user_password_path(username: username)
+  def confirm_forgot_password_path
+    facilities_management_rm3830_supplier_edit_user_password_path
   end
 
-  def confirm_email_path(email)
-    facilities_management_rm3830_supplier_users_confirm_path(email: email)
+  def confirm_email_path
+    facilities_management_rm3830_supplier_users_confirm_path
   end
 end

--- a/app/controllers/facilities_management/rm3830/supplier/users_controller.rb
+++ b/app/controllers/facilities_management/rm3830/supplier/users_controller.rb
@@ -2,7 +2,7 @@ class FacilitiesManagement::RM3830::Supplier::UsersController < Base::UsersContr
   private
 
   def new_service_challenge_path
-    facilities_management_rm3830_supplier_users_challenge_path(challenge_name: @challenge.new_challenge_name, username: params[:username])
+    facilities_management_rm3830_supplier_users_challenge_path(challenge_name: @challenge.new_challenge_name)
   end
 
   def after_sign_in_path_for(resource)
@@ -10,6 +10,6 @@ class FacilitiesManagement::RM3830::Supplier::UsersController < Base::UsersContr
   end
 
   def confirm_user_registration_path
-    facilities_management_rm3830_supplier_users_confirm_path(email: params[:email])
+    facilities_management_rm3830_supplier_users_confirm_path
   end
 end

--- a/app/controllers/facilities_management/rm3830/users_controller.rb
+++ b/app/controllers/facilities_management/rm3830/users_controller.rb
@@ -4,7 +4,7 @@ module FacilitiesManagement
       private
 
       def new_service_challenge_path
-        facilities_management_rm3830_users_challenge_path(challenge_name: @challenge.new_challenge_name, username: params[:username])
+        facilities_management_rm3830_users_challenge_path(challenge_name: @challenge.new_challenge_name)
       end
 
       def after_sign_in_path_for(resource)
@@ -12,7 +12,7 @@ module FacilitiesManagement
       end
 
       def confirm_user_registration_path
-        facilities_management_rm3830_users_confirm_path(email: params[:email])
+        facilities_management_rm3830_users_confirm_path
       end
     end
   end

--- a/app/views/facilities_management/buildings/_postcode_lookup_container.html.erb
+++ b/app/views/facilities_management/buildings/_postcode_lookup_container.html.erb
@@ -57,10 +57,10 @@
             </option>
           <% end %>
         </select>
+        <hr class="govuk-section-break govuk-!-margin-top-2">
         <% if f.object.id.nil? %>
           <%= f.submit(t('.cant_find_address'), tabindex: input_visible?(@find_address_helper.select_an_address_visible?), class: 'govuk-link govuk-!-margin-right-4 button_as_link', 'aria-label': t('.cant_find_address'), id: 'cant-find-address-link', name: 'add_address') %>
         <% else %>
-          <hr class="govuk-section-break govuk-!-margin-top-2">
           <%= link_to t('.cant_find_address'), cant_find_address_link, class: 'govuk-link govuk-!-margin-right-4', tabindex: input_visible?(@find_address_helper.select_an_address_visible?), id: 'cant-find-address-link' %>
         <% end %>
       </div>

--- a/app/views/facilities_management/rm3830/admin/users/_new_password_required.html.erb
+++ b/app/views/facilities_management/rm3830/admin/users/_new_password_required.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'shared/users/new_password_required', locals: { challenge_path: facilities_management_rm3830_admin_users_challenge_path } %>

--- a/app/views/facilities_management/rm3830/admin/users/_sms_mfa.html.erb
+++ b/app/views/facilities_management/rm3830/admin/users/_sms_mfa.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'shared/users/sms_mfa', locals: { challenge_path: facilities_management_rm3830_admin_users_challenge_path, resend_link: facilities_management_rm3830_admin_user_session_path } %>

--- a/app/views/facilities_management/rm3830/admin/users/challenge_new.html.erb
+++ b/app/views/facilities_management/rm3830/admin/users/challenge_new.html.erb
@@ -1,1 +1,1 @@
-<%= render "shared/users/#{@challenge.challenge_name.downcase}", challenge_path: facilities_management_rm3830_admin_users_challenge_path, resend_link: facilities_management_rm3830_admin_user_session_path %>
+<%= render @challenge.challenge_name.downcase %>

--- a/app/views/facilities_management/rm3830/procurements/_spreadsheet.html.erb
+++ b/app/views/facilities_management/rm3830/procurements/_spreadsheet.html.erb
@@ -37,6 +37,6 @@
   <%= form_for @procurement, url: facilities_management_rm3830_procurement_path(@procurement.id), method: :patch do |f| %>
       <%= f.submit t('.continue_link'), class: 'govuk-!-margin-right-4 govuk-button', name: :bulk_upload_spreadsheet, aria: { label: t('.continue_link') } %>
       <%= f.submit t('.save_and_return_link'), class: 'govuk-button govuk-button--secondary', name: :bulk_upload_spreadsheet, aria: { label: t('.save_and_return_link') } %><br/>
-      <%= f.submit t('.cancel_and_return_link'), class: 'govuk-link button_as_link', name: :change_requirements, aria: { label: t('.cancel_and_return_link') } %>
+      <span class="govuk-body"><%= f.submit t('.cancel_and_return_link'), class: 'govuk-link button_as_link', name: :change_requirements, aria: { label: t('.cancel_and_return_link') } %></span>
   <% end %>
 </div>

--- a/app/views/home/cookie_policy.html.erb
+++ b/app/views/home/cookie_policy.html.erb
@@ -62,21 +62,13 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.ga_cookies_1.name') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.ga_cookies_1.purpose') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.ga_cookies_1.expires') %></td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.ga_cookies_2.name') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.ga_cookies_2.purpose') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.ga_cookies_2.expires') %></td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.ga_cookies_3.name') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.ga_cookies_3.purpose') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.ga_cookies_3.expires') %></td>
-        </tr>
+        <% (1..3).each do |i| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".ga_cookies.row_#{i}.name") %></td>
+            <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".ga_cookies.row_#{i}.purpose") %></td>
+            <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".ga_cookies.row_#{i}.expires") %></td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   </div>
@@ -91,7 +83,7 @@
     </h2>
 
     <h3 class="govuk-heading-s">
-      <%= t('.cookies_message') %>
+      <%= t('.cookies_banner') %>
     </h3>
 
     <p>
@@ -107,16 +99,13 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-!-padding-right-2" style="word-break: break-all;"><%= t('.cookie_message_1.name') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.cookie_message_1.purpose') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.cookie_message_1.expires') %></td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-!-padding-right-2" style="word-break: break-all;"><%= t('.cookie_message_2.name') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.cookie_message_2.purpose') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.cookie_message_2.expires') %></td>
-        </tr>
+        <% (1..2).each do |i| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell govuk-!-padding-right-2" style="word-break: break-all;"><%= t(".cookie_banner_cookies.row_#{i}.name") %></td>
+            <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".cookie_banner_cookies.row_#{i}.purpose") %></td>
+            <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".cookie_banner_cookies.row_#{i}.expires") %></td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
 
@@ -137,21 +126,13 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_1.name') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_1.purpose') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_1.expires') %></td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_2.name') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_2.purpose') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_2.expires') %></td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_3.name') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_3.purpose') %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t('.reg_and_sign_in_cookie_3.expires') %></td>
-        </tr>
+      <% (1..4).each do |i| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell govuk-!-padding-right-2" style="word-break: break-all;"><%= t(".reg_and_sign_in_cookie.row_#{i}.name") %></td>
+            <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".reg_and_sign_in_cookie.row_#{i}.purpose") %></td>
+            <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".reg_and_sign_in_cookie.row_#{i}.expires") %></td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/app/views/shared/passwords/_edit.html.erb
+++ b/app/views/shared/passwords/_edit.html.erb
@@ -62,8 +62,7 @@
 
       </fieldset>
 
-      <%= hidden_field_tag :user_email_reset_by_CSC, params[:username] %>
-      <%= hidden_field_tag :user_email_reset_by_themself, @response.email %>
+      <%= hidden_field_tag :email, @response.email %>
 
       <%= submit_tag t('common.reset_password'), id: "submit", class: "govuk-button govuk-!-padding-left-7 govuk-!-padding-right-7", 'aria-label': "#{t('common.reset_password')}" %>
 

--- a/app/views/shared/users/_confirm_new.html.erb
+++ b/app/views/shared/users/_confirm_new.html.erb
@@ -9,7 +9,7 @@
     </h1>
 
     <p class="govuk-body-l">
-      <%= t('.lead_start') %> <span class="ccs-email-example"><%= cookies[:confirmation_email] %></span> <%= t('.lead_end') %>
+      <%= t('.lead_start') %> <span class="ccs-email-example"><%= cookies[:crown_marketplace_confirmation_email] %></span> <%= t('.lead_end') %>
     </p>
 
     <%= form_tag confirm_path, class: 'ccs-form', id: 'cop_confirmation_code', specialvalidation: true, novalidate: true, method: :post do %>
@@ -23,8 +23,8 @@
         <%= text_field_tag :confirmation_code, nil, class: "govuk-input govuk-!-width-one-third", id: 'confirmation', type: 'number' %>
       </div>
 
-      <% if cookies[:confirmation_email] %>
-        <%= hidden_field_tag :email, cookies[:confirmation_email] %>
+      <% if cookies[:crown_marketplace_confirmation_email] %>
+        <%= hidden_field_tag :email, cookies[:crown_marketplace_confirmation_email] %>
       <% else %>
         <div class="govuk-form-group <%= 'govuk-form-group--error' if @result.errors[:email].any? %>">
           <label class="govuk-label" for="email">
@@ -40,10 +40,14 @@
 
     <% end %>
 
-    <% if cookies[:confirmation_email] %>
-      <p class="govuk-body govuk-!-margin-bottom-7">
-        <%= t('.resend_the_confirmation_email_html', link: resend_path) %>
-      </p>
+    <% if cookies[:crown_marketplace_confirmation_email] %>
+      <%= form_tag resend_path, class: 'ccs-form', id: 'cop_resend_confirmation_code', specialvalidation: true, novalidate: true, method: :post do %>
+        <%= hidden_field_tag :email, cookies[:crown_marketplace_confirmation_email] %>
+
+        <p class="govuk-body govuk-!-margin-bottom-7">
+          <%= submit_tag t('.resend_the_confirmation_email'), id: "resend-the-confirmation-email", class: "govuk-link button_as_link", aria: { label: t('.resend_the_confirmation_email') } %>
+        </p>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/users/_new_password_required.html.erb
+++ b/app/views/shared/users/_new_password_required.html.erb
@@ -33,9 +33,9 @@
         <%= password_field_tag :new_password_confirmation, nil, class: "govuk-input govuk-!-width-two-thirds", id: "password02", autocomplete: "off" %>
       </div>
 
-      <%= hidden_field_tag :session, cookies[:session] %>
+      <%= hidden_field_tag :session, cookies[:crown_marketplace_challenge_session] %>
 
-      <%= hidden_field_tag :username, params[:username] %>
+      <%= hidden_field_tag :username, cookies[:crown_marketplace_challenge_username] %>
 
       <%= hidden_field_tag :challenge_name, params[:challenge_name] %>
 

--- a/app/views/shared/users/_sms_mfa.html.erb
+++ b/app/views/shared/users/_sms_mfa.html.erb
@@ -52,9 +52,9 @@
       </div>
 
 
-      <%= hidden_field_tag :session, cookies[:session] %>
+      <%= hidden_field_tag :session, cookies[:crown_marketplace_challenge_session] %>
 
-      <%= hidden_field_tag :username, params[:username] %>
+      <%= hidden_field_tag :username, cookies[:crown_marketplace_challenge_username] %>
 
       <%= hidden_field_tag :challenge_name, params[:challenge_name] %>
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -116,6 +116,9 @@ ignore_unused:
   - home.index.management_consultancy_link
   - home.index.legal_services_link
   - home.index.facilities_management_link
+  - home.cookie_policy.cookie_banner_cookies.row_*
+  - home.cookie_policy.ga_cookies.row_*
+  - home.cookie_policy.reg_and_sign_in_cookie.row_*
   - facilities_management.rm3830.procurements.results.hint-text-unpriced*
   - facilities_management.rm3830.procurements.results.sub-lot-1*
   - facilities_management.rm3830.procurement_buildings_services.service_standards.detail_text.*

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -407,44 +407,51 @@ en:
       change_settings_html: You can %{change_settings_link}.
       change_settings_link_text: change which cookies you’re happy for us to use
       change_your_settings: Change your settings
-      cookie_message_1:
-        expires: 1 year
-        name: crown_marketplace_google_analytics_enabled
-        purpose: Saves your cookie consent settings for Google Analytics
-      cookie_message_2:
-        expires: 1 year
-        name: crown_marketplace_cookie_settings_viewed
-        purpose: Lets us know that you’ve viewed your cookie consent settings
-      cookies_message: Cookies message
-      ga_cookies_1:
-        expires: 2 years
-        name: _ga
-        purpose: This cookie allows Google to track unique users via a client identifier that is randomly generated
-      ga_cookies_2:
-        expires: 10 minutes
-        name: _gat
-        purpose: This cookie is used to monitor and track visitors’ behaviour on the site anonymously
-      ga_cookies_3:
-        expires: 24 hours
-        name: _gid
-        purpose: This cookie is used to group the user behaviour
+      cookie_banner_cookies:
+        row_1:
+          expires: 1 year
+          name: crown_marketplace_google_analytics_enabled
+          purpose: Saves your cookie consent settings for Google Analytics
+        row_2:
+          expires: 1 year
+          name: crown_marketplace_cookie_settings_viewed
+          purpose: Lets us know that you’ve viewed your cookie consent settings
+      cookies_banner: Cookies banner
+      ga_cookies:
+        row_1:
+          expires: 2 years
+          name: _ga
+          purpose: This cookie allows Google to track unique users via a client identifier that is randomly generated
+        row_2:
+          expires: 10 minutes
+          name: _gat
+          purpose: This cookie is used to monitor and track visitors’ behaviour on the site anonymously
+        row_3:
+          expires: 24 hours
+          name: _gid
+          purpose: This cookie is used to group the user behaviour
       ga_sets_following_cookies: Google Analytics sets the following cookies.
       heading: Details about cookies on Crown Marketplace
       last_updated: Last updated 30 April 2021
       policy_will_apply: This cookie policy is applicable to all four services
       reg_and_sign_in: Registration and sign in
-      reg_and_sign_in_cookie_1:
-        expires: 20 minutes
-        name: reset_email
-        purpose: This cookie holds the email of the user when resetting their password
-      reg_and_sign_in_cookie_2:
-        expires: 20 minutes
-        name: session
-        purpose: This cookie holds the session id when a user is challenged while logging in
-      reg_and_sign_in_cookie_3:
-        expires: 20 minutes
-        name: confirmation_email
-        purpose: This cookie holds the email of the user when activating their account
+      reg_and_sign_in_cookie:
+        row_1:
+          expires: 20 minutes
+          name: crown_marketplace_reset_email
+          purpose: This cookie holds the email of the user when resetting their password
+        row_2:
+          expires: 20 minutes
+          name: crown_marketplace_challenge_session
+          purpose: This cookie holds the session id when a user is challenged while logging in
+        row_3:
+          expires: 20 minutes
+          name: crown_marketplace_challenge_username
+          purpose: This cookie holds the user id when a user is challenged while logging in
+        row_4:
+          expires: 20 minutes
+          name: crown_marketplace_confirmation_email
+          purpose: This cookie holds the email of the user when activating their account
       reg_and_sign_in_cookies: These cookies are sometimes required to complete the regestration and sign in process.
       we_do_not_let: We do not allow Google to use or share the data about how you use this site.
       what_are_cookies: Crown Marketplace puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site. Find out more about the cookies we use, what they’re for and when they expire.
@@ -614,7 +621,7 @@ en:
         heading: Activate your account
         lead_end: containing your confirmation code.
         lead_start: An email has been sent to
-        resend_the_confirmation_email_html: <a href="%{link}" class="govuk-link">Resend the email</a>
+        resend_the_confirmation_email: Resend the email
       new_password_required:
         confirm_your_password: Confirm your password
         create_your_password: Create a password you'll remember

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,6 @@ Rails.application.routes.draw do
       delete '/sign-out', to: 'sessions#destroy', as: :destroy_user_session
       get '/users/forgot-password', to: 'passwords#new', as: :new_user_password
       post '/users/password', to: 'passwords#create'
-      get '/users/forgot-password-confirmation', to: 'passwords#confirm_new', as: :confirm_new_user_password
       get '/users/password', to: 'passwords#edit', as: :edit_user_password
       put '/users/password', to: 'passwords#update'
       get '/users/password-reset-success', to: 'passwords#password_reset_success', as: :password_reset_success
@@ -25,7 +24,7 @@ Rails.application.routes.draw do
       post '/users/confirm', to: 'users#confirm'
       get '/users/challenge', to: 'users#challenge_new'
       post '/users/challenge', to: 'users#challenge'
-      get '/resend_confirmation_email', to: 'users#resend_confirmation_email', as: :resend_confirmation_email
+      post '/resend_confirmation_email', to: 'users#resend_confirmation_email', as: :resend_confirmation_email
     end
     concern :registrable do
       get '/sign-up', to: 'registrations#new', as: :new_user_registration

--- a/features/helpers/facilities_management/logging_in_helper.rb
+++ b/features/helpers/facilities_management/logging_in_helper.rb
@@ -1,31 +1,43 @@
+def stub_login
+  aws_client = instance_double(Aws::CognitoIdentityProvider::Client)
+  allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+  allow(aws_client).to receive(:initiate_auth).and_return(OpenStruct.new)
+end
+
 def create_user_with_details
   create_user(:with_detail)
+  stub_login
 end
 
 def create_user_without_details
   create_user(:without_detail)
+  stub_login
 end
 
 def create_admin_user_with_details
   @user = create(:user, :with_detail, confirmed_at: Time.zone.now, roles: %i[buyer ccs_employee fm_access supplier])
   allow_any_instance_of(Cognito::UpdateUser).to receive(:call).and_return(true)
   allow_any_instance_of(Cognito::UpdateUser).to receive(:call).with(anything).and_return(true)
+  stub_login
 end
 
 def create_supplier
   @supplier_user = create(:user, confirmed_at: Time.zone.now, roles: %i[supplier fm_access])
   allow_any_instance_of(Cognito::UpdateUser).to receive(:call).and_return(true)
   allow_any_instance_of(Cognito::UpdateUser).to receive(:call).with(anything).and_return(true)
+  stub_login
 end
 
 def create_supplier_with_email(email)
   @supplier_user = create(:user, confirmed_at: Time.zone.now, roles: %i[supplier fm_access], email: email)
   allow_any_instance_of(Cognito::UpdateUser).to receive(:call).and_return(true)
   allow_any_instance_of(Cognito::UpdateUser).to receive(:call).with(anything).and_return(true)
+  stub_login
 end
 
 def create_user(option)
   @user = create(:user, option, confirmed_at: Time.zone.now, roles: %i[buyer fm_access])
   allow_any_instance_of(Cognito::UpdateUser).to receive(:call).and_return(true)
   allow_any_instance_of(Cognito::UpdateUser).to receive(:call).with(anything).and_return(true)
+  stub_login
 end

--- a/features/step_definitions/facilities_management/common_steps.rb
+++ b/features/step_definitions/facilities_management/common_steps.rb
@@ -3,7 +3,7 @@ Given 'I sign in and navigate to my account for {string}' do |framework|
   update_banner_cookie(true) if @javascript
   create_user_with_details
   fill_in 'email', with: @user.email
-  fill_in 'password', with: nil
+  fill_in 'password', with: 'ValidPasswrod'
   click_on 'Sign in'
   expect(page.find('h1')).to have_content(@user.email)
 end

--- a/features/step_definitions/facilities_management/rm3830/admin_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/admin_steps.rb
@@ -3,7 +3,7 @@ Given('I sign in as an admin and navigate to my dashboard') do
   update_banner_cookie(true) if @javascript
   create_admin_user_with_details
   fill_in 'email', with: @user.email
-  fill_in 'password', with: nil
+  fill_in 'password', with: 'ValidPasswrod'
   click_on 'Sign in'
   expect(page.find('h1')).to have_content('RM3830 administration dashboard')
 end
@@ -26,7 +26,7 @@ Given('I sign out and sign in the admin user') do
   step "I click on 'Sign out'"
   visit facilities_management_rm3830_admin_new_user_session_path
   fill_in 'email', with: @user.email
-  fill_in 'password', with: nil
+  fill_in 'password', with: 'ValidPasswrod'
   click_on 'Sign in'
   expect(page.find('h1')).to have_content('RM3830 administration dashboard')
 end

--- a/features/step_definitions/facilities_management/rm3830/home_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/home_steps.rb
@@ -7,7 +7,7 @@ Given('I sign in without details') do
   update_banner_cookie(true) if @javascript
   create_user_without_details
   fill_in 'email', with: @user.email
-  fill_in 'password', with: nil
+  fill_in 'password', with: 'ValidPasswrod'
   click_on 'Sign in'
   expect(page.find('h1')).to have_content('Manage your details')
 end
@@ -32,7 +32,7 @@ end
 
 Then('I sign in') do
   fill_in 'email', with: @user.email
-  fill_in 'password', with: nil
+  fill_in 'password', with: 'ValidPasswrod'
   click_on 'Sign in'
 end
 

--- a/features/step_definitions/facilities_management/rm3830/supplier_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/supplier_steps.rb
@@ -37,7 +37,7 @@ Given('I logout and sign in the supplier {string}') do |email|
   visit facilities_management_rm3830_supplier_new_user_session_path
   update_banner_cookie(true) if @javascript
   fill_in 'email', with: @supplier_user.email
-  fill_in 'password', with: nil
+  fill_in 'password', with: 'ValidPasswrod'
   click_on 'Sign in'
   expect(page.find('h1')).to have_content('Direct award dashboard')
 end
@@ -46,7 +46,7 @@ Given('I logout and sign in the supplier again') do
   step "I click on 'Sign out'"
   visit facilities_management_rm3830_supplier_new_user_session_path
   fill_in 'email', with: @supplier_user.email
-  fill_in 'password', with: nil
+  fill_in 'password', with: 'ValidPasswrod'
   click_on 'Sign in'
   expect(page.find('h1')).to have_content('Direct award dashboard')
 end
@@ -93,7 +93,7 @@ Then('sign in supplier') do
   visit facilities_management_rm3830_supplier_new_user_session_path
   update_banner_cookie(true) if @javascript
   fill_in 'email', with: @supplier_user.email
-  fill_in 'password', with: nil
+  fill_in 'password', with: 'ValidPasswrod'
   click_on 'Sign in'
   expect(page.find('h1')).to have_content('Direct award dashboard')
 end

--- a/spec/controllers/crown_marketplace/passwords_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/passwords_controller_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe CrownMarketplace::PasswordsController, type: :controller do
+  let(:default_params) { { service: 'crown_marketplace' } }
+
+  describe 'GET new' do
+    before { get :new }
+
+    it 'renders the new page' do
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST create' do
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+      post :create, params: { email: email }
+      cookies.update(response.cookies)
+    end
+
+    context 'when the email is invalid' do
+      let(:email) { 'testtest.com' }
+
+      it 'redirects to the crown_marketplace_new_user_password_path' do
+        expect(response).to redirect_to crown_marketplace_new_user_password_path
+      end
+
+      it 'does not set the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to be nil
+      end
+    end
+
+    context 'when the email is valid' do
+      let(:email) { 'test@test.com' }
+
+      it 'redirects to crown_marketplace_edit_user_password_path' do
+        expect(response).to redirect_to crown_marketplace_edit_user_password_path
+      end
+
+      it 'sets the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    before do
+      cookies[:crown_marketplace_reset_email] = 'test@email.com'
+      get :edit
+    end
+
+    it 'renders the edit page' do
+      expect(response).to render_template(:edit)
+    end
+
+    it 'the email has been set correctly in the response object' do
+      expect(assigns(:response).email).to eq('test@email.com')
+    end
+  end
+
+  describe 'PUT update' do
+    before do
+      cookies[:crown_marketplace_reset_email] = 'test@email.com'
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
+      allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+      cookies.update(response.cookies)
+    end
+
+    context 'when the reset password is invalid' do
+      let(:password) { 'Pas12!' }
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'does not delete the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      end
+    end
+
+    context 'when the reset password is valid' do
+      let(:password) { 'Password12345!' }
+
+      it 'redirects to crown_marketplace_password_reset_success_path' do
+        expect(response).to redirect_to crown_marketplace_password_reset_success_path
+      end
+
+      it 'deletes the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to be nil
+      end
+    end
+  end
+
+  describe 'GET password_reset_success' do
+    before { get :password_reset_success }
+
+    it 'renders the password_reset_success page' do
+      expect(response).to render_template(:password_reset_success)
+    end
+  end
+end

--- a/spec/controllers/crown_marketplace/sessions_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/sessions_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :controller do
-  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM3830' } }
+RSpec.describe CrownMarketplace::SessionsController, type: :controller do
+  let(:default_params) { { service: 'crown_marketplace' } }
 
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
@@ -43,8 +43,8 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :c
       context 'when the password needs to be reset' do
         let(:exception) { Aws::CognitoIdentityProvider::Errors::PasswordResetRequiredException.new('oops', 'Oops') }
 
-        it 'redirects to facilities_management_rm3830_admin_edit_user_password_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_edit_user_password_path
+        it 'redirects to crown_marketplace_edit_user_password_path' do
+          expect(response).to redirect_to crown_marketplace_edit_user_password_path
         end
 
         it 'sets the crown_marketplace_reset_email cookie' do
@@ -59,7 +59,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :c
       let(:cognito_groups) do
         OpenStruct.new(groups: [
                          OpenStruct.new(group_name: 'ccs_employee'),
-                         OpenStruct.new(group_name: 'fm_access')
+                         OpenStruct.new(group_name: 'allow_list_access')
                        ])
       end
 
@@ -75,16 +75,16 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :c
       context 'and there is no challenge' do
         let(:challenge_name) { nil }
 
-        it 'redirects to facilities_management_rm3830_admin_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_path
+        it 'redirects to crown_marketplace_path' do
+          expect(response).to redirect_to crown_marketplace_path
         end
       end
 
       context 'and there is a challenge' do
         let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
 
-        it 'redirects to facilities_management_rm3830_admin_users_challenge_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_users_challenge_path(challenge_name: challenge_name)
+        it 'redirects to crown_marketplace_users_challenge_path' do
+          expect(response).to redirect_to crown_marketplace_users_challenge_path(challenge_name: challenge_name)
         end
 
         it 'the cookies are updated correctly' do

--- a/spec/controllers/crown_marketplace/users_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/users_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :controller do
-  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM3830' } }
+RSpec.describe CrownMarketplace::UsersController, type: :controller do
+  let(:default_params) { { service: 'crown_marketplace' } }
 
   describe 'GET challenge_new' do
     let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
@@ -17,7 +17,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :cont
       let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
 
       it 'renders the new_password_required partial' do
-        expect(response).to render_template('facilities_management/rm3830/admin/users/_new_password_required')
+        expect(response).to render_template('crown_marketplace/users/_new_password_required')
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :cont
       let(:challenge_name) { 'SMS_MFA' }
 
       it 'renders the sms_mfa partial' do
-        expect(response).to render_template('facilities_management/rm3830/admin/users/_sms_mfa')
+        expect(response).to render_template('crown_marketplace/users/_sms_mfa')
       end
     end
   end
@@ -74,8 +74,8 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :cont
         context 'and there is an additional challange' do
           let(:new_challenge_name) { 'SMS_MFA' }
 
-          it 'redirects to facilities_management_rm3830_admin_users_challenge_path' do
-            expect(response).to redirect_to facilities_management_rm3830_admin_users_challenge_path(challenge_name: new_challenge_name)
+          it 'redirects to crown_marketplace_users_challenge_path' do
+            expect(response).to redirect_to crown_marketplace_users_challenge_path(challenge_name: new_challenge_name)
           end
 
           it 'the cookies are updated correctly' do
@@ -85,8 +85,8 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :cont
         end
 
         context 'and there is no additional challange' do
-          it 'redirects to facilities_management_rm3830_admin_path' do
-            expect(response).to redirect_to facilities_management_rm3830_admin_path
+          it 'redirects to crown_marketplace_path' do
+            expect(response).to redirect_to crown_marketplace_path
           end
 
           it 'deletes the cookies' do
@@ -125,8 +125,8 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :cont
       end
 
       context 'and it is valid' do
-        it 'redirects to facilities_management_rm3830_admin_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_path
+        it 'redirects to crown_marketplace_path' do
+          expect(response).to redirect_to crown_marketplace_path
         end
 
         it 'deletes the cookies' do

--- a/spec/controllers/facilities_management/rm3830/admin/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/passwords_controller_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM3830::Admin::PasswordsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM3830' } }
+
+  describe 'GET new' do
+    before { get :new }
+
+    it 'renders the new page' do
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST create' do
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+      post :create, params: { email: email }
+      cookies.update(response.cookies)
+    end
+
+    context 'when the email is invalid' do
+      let(:email) { 'testtest.com' }
+
+      it 'redirects to the facilities_management_rm3830_admin_new_user_password_path' do
+        expect(response).to redirect_to facilities_management_rm3830_admin_new_user_password_path
+      end
+
+      it 'does not set the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to be nil
+      end
+    end
+
+    context 'when the email is valid' do
+      let(:email) { 'test@test.com' }
+
+      it 'redirects to facilities_management_rm3830_admin_edit_user_password_path' do
+        expect(response).to redirect_to facilities_management_rm3830_admin_edit_user_password_path
+      end
+
+      it 'sets the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    before do
+      cookies[:crown_marketplace_reset_email] = 'test@email.com'
+      get :edit
+    end
+
+    it 'renders the edit page' do
+      expect(response).to render_template(:edit)
+    end
+
+    it 'the email has been set correctly in the response object' do
+      expect(assigns(:response).email).to eq('test@email.com')
+    end
+  end
+
+  describe 'PUT update' do
+    before do
+      cookies[:crown_marketplace_reset_email] = 'test@email.com'
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
+      allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+      cookies.update(response.cookies)
+    end
+
+    context 'when the reset password is invalid' do
+      let(:password) { 'Pas12!' }
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'does not delete the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      end
+    end
+
+    context 'when the reset password is valid' do
+      let(:password) { 'Password12345!' }
+
+      it 'redirects to facilities_management_rm3830_admin_password_reset_success_path' do
+        expect(response).to redirect_to facilities_management_rm3830_admin_password_reset_success_path
+      end
+
+      it 'deletes the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to be nil
+      end
+    end
+  end
+
+  describe 'GET password_reset_success' do
+    before { get :password_reset_success }
+
+    it 'renders the password_reset_success page' do
+      expect(response).to render_template(:password_reset_success)
+    end
+  end
+end

--- a/spec/controllers/facilities_management/rm3830/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/passwords_controller_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM3830::PasswordsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management', framework: 'RM3830' } }
+
+  describe 'GET new' do
+    before { get :new }
+
+    it 'renders the new page' do
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST create' do
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+      post :create, params: { email: email }
+      cookies.update(response.cookies)
+    end
+
+    context 'when the email is invalid' do
+      let(:email) { 'testtest.com' }
+
+      it 'redirects to the facilities_management_rm3830_new_user_password_path' do
+        expect(response).to redirect_to facilities_management_rm3830_new_user_password_path
+      end
+
+      it 'does not set the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to be nil
+      end
+    end
+
+    context 'when the email is valid' do
+      let(:email) { 'test@test.com' }
+
+      it 'redirects to facilities_management_rm3830_edit_user_password_path' do
+        expect(response).to redirect_to facilities_management_rm3830_edit_user_password_path
+      end
+
+      it 'sets the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    before do
+      cookies[:crown_marketplace_reset_email] = 'test@email.com'
+      get :edit
+    end
+
+    it 'renders the edit page' do
+      expect(response).to render_template(:edit)
+    end
+
+    it 'the email has been set correctly in the response object' do
+      expect(assigns(:response).email).to eq('test@email.com')
+    end
+  end
+
+  describe 'PUT update' do
+    before do
+      cookies[:crown_marketplace_reset_email] = 'test@email.com'
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
+      allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+      cookies.update(response.cookies)
+    end
+
+    context 'when the reset password is invalid' do
+      let(:password) { 'Pas12!' }
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'does not delete the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      end
+    end
+
+    context 'when the reset password is valid' do
+      let(:password) { 'Password12345!' }
+
+      it 'redirects to facilities_management_rm3830_password_reset_success_path' do
+        expect(response).to redirect_to facilities_management_rm3830_password_reset_success_path
+      end
+
+      it 'deletes the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to be nil
+      end
+    end
+  end
+
+  describe 'GET password_reset_success' do
+    before { get :password_reset_success }
+
+    it 'renders the password_reset_success page' do
+      expect(response).to render_template(:password_reset_success)
+    end
+  end
+end

--- a/spec/controllers/facilities_management/rm3830/registrations_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/registrations_controller_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM3830::RegistrationsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management', framework: 'RM3830' } }
+
+  before { request.env['devise.mapping'] = Devise.mappings[:user] }
+
+  describe 'GET new' do
+    before { get :new }
+
+    it 'renders the new page' do
+      expect(response).to render_template(:new)
+    end
+
+    it 'gives the user the buyer and fm_access roles' do
+      expect(assigns(:result).roles).to eq(%i[buyer fm_access])
+    end
+  end
+
+  describe 'POST create' do
+    let(:email) { 'test@testemail.com' }
+    let(:password) { 'Password890!' }
+    let(:password_confirmation) { password }
+
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_return({ 'user_sub': '1234567890' })
+      allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
+      allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
+      # rubocop:enable RSpec/AnyInstance
+      post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+      cookies.update(response.cookies)
+    end
+
+    context 'when the emaildomain is not on the allow list' do
+      let(:email) { 'test@fake-testemail.com' }
+
+      it 'redirects to facilities_management_rm3830_domain_not_on_safelist_path' do
+        expect(response).to redirect_to facilities_management_rm3830_domain_not_on_safelist_path
+      end
+    end
+
+    context 'when some of the information is invalid' do
+      let(:password_confirmation) { 'I do not match the password' }
+
+      it 'renders the new page' do
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when all the information is valid' do
+      it 'redirects to facilities_management_rm3830_users_confirm_path' do
+        expect(response).to redirect_to facilities_management_rm3830_users_confirm_path
+      end
+
+      it 'sets the crown_marketplace_confirmation_email cookie' do
+        expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+      end
+    end
+  end
+
+  describe 'GET domain_not_on_safelist' do
+    before { get :domain_not_on_safelist }
+
+    it 'renders the new page' do
+      expect(response).to render_template(:domain_not_on_safelist)
+    end
+  end
+end

--- a/spec/controllers/facilities_management/rm3830/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/sessions_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :controller do
-  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM3830' } }
+RSpec.describe FacilitiesManagement::RM3830::SessionsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management', framework: 'RM3830' } }
 
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
@@ -43,12 +43,24 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :c
       context 'when the password needs to be reset' do
         let(:exception) { Aws::CognitoIdentityProvider::Errors::PasswordResetRequiredException.new('oops', 'Oops') }
 
-        it 'redirects to facilities_management_rm3830_admin_edit_user_password_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_edit_user_password_path
+        it 'redirects to facilities_management_rm3830_edit_user_password_path' do
+          expect(response).to redirect_to facilities_management_rm3830_edit_user_password_path
         end
 
         it 'sets the crown_marketplace_reset_email cookie' do
           expect(cookies[:crown_marketplace_reset_email]).to eq email
+        end
+      end
+
+      context 'when the user needs confirmation' do
+        let(:exception) { Aws::CognitoIdentityProvider::Errors::UserNotConfirmedException.new('oops', 'Oops') }
+
+        it 'redirects to facilities_management_rm3830_edit_user_password_path' do
+          expect(response).to redirect_to facilities_management_rm3830_users_confirm_path
+        end
+
+        it 'sets the crown_marketplace_confirmation_email cookie' do
+          expect(cookies[:crown_marketplace_confirmation_email]).to eq email
         end
       end
     end
@@ -58,7 +70,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :c
       let(:session) { 'I_AM_THE_SESSION' }
       let(:cognito_groups) do
         OpenStruct.new(groups: [
-                         OpenStruct.new(group_name: 'ccs_employee'),
+                         OpenStruct.new(group_name: 'buyer'),
                          OpenStruct.new(group_name: 'fm_access')
                        ])
       end
@@ -75,16 +87,16 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :c
       context 'and there is no challenge' do
         let(:challenge_name) { nil }
 
-        it 'redirects to facilities_management_rm3830_admin_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_path
+        it 'redirects to facilities_management_path' do
+          expect(response).to redirect_to facilities_management_rm3830_path
         end
       end
 
       context 'and there is a challenge' do
         let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
 
-        it 'redirects to facilities_management_rm3830_admin_users_challenge_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_users_challenge_path(challenge_name: challenge_name)
+        it 'redirects to facilities_management_rm3830_users_challenge_path' do
+          expect(response).to redirect_to facilities_management_rm3830_users_challenge_path(challenge_name: challenge_name)
         end
 
         it 'the cookies are updated correctly' do

--- a/spec/controllers/facilities_management/rm3830/supplier/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/supplier/passwords_controller_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM3830::Supplier::PasswordsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management/supplier', framework: 'RM3830' } }
+
+  describe 'GET new' do
+    before { get :new }
+
+    it 'renders the new page' do
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST create' do
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+      post :create, params: { email: email }
+      cookies.update(response.cookies)
+    end
+
+    context 'when the email is invalid' do
+      let(:email) { 'testtest.com' }
+
+      it 'redirects to the facilities_management_rm3830_supplier_new_user_password_path' do
+        expect(response).to redirect_to facilities_management_rm3830_supplier_new_user_password_path
+      end
+
+      it 'does not set the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to be nil
+      end
+    end
+
+    context 'when the email is valid' do
+      let(:email) { 'test@test.com' }
+
+      it 'redirects to facilities_management_rm3830_supplier_edit_user_password_path' do
+        expect(response).to redirect_to facilities_management_rm3830_supplier_edit_user_password_path
+      end
+
+      it 'sets the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    before do
+      cookies[:crown_marketplace_reset_email] = 'test@email.com'
+      get :edit
+    end
+
+    it 'renders the edit page' do
+      expect(response).to render_template(:edit)
+    end
+
+    it 'the email has been set correctly in the response object' do
+      expect(assigns(:response).email).to eq('test@email.com')
+    end
+  end
+
+  describe 'PUT update' do
+    before do
+      cookies[:crown_marketplace_reset_email] = 'test@email.com'
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
+      allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+      cookies.update(response.cookies)
+    end
+
+    context 'when the reset password is invalid' do
+      let(:password) { 'Pas12!' }
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'does not delete the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      end
+    end
+
+    context 'when the reset password is valid' do
+      let(:password) { 'Password12345!' }
+
+      it 'redirects to facilities_management_rm3830_supplier_password_reset_success_path' do
+        expect(response).to redirect_to facilities_management_rm3830_supplier_password_reset_success_path
+      end
+
+      it 'deletes the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to be nil
+      end
+    end
+  end
+
+  describe 'GET password_reset_success' do
+    before { get :password_reset_success }
+
+    it 'renders the password_reset_success page' do
+      expect(response).to render_template(:password_reset_success)
+    end
+  end
+end

--- a/spec/controllers/facilities_management/rm3830/supplier/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/supplier/sessions_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :controller do
-  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM3830' } }
+RSpec.describe FacilitiesManagement::RM3830::Supplier::SessionsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management/supplier', framework: 'RM3830' } }
 
   before { request.env['devise.mapping'] = Devise.mappings[:user] }
 
@@ -43,8 +43,8 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :c
       context 'when the password needs to be reset' do
         let(:exception) { Aws::CognitoIdentityProvider::Errors::PasswordResetRequiredException.new('oops', 'Oops') }
 
-        it 'redirects to facilities_management_rm3830_admin_edit_user_password_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_edit_user_password_path
+        it 'redirects to facilities_management_rm3830_supplier_edit_user_password_path' do
+          expect(response).to redirect_to facilities_management_rm3830_supplier_edit_user_password_path
         end
 
         it 'sets the crown_marketplace_reset_email cookie' do
@@ -58,7 +58,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :c
       let(:session) { 'I_AM_THE_SESSION' }
       let(:cognito_groups) do
         OpenStruct.new(groups: [
-                         OpenStruct.new(group_name: 'ccs_employee'),
+                         OpenStruct.new(group_name: 'supplier'),
                          OpenStruct.new(group_name: 'fm_access')
                        ])
       end
@@ -75,16 +75,16 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :c
       context 'and there is no challenge' do
         let(:challenge_name) { nil }
 
-        it 'redirects to facilities_management_rm3830_admin_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_path
+        it 'redirects to facilities_management_rm3830_supplier_path' do
+          expect(response).to redirect_to facilities_management_rm3830_supplier_path
         end
       end
 
       context 'and there is a challenge' do
         let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
 
-        it 'redirects to facilities_management_rm3830_admin_users_challenge_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_users_challenge_path(challenge_name: challenge_name)
+        it 'redirects to facilities_management_rm3830_supplier_users_challenge_path' do
+          expect(response).to redirect_to facilities_management_rm3830_supplier_users_challenge_path(challenge_name: challenge_name)
         end
 
         it 'the cookies are updated correctly' do

--- a/spec/controllers/facilities_management/rm3830/supplier/users_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/supplier/users_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :controller do
-  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM3830' } }
+RSpec.describe FacilitiesManagement::RM3830::Supplier::UsersController, type: :controller do
+  let(:default_params) { { service: 'facilities_management/supplier', framework: 'RM3830' } }
 
   describe 'GET challenge_new' do
     let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
@@ -17,7 +17,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :cont
       let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
 
       it 'renders the new_password_required partial' do
-        expect(response).to render_template('facilities_management/rm3830/admin/users/_new_password_required')
+        expect(response).to render_template('facilities_management/rm3830/supplier/users/_new_password_required')
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :cont
       let(:challenge_name) { 'SMS_MFA' }
 
       it 'renders the sms_mfa partial' do
-        expect(response).to render_template('facilities_management/rm3830/admin/users/_sms_mfa')
+        expect(response).to render_template('facilities_management/rm3830/supplier/users/_sms_mfa')
       end
     end
   end
@@ -74,8 +74,8 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :cont
         context 'and there is an additional challange' do
           let(:new_challenge_name) { 'SMS_MFA' }
 
-          it 'redirects to facilities_management_rm3830_admin_users_challenge_path' do
-            expect(response).to redirect_to facilities_management_rm3830_admin_users_challenge_path(challenge_name: new_challenge_name)
+          it 'redirects to facilities_management_rm3830_supplier_users_challenge_path' do
+            expect(response).to redirect_to facilities_management_rm3830_supplier_users_challenge_path(challenge_name: new_challenge_name)
           end
 
           it 'the cookies are updated correctly' do
@@ -85,8 +85,8 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :cont
         end
 
         context 'and there is no additional challange' do
-          it 'redirects to facilities_management_rm3830_admin_path' do
-            expect(response).to redirect_to facilities_management_rm3830_admin_path
+          it 'redirects to facilities_management_rm3830_supplier_path' do
+            expect(response).to redirect_to facilities_management_rm3830_supplier_path
           end
 
           it 'deletes the cookies' do
@@ -125,8 +125,8 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController, type: :cont
       end
 
       context 'and it is valid' do
-        it 'redirects to facilities_management_rm3830_admin_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_path
+        it 'redirects to facilities_management_rm3830_supplier_path' do
+          expect(response).to redirect_to facilities_management_rm3830_supplier_path
         end
 
         it 'deletes the cookies' do

--- a/spec/controllers/facilities_management/rm3830/users_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/users_controller_spec.rb
@@ -1,41 +1,199 @@
 require 'rails_helper'
 
-RSpec.describe FacilitiesManagement::RM3830::UsersController do
+RSpec.describe FacilitiesManagement::RM3830::UsersController, type: :controller do
   let(:default_params) { { service: 'facilities_management', framework: 'RM3830' } }
 
-  describe '#challenge_new' do
+  describe 'GET confirm_new' do
+    before { get :confirm_new }
+
+    it 'renders the confirm_new page' do
+      expect(response).to render_template(:confirm_new)
+    end
+  end
+
+  describe 'POST confirm' do
+    let(:user) { create(:user) }
+    let(:user_email) { user.email }
+
     before do
-      sign_in user
-      allow(Cognito::RespondToChallenge).to receive(:new).and_return(true)
-      allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(instance_double(Cognito::CreateUserFromCognito, user: user))
+      cookies[:crown_marketplace_confirmation_email] = user_email
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+      post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
+      cookies.update(response.cookies)
     end
 
-    context 'when user has a phone number' do
-      let(:user) { create(:user, :with_phone_number) }
+    context 'when the information is invalid' do
+      let(:confirmation_code) { '' }
 
-      it 'returns http success' do
-        get :challenge_new, params: { challenge_name: 'FORCE_CHANGE_PASSWORD', username: user.email, session: 'test' }
-        expect(response).to have_http_status(:ok)
+      it 'renders confirm_new' do
+        expect(response).to render_template(:confirm_new)
       end
 
-      it 'assigns @user_phone' do
-        get :challenge_new, params: { challenge_name: 'FORCE_CHANGE_PASSWORD', username: user.email, session: 'test' }
-        expect(assigns(:user_phone)).not_to be_nil
+      it 'does not delete the crown_marketplace_confirmation_email cookie' do
+        expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
       end
     end
 
-    context 'when user does not have a phone number' do
-      let(:user) { create(:user) }
+    context 'when the information is valid' do
+      let(:confirmation_code) { '123456' }
 
-      it 'returns http success' do
-        get :challenge_new, params: { challenge_name: 'FORCE_CHANGE_PASSWORD', username: user.email, session: 'test' }
-        expect(response).to have_http_status(:ok)
+      it 'redirects to facilities_management_path' do
+        expect(response).to redirect_to facilities_management_path
       end
 
-      it 'does not assign @user_phone' do
-        get :challenge_new, params: { challenge_name: 'FORCE_CHANGE_PASSWORD', username: user.email, session: 'test' }
-        expect(assigns(:user_phone)).to be_nil
+      it 'deletes the crown_marketplace_confirmation_email cookie' do
+        expect(cookies[:crown_marketplace_confirmation_email]).to be nil
       end
     end
   end
+
+  describe 'POST resend_confirmation_email' do
+    let(:email) { 'test@testemail.com' }
+
+    before do
+      allow(Cognito::ResendConfirmationCode).to receive(:call).with(email).and_return(Cognito::ResendConfirmationCode.new(email))
+      post :resend_confirmation_email, params: { email: email }
+    end
+
+    it 'redirects to facilities_management_rm3830_users_confirm_path' do
+      expect(response).to redirect_to facilities_management_rm3830_users_confirm_path
+    end
+  end
+
+  describe 'GET challenge_new' do
+    let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
+
+    before do
+      cookies[:crown_marketplace_challenge_username] = user.cognito_uuid
+      get :challenge_new, params: { challenge_name: challenge_name }
+    end
+
+    render_views
+
+    context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+      let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+      it 'renders the new_password_required partial' do
+        expect(response).to render_template('facilities_management/rm3830/users/_new_password_required')
+      end
+    end
+
+    context 'when the challenge is SMS_MFA' do
+      let(:challenge_name) { 'SMS_MFA' }
+
+      it 'renders the sms_mfa partial' do
+        expect(response).to render_template('facilities_management/rm3830/users/_sms_mfa')
+      end
+    end
+  end
+
+  # rubocop:disable RSpec/NestedGroups
+  describe 'POST challenge' do
+    let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
+    let(:session) { 'I_AM_THE_SESSION' }
+    let(:username) { user.cognito_uuid }
+
+    before do
+      cookies[:crown_marketplace_challenge_session] = session
+      cookies[:crown_marketplace_challenge_username] = username
+    end
+
+    context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+      let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+      let(:password) { 'Password12345!' }
+      let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
+      let(:new_challenge_name) { nil }
+      let(:new_session) { 'I_AM_THE_NEW_SESSION' }
+
+      before do
+        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
+
+        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+        cookies.update(response.cookies)
+      end
+
+      context 'and it is not valid' do
+        let(:password) { 'Pas12!' }
+
+        it 'renders challenge_new' do
+          expect(response).to render_template(:challenge_new)
+        end
+
+        it 'does not delete the cookies' do
+          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        end
+      end
+
+      context 'and it is valid' do
+        context 'and there is an additional challange' do
+          let(:new_challenge_name) { 'SMS_MFA' }
+
+          it 'redirects to facilities_management_rm3830_users_challenge_path' do
+            expect(response).to redirect_to facilities_management_rm3830_users_challenge_path(challenge_name: new_challenge_name)
+          end
+
+          it 'the cookies are updated correctly' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+            expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+          end
+        end
+
+        context 'and there is no additional challange' do
+          it 'redirects to facilities_management_path' do
+            expect(response).to redirect_to facilities_management_path
+          end
+
+          it 'deletes the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to be nil
+            expect(cookies[:crown_marketplace_challenge_username]).to be nil
+          end
+        end
+      end
+    end
+
+    context 'when the challenge is SMS_MFA' do
+      let(:challenge_name) { 'SMS_MFA' }
+      let(:access_code) { '123456' }
+      let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
+
+      before do
+        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new)
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
+
+        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+        cookies.update(response.cookies)
+      end
+
+      context 'and it is not valid' do
+        let(:access_code) { '123' }
+
+        it 'renders challenge_new' do
+          expect(response).to render_template(:challenge_new)
+        end
+
+        it 'does not delete the cookies' do
+          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        end
+      end
+
+      context 'and it is valid' do
+        it 'redirects to facilities_management_path' do
+          expect(response).to redirect_to facilities_management_path
+        end
+
+        it 'deletes the cookies' do
+          expect(cookies[:crown_marketplace_challenge_session]).to be nil
+          expect(cookies[:crown_marketplace_challenge_username]).to be nil
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/NestedGroups
 end


### PR DESCRIPTION
Made various changes with regards to logging in to fix a bug and prevent PII appearing in the URL:
- Change `resend_confirmation_email` to post so that the email parameter is passed through as data rather than in the URL
- Updated some areas where there was still PII ending up in the URL
- Update the names of the cookies so it is more clear what they are for
- Add controller tests for the `authenticatable` and `registrable` routes

[FMFR-1136](https://crowncommercialservice.atlassian.net/browse/FMFR-1136)