### PR TITLE
Revert js-cookie back to 2.2.1

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,7 @@
 //= require jquery3
 //= require rails-ujs
 //= require govuk-frontend/govuk/all
-//= require js-cookie/dist/js.cookie
+//= require js-cookie/src/js.cookie
 //= require google-analytics
 //= require cookie-banner
 //= require_tree ./common

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@hmcts/frontend": "0.0.29-alpha",
     "govuk-frontend": "^3.14.0",
     "html5shiv": "^3.7.3",
-    "js-cookie": "^3.0.1"
+    "js-cookie": "^2.2.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,10 +1466,10 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-js-cookie@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
-  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This is because our node engine is `8.17` and we need it to be at least `12` for this (I will look to see how we can update this)