### PR TITLE
FMFR-1126 - Add config to limit the name of hosts in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,4 +95,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Prevents against DNS rebinding and other Host header attacks.
+  config.hosts << ENV['ENVIRONMENT_HOST']
 end


### PR DESCRIPTION
Ticket: [FMFR-1126](https://crowncommercialservice.atlassian.net/browse/FMFR-1126)

See [actiondispatch-hostauthorization](https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization) for details.

This should prevents against DNS rebinding and other `Host` header attacks.

The following environment variables need to be set:

Environment | `/Environment/global/ENVIRONMENT_HOST` value
-- | --
cmpdev | `.cmp.cmpdev.crowncommercial.gov.uk`
sandbox | `.cmp.cmp-sandbox.crowncommercial.gov.uk`
preview | `.marketplace.preview.crowncommercial.gov.uk`
production | `.marketplace.service.crowncommercial.gov.uk`

