### PR TITLE
Add ability to change when a framework is live through the database

### DIFF
--- a/app/controllers/api/v2/nuts_controller.rb
+++ b/app/controllers/api/v2/nuts_controller.rb
@@ -5,7 +5,7 @@ module Api
     # return json
     class NutsController < FacilitiesManagement::FrameworkController
       protect_from_forgery with: :exception
-      before_action :validate_service, :raise_if_unrecognised_framework, :redirect_to_buyer_detail, except: %i[show_post_code show_nuts_code find_region_query find_region_query_by_postcode]
+      before_action :validate_service, :raise_if_unrecognised_live_framework, :redirect_to_buyer_detail, except: %i[show_post_code show_nuts_code find_region_query find_region_query_by_postcode]
 
       def show_post_code
         result = PostcodesNutsRegion.select(:id, :code, :postcode).find_by(postcode: params[:postcode].delete(' '))

--- a/app/controllers/api/v2/postcodes_controller.rb
+++ b/app/controllers/api/v2/postcodes_controller.rb
@@ -5,7 +5,7 @@ module Api
   module V2
     class PostcodesController < FacilitiesManagement::FrameworkController
       protect_from_forgery with: :exception
-      before_action :validate_service, :raise_if_unrecognised_framework, :redirect_to_buyer_detail, except: :show
+      before_action :validate_service, :raise_if_unrecognised_live_framework, :redirect_to_buyer_detail, except: :show
 
       # GET /postcodes/SW1A 2AA
       # GET /postcodes/SW1A 2AA.json

--- a/app/controllers/base/sessions_controller.rb
+++ b/app/controllers/base/sessions_controller.rb
@@ -60,10 +60,10 @@ module Base
       when 'crown-marketplace'
         crown_marketplace_new_user_session_path(expired: true)
       when 'facilities-management'
-        framework = if FacilitiesManagement::RECOGNISED_FRAMEWORKS.include?(split_url[2])
+        framework = if FacilitiesManagement::Framework.recognised_live_framework?(split_url[2])
                       split_url[2]
                     else
-                      FacilitiesManagement::DEFAULT_FRAMEWORK
+                      FacilitiesManagement::Framework.default_framework
                     end
         service_type ||= split_url[3] if split_url[3] == 'supplier' || split_url[3] == 'admin'
 

--- a/app/controllers/facilities_management/admin/frameworks_controller.rb
+++ b/app/controllers/facilities_management/admin/frameworks_controller.rb
@@ -1,0 +1,37 @@
+module FacilitiesManagement
+  module Admin
+    class FrameworksController < FacilitiesManagement::Admin::FrameworkController
+      before_action :raise_if_unrecognised_framework, except: %i[index edit update]
+      before_action :set_framework, only: %i[edit update]
+
+      def index
+        @frameworks = Framework.all
+      end
+
+      def edit; end
+
+      def update
+        if @framework.update(framework_params)
+          redirect_to facilities_management_admin_frameworks_path
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def set_framework
+        @framework = Framework.find(params[:id])
+      end
+
+      def framework_params
+        params.require(:facilities_management_framework)
+              .permit(
+                :live_at_dd,
+                :live_at_mm,
+                :live_at_yyyy,
+              )
+      end
+    end
+  end
+end

--- a/app/controllers/facilities_management/framework_controller.rb
+++ b/app/controllers/facilities_management/framework_controller.rb
@@ -2,7 +2,7 @@ module FacilitiesManagement
   class FrameworkController < ::ApplicationController
     before_action :authenticate_user!
     before_action :authorize_user
-    before_action :raise_if_unrecognised_framework
+    before_action :raise_if_unrecognised_live_framework
     before_action :redirect_to_buyer_detail
 
     protected

--- a/app/controllers/facilities_management/home_controller.rb
+++ b/app/controllers/facilities_management/home_controller.rb
@@ -1,6 +1,6 @@
 module FacilitiesManagement
   class HomeController < FacilitiesManagement::FrameworkController
-    before_action :authenticate_user!, :authorize_user, :raise_if_unrecognised_framework, :redirect_to_buyer_detail, except: %i[not_permitted accessibility_statement cookie_policy cookie_settings framework]
+    before_action :authenticate_user!, :authorize_user, :raise_if_unrecognised_live_framework, :redirect_to_buyer_detail, except: %i[not_permitted accessibility_statement cookie_policy cookie_settings framework]
 
     def not_permitted
       render 'home/not_permitted', layout: 'error'

--- a/app/controllers/facilities_management/sessions_controller.rb
+++ b/app/controllers/facilities_management/sessions_controller.rb
@@ -1,5 +1,5 @@
 module FacilitiesManagement
   class SessionsController < Base::SessionsController
-    before_action :raise_if_unrecognised_framework
+    before_action :raise_if_unrecognised_live_framework
   end
 end

--- a/app/controllers/facilities_management/supplier/framework_controller.rb
+++ b/app/controllers/facilities_management/supplier/framework_controller.rb
@@ -1,7 +1,7 @@
 class FacilitiesManagement::Supplier::FrameworkController < ::ApplicationController
   before_action :authenticate_user!
   before_action :authorize_user
-  before_action :raise_if_unrecognised_framework
+  before_action :raise_if_unrecognised_live_framework
 
   protected
 

--- a/app/controllers/facilities_management/supplier/home_controller.rb
+++ b/app/controllers/facilities_management/supplier/home_controller.rb
@@ -1,5 +1,5 @@
 class FacilitiesManagement::Supplier::HomeController < FacilitiesManagement::Supplier::FrameworkController
-  before_action :authenticate_user!, :authorize_user, :raise_if_unrecognised_framework, except: %i[accessibility_statement cookie_policy cookie_settings framework]
+  before_action :authenticate_user!, :authorize_user, :raise_if_unrecognised_live_framework, except: %i[accessibility_statement cookie_policy cookie_settings framework]
 
   def accessibility_statement
     render 'home/accessibility_statement'

--- a/app/helpers/header_navigation_links_helper.rb
+++ b/app/helpers/header_navigation_links_helper.rb
@@ -1,6 +1,6 @@
 module HeaderNavigationLinksHelper
   def default_navigation_links
-    framework = params[:framework] || FacilitiesManagement::DEFAULT_FRAMEWORK
+    framework = params[:framework] || FacilitiesManagement::Framework.default_framework
 
     build_navigation_links do |navigation_links|
       navigation_links << { link_text: t('header_navigation_links_helper.back_to_start'), link_url: facilities_management_path(framework: framework) } unless not_permitted_page?
@@ -9,7 +9,7 @@ module HeaderNavigationLinksHelper
   end
 
   def facilities_management_navigation_links(framework)
-    framework ||= FacilitiesManagement::DEFAULT_FRAMEWORK
+    framework ||= FacilitiesManagement::Framework.default_framework
 
     build_navigation_links do |navigation_links|
       navigation_links << back_to_start_link(framework) unless page_does_not_require_back_to_start?
@@ -19,7 +19,7 @@ module HeaderNavigationLinksHelper
   end
 
   def facilites_management_admin_navigation_links(framework)
-    framework ||= FacilitiesManagement::DEFAULT_FRAMEWORK
+    framework ||= FacilitiesManagement::Framework.default_framework
 
     build_navigation_links do |navigation_links|
       navigation_links << { link_text: admin_back_to_start_text, link_url: "/facilities-management/#{framework}/admin" } unless sign_in_or_dashboard?('home')
@@ -28,7 +28,7 @@ module HeaderNavigationLinksHelper
   end
 
   def facilites_management_supplier_navigation_links(framework)
-    framework ||= FacilitiesManagement::DEFAULT_FRAMEWORK
+    framework ||= FacilitiesManagement::Framework.default_framework
 
     build_navigation_links do |navigation_links|
       navigation_links << { link_text: supplier_back_to_start_text, link_url: "/facilities-management/#{framework}/supplier" } unless sign_in_or_dashboard?('dashboard')

--- a/app/models/facilities_management.rb
+++ b/app/models/facilities_management.rb
@@ -2,7 +2,4 @@ module FacilitiesManagement
   def self.table_name_prefix
     'facilities_management_'
   end
-
-  RECOGNISED_FRAMEWORKS = ['RM3830'].freeze
-  DEFAULT_FRAMEWORK = 'RM3830'.freeze
 end

--- a/app/models/facilities_management/framework.rb
+++ b/app/models/facilities_management/framework.rb
@@ -1,0 +1,42 @@
+module FacilitiesManagement
+  class Framework < ApplicationRecord
+    default_scope { order(live_at: :asc) }
+
+    acts_as_gov_uk_date :live_at, error_clash_behaviour: :omit_gov_uk_date_field_error
+    validate :live_at_date_present, :live_at_date_real, on: :update
+
+    def self.frameworks
+      pluck(:framework)
+    end
+
+    def self.live_frameworks
+      where('live_at <= ?', Time.now.in_time_zone('London')).pluck(:framework)
+    end
+
+    def self.default_framework
+      live_frameworks.last
+    end
+
+    def self.recognised_live_framework?(framework)
+      live_frameworks.include?(framework)
+    end
+
+    def self.recognised_framework?(framework)
+      frameworks.include?(framework)
+    end
+
+    def status
+      live_at <= Time.now.in_time_zone('London') ? :live : :coming
+    end
+
+    private
+
+    def live_at_date_present
+      errors.add(:live_at, :blank) if live_at_yyyy.blank? || live_at_mm.blank? || live_at_dd.blank?
+    end
+
+    def live_at_date_real
+      errors.add(:live_at, :not_a_date) unless Date.valid_date?(live_at_yyyy.to_i, live_at_mm.to_i, live_at_dd.to_i)
+    end
+  end
+end

--- a/app/models/facilities_management/rm3830/procurement_supplier.rb
+++ b/app/models/facilities_management/rm3830/procurement_supplier.rb
@@ -259,7 +259,7 @@ module FacilitiesManagement
           'da-offer-1-name': procurement.contract_name,
           'da-offer-1-decline-reason': reason_for_declining,
           'da-offer-1-accept-date': format_date_time_numeric(supplier_response_date),
-          'da-offer-1-link': "#{ENV['RAILS_ENV_URL']}/facilities-management/RM3830/procurements/#{procurement.id}/contracts/#{id}"
+          'da-offer-1-link': "#{Marketplace.rails_env_url}/facilities-management/RM3830/procurements/#{procurement.id}/contracts/#{id}"
         }.to_json
 
         GovNotifyNotification.perform_async(template_name, procurement.user.email, gov_notify_template_arg)
@@ -270,7 +270,7 @@ module FacilitiesManagement
           'da-offer-1-buyer-1': procurement.user.buyer_detail.organisation_name,
           'da-offer-1-name': procurement.contract_name,
           'da-offer-1-expiry': format_date_time_numeric(contract_expiry_date),
-          'da-offer-1-link': "#{ENV['RAILS_ENV_URL']}/facilities-management/RM3830/supplier/contracts/#{id}",
+          'da-offer-1-link': "#{Marketplace.rails_env_url}/facilities-management/RM3830/supplier/contracts/#{id}",
           'da-offer-1-supplier-1': supplier_name,
           'da-offer-1-reference': contract_number,
           'da-offer-1-not-signed-reason': reason_for_not_signing,

--- a/app/views/facilities_management/admin/frameworks/edit.html.erb
+++ b/app/views/facilities_management/admin/frameworks/edit.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, t('.page_title').html_safe %>
+
+<%= form_with model: @framework, url: facilities_management_admin_framework_path, method: :put, local: 'false', html: { specialvalidation: true, novalidate: true } do |f| %>
+  <%= render partial: 'shared/error_summary', locals: { errors: f.object.errors } %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-!-margin-top-5">
+        <div class="govuk-form-group <%= 'govuk-form-group--error' if @framework.errors[:live_at].any?%>">
+          <h1 class="govuk-label-wrapper">
+            <%= f.label :live_at, t('.update_live_at_date', framework: @framework.framework), class: "govuk-label--m"%>
+          </h1>
+          <p class="govuk-caption-m">
+            <%= t('.buyer_section_visible', current_date: Time.now.in_time_zone('London').strftime('%e/%-m/%Y'))%>
+          </p>
+          <%= display_errors(f.object, :live_at)%>
+          <%= f.gov_uk_date_field :live_at, legend_options: { page_heading: false, visually_hidden: true } %>
+        </div>
+      </div>
+
+      <%= f.submit t('.save_and_return'), class: 'govuk-button', aria: { label: t('.save_and_return')} %>
+      <p class="govuk-body">
+        <%= link_to t('.return_to_frameworks'), facilities_management_admin_frameworks_path, class: 'govuk-link--no-visited-state' %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/facilities_management/admin/frameworks/index.html.erb
+++ b/app/views/facilities_management/admin/frameworks/index.html.erb
@@ -1,0 +1,52 @@
+<% content_for :page_title, t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t('.page_title') %></h1>
+    <p>
+      <%= t('.this_section_allows') %>
+    </p>
+
+    <p>
+      <%= t('.if_the_framework', current_date: format_date(Time.now.in_time_zone('London'))) %>
+    </p>
+
+    <p>
+      <%= t('.the_admin_section') %>
+    </p>
+
+    <p>
+      <span class="govuk-!-font-weight-bold">
+        <%= t('.section_not_accessible') %>
+      </span>
+      <%= t('.to_update_in_prod') %>
+    </p>
+  
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header"><%= t('.framework') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.live_at') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.status') %></th>
+          <td class="govuk-table__header"></td>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @frameworks.each do |framework| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= framework.framework %></th>
+            <td class="govuk-table__cell"><%= format_date(framework.live_at) %></td>
+            <td class="govuk-table__cell">
+              <% if framework.status == :live %>
+                <%= govuk_tag_with_text(:blue, t('.live')) %>
+              <% else %>
+                <%= govuk_tag_with_text(:grey, t('.coming')) %>
+              <% end %>
+            </td>
+            <td class="govuk-table__cell"><%= link_to t('.change'), edit_facilities_management_admin_framework_path(framework) %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/home/unrecognised_framework.html.erb
+++ b/app/views/home/unrecognised_framework.html.erb
@@ -6,7 +6,7 @@
     <p><%= t('.make_sure_listed', framework: @unrecognised_framework) %></p>
     <p><%= t('.the_recognised_are') %></p>
     <ul class="govuk-list govuk-list--bullet">
-      <% FacilitiesManagement::RECOGNISED_FRAMEWORKS.each do |framework| %>
+      <% FacilitiesManagement::Framework.live_frameworks.each do |framework| %>
         <li>
           <%= link_to framework, "/facilities-management/#{framework}", class: 'govuk-link' %>
         </li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -152,4 +152,12 @@ module Marketplace
   def self.upload_privileges?
     ENV['APP_HAS_UPLOAD_PRIVILEGES'].present?
   end
+
+  def self.rails_env_url
+    @rails_env_url ||= ENV.fetch('RAILS_ENV_URL')
+  end
+
+  def self.can_edit_facilities_management_frameworks?
+    @can_edit_facilities_management_frameworks ||= rails_env_url != 'https://marketplace.service.crowncommercial.gov.uk'
+  end
 end

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -96,11 +96,37 @@ en:
             telephone_number:
               blank: Enter a UK telephone number, for example 020 7946 0000
               invalid: Enter a UK telephone number, for example 020 7946 0000
+        facilities_management/framework:
+          attributes:
+            live_at:
+              blank: Enter a valid 'live at' date
+              not_a_date: Enter a valid 'live at' date
   dashboard:
     index:
       admin_link: Managing framework and supplier data
       supplier_link: Facilities management supplier account
   facilities_management:
+    admin:
+      frameworks:
+        edit:
+          buyer_section_visible: The buyer section for this framework will be visible if the 'live at' date is today (%{current_date}) or earlier.
+          page_title: Framework 'live at' date
+          return_to_frameworks: Return to facilities management frameworks
+          save_and_return: Save and return
+          update_live_at_date: Update framework 'live at' date for %{framework}
+        index:
+          change: Change
+          coming: coming
+          framework: Framework
+          if_the_framework: If the framework 'live at' date is before the current date (%{current_date}), the buyer section for this framework will be accessible to our customers.
+          live: live
+          live_at: Live at
+          page_title: Facilities management frameworks
+          section_not_accessible: This section is not accessible in production and is for testing purposes only.
+          status: Status
+          the_admin_section: The admin section for a framework will always be visible for any framework that is on the system no matter when it goes live.
+          this_section_allows: This section allows you to view and change the 'live at' date for a facilities management framework.
+          to_update_in_prod: To update the framework 'live at' date in production speak to a developer.
     basket:
       or_text: or
       selectall_text: Select all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
 
     namespace :admin, path: 'admin', defaults: { service: 'facilities_management/admin' } do
       concerns %i[shared_pages framework]
+      resources :frameworks, only: %i[index edit update] if Marketplace.can_edit_facilities_management_frameworks?
     end
 
     namespace 'rm3830', path: 'RM3830', defaults: { framework: 'RM3830' } do

--- a/db/migrate/20220323103620_create_facilities_management_framework_table.rb
+++ b/db/migrate/20220323103620_create_facilities_management_framework_table.rb
@@ -1,0 +1,10 @@
+class CreateFacilitiesManagementFrameworkTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :facilities_management_frameworks, id: :uuid do |t|
+      t.string :framework, limit: 6
+      t.date :live_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_16_112653) do
+ActiveRecord::Schema.define(version: 2022_03_23_103620) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -78,6 +78,13 @@ ActiveRecord::Schema.define(version: 2021_07_16_112653) do
     t.datetime "updated_at", null: false
     t.uuid "user_id", null: false
     t.index ["user_id"], name: "index_facilities_management_buyer_details_on_user_id"
+  end
+
+  create_table "facilities_management_frameworks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "framework", limit: 6
+    t.date "live_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "facilities_management_regions", id: false, force: :cascade do |t|

--- a/lib/tasks/facilities_management/frameworks.rake
+++ b/lib/tasks/facilities_management/frameworks.rake
@@ -1,0 +1,31 @@
+module Frameworks
+  def self.rm6232_live_at
+    if Rails.env.test?
+      Time.zone.now + 1.day
+    else
+      # This is not correct but it is far in the future and we can update it with another migration later on
+      Time.new(2025, 7, 17).in_time_zone('London')
+    end
+  end
+
+  def self.add_frameworks
+    ActiveRecord::Base.connection.truncate_tables(:facilities_management_frameworks)
+
+    FacilitiesManagement::Framework.create(framework: 'RM3830', live_at: Time.new(2020, 6, 26).in_time_zone('London'))
+    FacilitiesManagement::Framework.create(framework: 'RM6232', live_at: rm6232_live_at)
+  end
+end
+
+namespace :db do
+  desc 'add the frameworks into the database'
+  task fm_frameworks: :environment do
+    p 'Loading FM Frameworks'
+    DistributedLocks.distributed_lock(157) do
+      Frameworks.add_frameworks
+    end
+  end
+
+  desc 'add static data to the database'
+  task static: :fm_frameworks do
+  end
+end

--- a/spec/controllers/facilities_management/admin/frameworks_controller_spec.rb
+++ b/spec/controllers/facilities_management/admin/frameworks_controller_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::Admin::FrameworksController do
+  let(:default_params) { { service: 'facilities_management/admin' } }
+
+  login_fm_admin
+
+  describe 'GET index' do
+    it 'renders the index page' do
+      get :index
+      expect(response).to render_template(:index)
+    end
+  end
+
+  describe 'GET edit' do
+    let(:framework) { create(:facilities_management_framework) }
+
+    it 'renders the edit page' do
+      get :edit, params: { id: framework.id }
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'POST update' do
+    let(:framework) { create(:facilities_management_framework) }
+    let(:live_at_yyyy) { framework.live_at.year.to_s }
+    let(:live_at_mm) { framework.live_at.month.to_s }
+    let(:live_at_dd) { framework.live_at.day.to_s }
+
+    before { post :update, params: { id: framework.id, facilities_management_framework: { live_at_dd: live_at_dd, live_at_mm: live_at_mm, live_at_yyyy: live_at_yyyy } } }
+
+    context 'when the data is valid' do
+      it 'redirects to facilities_management_admin_frameworks_path' do
+        expect(response).to redirect_to facilities_management_admin_frameworks_path
+      end
+    end
+
+    context 'when the data is invalid' do
+      let(:live_at_mm) { '13' }
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/controllers/facilities_management/buildings_controller_spec.rb
+++ b/spec/controllers/facilities_management/buildings_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe FacilitiesManagement::BuildingsController, type: :controller do
 
       it 'sets the framework variables' do
         expect(assigns(:unrecognised_framework)).to eq 'RM3840'
-        expect(controller.params[:framework]).to eq FacilitiesManagement::DEFAULT_FRAMEWORK
+        expect(controller.params[:framework]).to eq FacilitiesManagement::Framework.default_framework
       end
     end
 

--- a/spec/controllers/facilities_management/buyer_details_controller_spec.rb
+++ b/spec/controllers/facilities_management/buyer_details_controller_spec.rb
@@ -44,7 +44,7 @@ module FacilitiesManagement
 
         it 'sets the framework variables' do
           expect(assigns(:unrecognised_framework)).to eq 'RM3840'
-          expect(controller.params[:framework]).to eq FacilitiesManagement::DEFAULT_FRAMEWORK
+          expect(controller.params[:framework]).to eq FacilitiesManagement::Framework.default_framework
         end
       end
     end

--- a/spec/controllers/facilities_management/rm3830/admin/home_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/home_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::HomeController do
 
       it 'sets the framework variables' do
         expect(assigns(:unrecognised_framework)).to eq 'RM007'
-        expect(controller.params[:framework]).to eq FacilitiesManagement::DEFAULT_FRAMEWORK
+        expect(controller.params[:framework]).to eq FacilitiesManagement::Framework.default_framework
       end
     end
   end

--- a/spec/controllers/facilities_management/rm3830/admin/management_reports_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/management_reports_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::ManagementReportsController,
 
       it 'sets the framework variables' do
         expect(assigns(:unrecognised_framework)).to eq 'RM007'
-        expect(controller.params[:framework]).to eq FacilitiesManagement::DEFAULT_FRAMEWORK
+        expect(controller.params[:framework]).to eq FacilitiesManagement::Framework.default_framework
       end
     end
   end

--- a/spec/controllers/facilities_management/rm3830/buyer_account_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/buyer_account_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuyerAccountController, type: :cont
 
       it 'sets the framework variables' do
         expect(assigns(:unrecognised_framework)).to eq 'RM31415'
-        expect(controller.params[:framework]).to eq FacilitiesManagement::DEFAULT_FRAMEWORK
+        expect(controller.params[:framework]).to eq FacilitiesManagement::Framework.default_framework
       end
     end
   end

--- a/spec/controllers/facilities_management/rm3830/supplier/dashboard_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/supplier/dashboard_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::DashboardController, type
 
       it 'sets the framework variables' do
         expect(assigns(:unrecognised_framework)).to eq '↑↑↓↓←→←→BA'
-        expect(controller.params[:framework]).to eq FacilitiesManagement::DEFAULT_FRAMEWORK
+        expect(controller.params[:framework]).to eq FacilitiesManagement::Framework.default_framework
       end
     end
   end

--- a/spec/factories/facilities_management/framework.rb
+++ b/spec/factories/facilities_management/framework.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :facilities_management_framework, class: 'FacilitiesManagement::Framework' do
+    id { SecureRandom.uuid }
+    framework { "FK#{Array.new(4) { rand(10) }.join}" }
+    live_at { Time.zone.now + 1.year }
+  end
+end

--- a/spec/models/facilities_management/frameworks_spec.rb
+++ b/spec/models/facilities_management/frameworks_spec.rb
@@ -1,0 +1,229 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::Framework, type: :model do
+  describe '.frameworks' do
+    it 'returns RM3830 ad RM6232' do
+      expect(described_class.frameworks).to eq ['RM3830', 'RM6232']
+    end
+  end
+
+  shared_context 'and RM6232 is live in the past' do
+    before { described_class.find_by(framework: 'RM6232').update(live_at: Time.zone.now - 1.day) }
+  end
+
+  shared_context 'and RM6232 is live today' do
+    before { described_class.find_by(framework: 'RM6232').update(live_at: Time.zone.now) }
+  end
+
+  describe '.live_frameworks' do
+    context 'when RM6232 goes live tomorrow' do
+      it 'returns only RM3830' do
+        expect(described_class.live_frameworks).to eq ['RM3830']
+      end
+    end
+
+    context 'when RM6232 is live today' do
+      include_context 'and RM6232 is live today'
+
+      it 'returns RM3830 and RM6232' do
+        expect(described_class.live_frameworks).to eq ['RM3830', 'RM6232']
+      end
+    end
+
+    context 'when RM6232 went live yesterday' do
+      include_context 'and RM6232 is live in the past'
+
+      it 'returns RM3830 and RM6232' do
+        expect(described_class.live_frameworks).to eq ['RM3830', 'RM6232']
+      end
+    end
+  end
+
+  describe '.default_framework' do
+    context 'when RM6232 goes live tomorrow' do
+      it 'returns RM3830' do
+        expect(described_class.default_framework).to eq 'RM3830'
+      end
+    end
+
+    context 'when RM6232 is live today' do
+      include_context 'and RM6232 is live today'
+
+      it 'returns RM6232' do
+        expect(described_class.default_framework).to eq 'RM6232'
+      end
+    end
+
+    context 'when RM6232 went live yesterday' do
+      include_context 'and RM6232 is live in the past'
+
+      it 'returns RM6232' do
+        expect(described_class.default_framework).to eq 'RM6232'
+      end
+    end
+  end
+
+  describe '.recognised_live_framework' do
+    context 'when the framework is RM3830' do
+      it 'returns true' do
+        expect(described_class.recognised_live_framework?('RM3830')).to be true
+      end
+    end
+
+    context 'when the framework is RM6232' do
+      context 'and RM6232 goes live tomorrow' do
+        it 'returns false' do
+          expect(described_class.recognised_live_framework?('RM6232')).to be false
+        end
+      end
+
+      context 'when RM6232 is live today' do
+        include_context 'and RM6232 is live today'
+
+        it 'returns true' do
+          expect(described_class.recognised_live_framework?('RM6232')).to be true
+        end
+      end
+
+      context 'and RM6232 went live yesterday' do
+        include_context 'and RM6232 is live in the past'
+
+        it 'returns true' do
+          expect(described_class.recognised_live_framework?('RM6232')).to be true
+        end
+      end
+    end
+
+    context 'when the framework is neither RM3830 ir RM6232' do
+      it 'returns false' do
+        expect(described_class.recognised_live_framework?('RM0087')).to be false
+      end
+    end
+  end
+
+  describe '.recognised_framework' do
+    context 'when the framework is RM3830' do
+      it 'returns true' do
+        expect(described_class.recognised_framework?('RM3830')).to be true
+      end
+    end
+
+    context 'when the framework is RM6232' do
+      context 'and RM6232 goes live tomorrow' do
+        it 'returns true' do
+          expect(described_class.recognised_framework?('RM6232')).to be true
+        end
+      end
+
+      context 'when RM6232 is live today' do
+        include_context 'and RM6232 is live today'
+
+        it 'returns true' do
+          expect(described_class.recognised_framework?('RM6232')).to be true
+        end
+      end
+
+      context 'and RM6232 went live yesterday' do
+        include_context 'and RM6232 is live in the past'
+
+        it 'returns true' do
+          expect(described_class.recognised_framework?('RM6232')).to be true
+        end
+      end
+    end
+
+    context 'when the framework is neither RM3830 ir RM6232' do
+      it 'returns false' do
+        expect(described_class.recognised_framework?('RM0087')).to be false
+      end
+    end
+  end
+
+  describe '.status' do
+    let(:framework) { create(:facilities_management_framework, live_at: live_at) }
+
+    context 'when the live_at date is before today' do
+      let(:live_at) { Time.zone.now - 1.day }
+
+      it 'returns live' do
+        expect(framework.status).to eq :live
+      end
+    end
+
+    context 'when the live_at date is today' do
+      let(:live_at) { Time.zone.now }
+
+      it 'returns live' do
+        expect(framework.status).to eq :live
+      end
+    end
+
+    context 'when the live_at date is after today' do
+      let(:live_at) { Time.zone.now + 1.day }
+
+      it 'returns coming' do
+        expect(framework.status).to eq :coming
+      end
+    end
+  end
+
+  describe 'validating the live at date' do
+    let(:framework) { create(:facilities_management_framework) }
+    let(:live_at) { Time.zone.now + 1.day }
+    let(:live_at_yyyy) { live_at.year.to_s }
+    let(:live_at_mm) { live_at.month.to_s }
+    let(:live_at_dd) { live_at.day.to_s }
+
+    before do
+      framework.live_at_yyyy = live_at_yyyy
+      framework.live_at_mm = live_at_mm
+      framework.live_at_dd = live_at_dd
+    end
+
+    context 'when considering live_at_yyyy and it is nil' do
+      let(:live_at_yyyy) { nil }
+
+      it 'is not valid and has the correct error message' do
+        expect(framework.valid?(:update)).to eq false
+        expect(framework.errors[:live_at].first).to eq 'Enter a valid \'live at\' date'
+      end
+    end
+
+    context 'when considering live_at_mm and it is blank' do
+      let(:live_at_mm) { '' }
+
+      it 'is not valid and has the correct error message' do
+        expect(framework.valid?(:update)).to eq false
+        expect(framework.errors[:live_at].first).to eq 'Enter a valid \'live at\' date'
+      end
+    end
+
+    context 'when considering live_at_dd and it is empty' do
+      let(:live_at_dd) { '    ' }
+
+      it 'is not valid and has the correct error message' do
+        expect(framework.valid?(:update)).to eq false
+        expect(framework.errors[:live_at].first).to eq 'Enter a valid \'live at\' date'
+      end
+    end
+
+    context 'when considering the full live_at' do
+      context 'and it is not a real date' do
+        let(:live_at_yyyy) { live_at.year.to_s }
+        let(:live_at_mm) { '2' }
+        let(:live_at_dd) { '30' }
+
+        it 'is not valid and has the correct error message' do
+          expect(framework.valid?(:update)).to eq false
+          expect(framework.errors[:live_at].first).to eq 'Enter a valid \'live at\' date'
+        end
+      end
+
+      context 'and it is a real date' do
+        it 'is valid' do
+          expect(framework.valid?(:update)).to eq true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: [FMFR-1144](https://crowncommercialservice.atlassian.net/browse/FMFR-1144)

The purpose of this is so that we don't have to manage the status of frameworks through environment variables. By creating a table in the database we can have a dynamic list of frameworks that also include the 'live at' date which we can change to show or hide the new framework.

In addition, I created a tool in the admin section (`facilities-management/admin/frameworks`) which will allow us to change the 'live at' date without the need for a deployment. This is not available on the production environment as that should be done through the static task only to keep it fixed.

Environment variable changes:
| Environment variable | New value |
| --------------------- | ------------------- |
| `/Environment/ccs/cmp/APP_RUN_RAKE_TASKS`| `TRUE` |
| `/Environment/ccs/cmp/RAKE_TASK_LIST` | `db:fm_frameworks` |