### PR TITLE
Change to `cancancan` as `cancan` is no longer supported

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'sinatra', '~> 2.2.0', require: false
 gem 'slim', '~> 4.1.0'
 
 # for authorization
-gem 'cancan', '~> 1.6.10'
+gem 'cancancan', '~> 3.2.0'
 
 gem 'role_model', '~> 0.8.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
-    cancan (1.6.10)
+    cancancan (3.2.2)
     capybara (3.36.0)
       addressable
       matrix
@@ -606,7 +606,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bullet
   byebug
-  cancan (~> 1.6.10)
+  cancancan (~> 3.2.0)
   capybara (>= 3.35.3)
   caracal-rails (>= 1.0.2)
   caxlsx (>= 3.1.0)


### PR DESCRIPTION
The purpose of this PR is to change from using `cancan` to `cancancan` due to the former no longer being supported anymore. as `cancancan` is based off of `cancan` we do not require any additional changes and we have tests for permissions which verify that they all still working as expected.