### PR TITLE
FMFR-TBA - Add methods and services to select the suppliers

### DIFF
--- a/app/models/facilities_management/rm6232/service.rb
+++ b/app/models/facilities_management/rm6232/service.rb
@@ -2,6 +2,51 @@ module FacilitiesManagement
   module RM6232
     class Service < ApplicationRecord
       belongs_to :work_package, foreign_key: :work_package_code, inverse_of: :services
+
+      def self.find_lot_number(service_codes, annual_contract_value)
+        lot_number = determine_lot_number(service_codes)
+
+        "#{lot_number}#{determine_lot_code(lot_number, annual_contract_value)}"
+      end
+
+      def self.determine_lot_number(service_codes)
+        service_count = where(code: service_codes).count
+        hard_fm_service_count = where(code: service_codes, hard: true).count
+        soft_fm_service_count = where(code: service_codes, soft: true).count
+
+        if hard_fm_service_count == service_count && soft_fm_service_count < hard_fm_service_count
+          # HARD FM
+          '2'
+        elsif soft_fm_service_count == service_count && hard_fm_service_count < service_count
+          # SOFT FM
+          '3'
+        else
+          # TOTAL FM
+          '1'
+        end
+      end
+
+      def self.determine_lot_code(lot_number, annual_contract_value)
+        if lot_number == '3'
+          case annual_contract_value
+          when 0..1_000_000
+            'a'
+          when 1_000_000..7_000_000
+            'b'
+          else
+            'c'
+          end
+        else
+          case annual_contract_value
+          when 0..1_500_000
+            'a'
+          when 1_500_000..10_000_000
+            'b'
+          else
+            'c'
+          end
+        end
+      end
     end
   end
 end

--- a/app/models/facilities_management/rm6232/supplier.rb
+++ b/app/models/facilities_management/rm6232/supplier.rb
@@ -2,6 +2,14 @@ module FacilitiesManagement
   module RM6232
     class Supplier < ApplicationRecord
       has_many :lot_data, inverse_of: :supplier, class_name: 'FacilitiesManagement::RM6232::Supplier::LotData', dependent: :destroy, foreign_key: :facilities_management_rm6232_supplier_id
+
+      def self.select_suppliers(lot_code, service_codes, region_codes)
+        joins(:lot_data)
+          .where('facilities_management_rm6232_supplier_lot_data.lot_code': lot_code)
+          .where('facilities_management_rm6232_supplier_lot_data.service_codes @> ?', "{#{service_codes.join(',')}}")
+          .where('facilities_management_rm6232_supplier_lot_data.region_codes @> ?', "{#{region_codes.join(',')}}")
+          .order(:supplier_name)
+      end
     end
   end
 end

--- a/app/services/facilities_management/rm6232/suppliers_selector.rb
+++ b/app/services/facilities_management/rm6232/suppliers_selector.rb
@@ -1,0 +1,10 @@
+module FacilitiesManagement::RM6232
+  class SuppliersSelector
+    attr_reader :lot_number, :selected_suppliers
+
+    def initialize(service_codes, region_codes, annual_contract_value)
+      @lot_number = Service.find_lot_number(service_codes, annual_contract_value)
+      @selected_suppliers = Supplier.select_suppliers(@lot_number.last, service_codes, region_codes)
+    end
+  end
+end

--- a/spec/factories/facilities_management/rm6232/supplier.rb
+++ b/spec/factories/facilities_management/rm6232/supplier.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :facilities_management_rm6232_supplier, class: 'FacilitiesManagement::RM6232::Supplier' do
+    id { SecureRandom.uuid }
+    supplier_name { Faker::Company.unique.name }
+    contact_name { Faker::Name.unique.name }
+    contact_email { Faker::Internet.unique.email }
+    contact_phone { Faker::PhoneNumber.unique.phone_number }
+    sme { true }
+    duns { Faker::Company.unique.duns_number.gsub('-', '') }
+    registration_number { '0123456' }
+    address_line_1 { Faker::Address.street_address }
+    address_line_2 { Faker::Address.street_name }
+    address_town { Faker::Address.city }
+    address_county { Faker::Address.county }
+    address_postcode { Faker::Address.postcode }
+    lot_data { build_list :facilities_management_rm6232_supplier_lot_data, 1 }
+  end
+end

--- a/spec/factories/facilities_management/rm6232/supplier/lot_data.rb
+++ b/spec/factories/facilities_management/rm6232/supplier/lot_data.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :facilities_management_rm6232_supplier_lot_data, class: 'FacilitiesManagement::RM6232::Supplier::LotData' do
+    id { SecureRandom.uuid }
+    lot_code { 'a' }
+    service_codes { %w[E.16 H.6 P.11] }
+    region_codes { %w[UKC1 UKD1 UKE1] }
+  end
+end

--- a/spec/models/facilities_management/rm6232/service_spec.rb
+++ b/spec/models/facilities_management/rm6232/service_spec.rb
@@ -44,4 +44,403 @@ RSpec.describe FacilitiesManagement::RM6232::Service, type: :model do
       end
     end
   end
+
+  describe '.determine_lot_code' do
+    let(:result) { described_class.determine_lot_code(lot_number, annual_contract_value) }
+
+    context 'when the lot number is 1' do
+      let(:lot_number) { '1' }
+
+      context 'when the annual_contract_value is less than 1,500,000' do
+        let(:annual_contract_value) { rand(1_500_000) }
+
+        it 'returns a' do
+          expect(result).to eq 'a'
+        end
+      end
+
+      context 'when the annual_contract_value is 1,500,000' do
+        let(:annual_contract_value) { 1_500_000 }
+
+        it 'returns a' do
+          expect(result).to eq 'a'
+        end
+      end
+
+      context 'when the annual_contract_value is a little more than 1,500,000' do
+        let(:annual_contract_value) { 1_500_001 }
+
+        it 'returns b' do
+          expect(result).to eq 'b'
+        end
+      end
+
+      context 'when the annual_contract_value is a more than 1,500,000 and less than 10,000,000' do
+        let(:annual_contract_value) { rand(1_500_000...10_000_000) }
+
+        it 'returns b' do
+          expect(result).to eq 'b'
+        end
+      end
+
+      context 'when the annual_contract_value is 10,000,000' do
+        let(:annual_contract_value) { 10_000_000 }
+
+        it 'returns b' do
+          expect(result).to eq 'b'
+        end
+      end
+
+      context 'when the annual_contract_value is a little more than 10,000,000' do
+        let(:annual_contract_value) { 10_000_001 }
+
+        it 'returns c' do
+          expect(result).to eq 'c'
+        end
+      end
+
+      context 'when the annual_contract_value is more than 10,000,000' do
+        let(:annual_contract_value) { rand(10_000_000...50_000_000) }
+
+        it 'returns c' do
+          expect(result).to eq 'c'
+        end
+      end
+    end
+
+    context 'when the lot number is 2' do
+      let(:lot_number) { '2' }
+
+      context 'when the annual_contract_value is less than 1,500,000' do
+        let(:annual_contract_value) { rand(1_500_000) }
+
+        it 'returns a' do
+          expect(result).to eq 'a'
+        end
+      end
+
+      context 'when the annual_contract_value is 1,500,000' do
+        let(:annual_contract_value) { 1_500_000 }
+
+        it 'returns a' do
+          expect(result).to eq 'a'
+        end
+      end
+
+      context 'when the annual_contract_value is a little more than 1,500,000' do
+        let(:annual_contract_value) { 1_500_001 }
+
+        it 'returns b' do
+          expect(result).to eq 'b'
+        end
+      end
+
+      context 'when the annual_contract_value is a more than 1,500,000 and less than 10,000,000' do
+        let(:annual_contract_value) { rand(1_500_000...10_000_000) }
+
+        it 'returns b' do
+          expect(result).to eq 'b'
+        end
+      end
+
+      context 'when the annual_contract_value is 10,000,000' do
+        let(:annual_contract_value) { 10_000_000 }
+
+        it 'returns b' do
+          expect(result).to eq 'b'
+        end
+      end
+
+      context 'when the annual_contract_value is a little more than 10,000,000' do
+        let(:annual_contract_value) { 10_000_001 }
+
+        it 'returns c' do
+          expect(result).to eq 'c'
+        end
+      end
+
+      context 'when the annual_contract_value is more than 10,000,000' do
+        let(:annual_contract_value) { rand(10_000_000...50_000_000) }
+
+        it 'returns c' do
+          expect(result).to eq 'c'
+        end
+      end
+    end
+
+    context 'when the lot number is 3' do
+      let(:lot_number) { '3' }
+
+      context 'when the annual_contract_value is less than 1,000,000' do
+        let(:annual_contract_value) { rand(1_000_000) }
+
+        it 'returns a' do
+          expect(result).to eq 'a'
+        end
+      end
+
+      context 'when the annual_contract_value is 1,000,000' do
+        let(:annual_contract_value) { 1_000_000 }
+
+        it 'returns a' do
+          expect(result).to eq 'a'
+        end
+      end
+
+      context 'when the annual_contract_value is a little more than 1,000,000' do
+        let(:annual_contract_value) { 1_000_001 }
+
+        it 'returns b' do
+          expect(result).to eq 'b'
+        end
+      end
+
+      context 'when the annual_contract_value is a more than 1,000,000 and less than 7,000,000' do
+        let(:annual_contract_value) { rand(1_000_000...7_000_000) }
+
+        it 'returns b' do
+          expect(result).to eq 'b'
+        end
+      end
+
+      context 'when the annual_contract_value is 7,000,000' do
+        let(:annual_contract_value) { 7_000_000 }
+
+        it 'returns b' do
+          expect(result).to eq 'b'
+        end
+      end
+
+      context 'when the annual_contract_value is a little more than 7,000,000' do
+        let(:annual_contract_value) { 7_000_001 }
+
+        it 'returns c' do
+          expect(result).to eq 'c'
+        end
+      end
+
+      context 'when the annual_contract_value is more than 7,000,000' do
+        let(:annual_contract_value) { rand(7_000_000...50_000_000) }
+
+        it 'returns c' do
+          expect(result).to eq 'c'
+        end
+      end
+    end
+  end
+
+  describe '.determine_lot_number' do
+    let(:selection_one) { { total: false, hard: false, soft: false } }
+    let(:selection_one_sample) { 3 }
+    let(:selection_two) { { total: false, hard: false, soft: false } }
+    let(:selection_two_sample) { 3 }
+    let(:service_codes) { described_class.where(**selection_one).sample(selection_one_sample).pluck(:code) + described_class.where(**selection_two).sample(selection_two_sample).pluck(:code) }
+
+    let(:result) { described_class.determine_lot_number(service_codes) }
+
+    context 'when all services are hard' do
+      let(:selection_one) { { total: true, hard: true, soft: false } }
+      let(:selection_one_sample) { 5 }
+
+      it 'returns 2 (hard)' do
+        expect(result).to eq '2'
+      end
+    end
+
+    context 'when all services are soft' do
+      let(:selection_one) { { total: true, hard: false, soft: true } }
+      let(:selection_one_sample) { 5 }
+
+      it 'returns 3 (soft)' do
+        expect(result).to eq '3'
+      end
+    end
+
+    context 'when all services are just total' do
+      let(:selection_one) { { total: true, hard: false, soft: false } }
+      let(:selection_one_sample) { 5 }
+
+      it 'returns 1 (total)' do
+        expect(result).to eq '1'
+      end
+    end
+
+    context 'when there are hard services with some that are just total' do
+      let(:selection_one) { { total: true, hard: true, soft: false } }
+      let(:selection_two) { { total: true, hard: false, soft: false } }
+
+      it 'returns 1 (total)' do
+        expect(result).to eq '1'
+      end
+    end
+
+    context 'when there are hard services with some that are total with soft' do
+      let(:selection_one) { { total: true, hard: true, soft: false } }
+      let(:selection_two) { { total: true, hard: true, soft: true } }
+
+      it 'returns 2 (hard)' do
+        expect(result).to eq '2'
+      end
+    end
+
+    context 'when there are soft services with some that are just total' do
+      let(:selection_one) { { total: true, hard: false, soft: true } }
+      let(:selection_two) { { total: true, hard: false, soft: false } }
+
+      it 'returns 1 (total)' do
+        expect(result).to eq '1'
+      end
+    end
+
+    context 'when there are soft services with some that are total with hard' do
+      let(:selection_one) { { total: true, hard: false, soft: true } }
+      let(:selection_two) { { total: true, hard: true, soft: true } }
+
+      it 'returns 3 (soft)' do
+        expect(result).to eq '3'
+      end
+    end
+
+    context 'when there are total services with some that are hard and soft' do
+      let(:selection_one) { { total: true, hard: false, soft: true } }
+      let(:selection_two) { { total: true, hard: true, soft: false } }
+
+      it 'returns 1 (total)' do
+        expect(result).to eq '1'
+      end
+    end
+
+    context 'when there are soft and hard services' do
+      let(:selection_one) { { total: true, hard: true, soft: false } }
+      let(:selection_two) { { total: true, hard: false, soft: true } }
+
+      it 'returns 1 (total)' do
+        expect(result).to eq '1'
+      end
+    end
+
+    context 'when there are total services which are hard and soft' do
+      let(:selection_one) { { total: true, hard: true, soft: true } }
+      let(:selection_one_sample) { 5 }
+
+      it 'returns 1 (total)' do
+        expect(result).to eq '1'
+      end
+    end
+
+    context 'when there are total services which are hard and soft with one hard service' do
+      let(:selection_one) { { total: true, hard: true, soft: true } }
+      let(:selection_two) { { total: true, hard: true, soft: false } }
+      let(:selection_one_sample) { 5 }
+      let(:selection_two_sample) { 1 }
+
+      it 'returns 2 (hard)' do
+        expect(result).to eq '2'
+      end
+    end
+
+    context 'when there are total services which are hard and soft with one soft service' do
+      let(:selection_one) { { total: true, hard: true, soft: true } }
+      let(:selection_two) { { total: true, hard: false, soft: true } }
+      let(:selection_one_sample) { 5 }
+      let(:selection_two_sample) { 1 }
+
+      it 'returns 3 (soft)' do
+        expect(result).to eq '3'
+      end
+    end
+  end
+
+  describe '.find_lot_number' do
+    let(:selection_one) { { total: false, hard: false, soft: false } }
+    let(:selection_two) { { total: false, hard: false, soft: false } }
+    let(:service_codes) { described_class.where(**selection_one).sample(3).pluck(:code) + described_class.where(**selection_two).sample(3).pluck(:code) }
+
+    let(:result) { described_class.find_lot_number(service_codes, annual_contract_value) }
+
+    context 'when all services are hard' do
+      let(:selection_one) { { total: true, hard: true, soft: false } }
+
+      context 'and the annual_contract_value is less than 1,500,000' do
+        let(:annual_contract_value) { rand(1_500_000) }
+
+        it 'returns 2a' do
+          expect(result).to eq '2a'
+        end
+      end
+
+      context 'and the annual_contract_value is a more than 1,500,000 and less than 10,000,000' do
+        let(:annual_contract_value) { rand(1_500_000...10_000_000) }
+
+        it 'returns 2b' do
+          expect(result).to eq '2b'
+        end
+      end
+
+      context 'and the annual_contract_value is more than 10,000,000' do
+        let(:annual_contract_value) { rand(10_000_000...50_000_000) }
+
+        it 'returns 2c' do
+          expect(result).to eq '2c'
+        end
+      end
+    end
+
+    context 'when all services are soft' do
+      let(:selection_one) { { total: true, hard: false, soft: true } }
+
+      context 'and the annual_contract_value is less than 1,000,000' do
+        let(:annual_contract_value) { rand(1_000_000) }
+
+        it 'returns 3a' do
+          expect(result).to eq '3a'
+        end
+      end
+
+      context 'and the annual_contract_value is a more than 1,000,000 and less than 7,000,000' do
+        let(:annual_contract_value) { rand(1_000_000...7_000_000) }
+
+        it 'returns 3b' do
+          expect(result).to eq '3b'
+        end
+      end
+
+      context 'and the annual_contract_value is more than 7,000,000' do
+        let(:annual_contract_value) { rand(7_000_000...50_000_000) }
+
+        it 'returns 3c' do
+          expect(result).to eq '3c'
+        end
+      end
+    end
+
+    context 'when there are a mix of hard and soft' do
+      let(:selection_one) { { total: true, hard: true, soft: false } }
+      let(:selection_two) { { total: true, hard: false, soft: true } }
+
+      context 'and the annual_contract_value is less than 1,500,000' do
+        let(:annual_contract_value) { rand(1_500_000) }
+
+        it 'returns 1a' do
+          expect(result).to eq '1a'
+        end
+      end
+
+      context 'and the annual_contract_value is a more than 1,500,000 and less than 10,000,000' do
+        let(:annual_contract_value) { rand(1_500_000...10_000_000) }
+
+        it 'returns 1b' do
+          expect(result).to eq '1b'
+        end
+      end
+
+      context 'and the annual_contract_value is more than 10,000,000' do
+        let(:annual_contract_value) { rand(10_000_000...50_000_000) }
+
+        it 'returns 1c' do
+          expect(result).to eq '1c'
+        end
+      end
+    end
+  end
 end

--- a/spec/models/facilities_management/rm6232/supplier_spec.rb
+++ b/spec/models/facilities_management/rm6232/supplier_spec.rb
@@ -16,4 +16,189 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
       end
     end
   end
+
+  # rubocop:disable RSpec/NestedGroups
+  describe '.select_suppliers' do
+    let(:result) { described_class.select_suppliers(lot_code, service_codes[..-3], region_codes[..2]) }
+    let(:supplier_names) { result.map(&:supplier_name) }
+
+    let(:my_supplier) do
+      create(:facilities_management_rm6232_supplier) do |supplier|
+        supplier.lot_data = build_list(:facilities_management_rm6232_supplier_lot_data, 1, lot_code: lot_code, service_codes: supplier_services, region_codes: supplier_regions)
+      end
+    end
+
+    let(:selection_two) { { total: false, hard: false, soft: false } }
+    let(:service_codes) { FacilitiesManagement::RM6232::Service.where(**selection_one).sample(5).pluck(:code) + FacilitiesManagement::RM6232::Service.where(**selection_two).sample(5).pluck(:code) }
+    let(:region_codes) { FacilitiesManagement::Region.all[..-2].sample(5).map(&:code) }
+
+    context 'when all the inputs are nil' do
+      let(:lot_code) { nil }
+      let(:service_codes) { [] }
+      let(:region_codes) { [] }
+
+      it 'returns nothing' do
+        expect(result).to be_empty
+      end
+    end
+
+    context 'when all the inputs are present' do
+      let(:supplier_services) { service_codes }
+      let(:supplier_regions) { region_codes }
+
+      before { my_supplier }
+
+      context 'when Total FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+        let(:selection_two) { { total: true, hard: false, soft: true } }
+
+        context 'and the lot code is a (lot: 1a)' do
+          let(:lot_code) { 'a' }
+
+          it 'returns a list of suppliers that includes my_supplier' do
+            expect(supplier_names).to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and the lot code is b (lot: 1b)' do
+          let(:lot_code) { 'b' }
+
+          it 'returns a list of suppliers that includes my_supplier' do
+            expect(supplier_names).to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and the lot code is c (lot: 1c)' do
+          let(:lot_code) { 'c' }
+
+          it 'returns a list of suppliers that includes my_supplier' do
+            expect(supplier_names).to include my_supplier.supplier_name
+          end
+        end
+      end
+
+      context 'when Hard FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+
+        context 'and the lot code is a (lot: 2a)' do
+          let(:lot_code) { 'a' }
+
+          it 'returns a list of suppliers that includes my_supplier' do
+            expect(supplier_names).to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and the lot code is b (lot: 2b)' do
+          let(:lot_code) { 'b' }
+
+          it 'returns a list of suppliers that includes my_supplier' do
+            expect(supplier_names).to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and the lot code is c (lot: 2c)' do
+          let(:lot_code) { 'c' }
+
+          it 'returns a list of suppliers that includes my_supplier' do
+            expect(supplier_names).to include my_supplier.supplier_name
+          end
+        end
+      end
+
+      context 'when Soft FM services are selected' do
+        let(:selection_one) { { total: true, hard: false, soft: true } }
+
+        context 'and the lot code is a (lot: 3a)' do
+          let(:lot_code) { 'a' }
+
+          it 'returns a list of suppliers that includes my_supplier' do
+            expect(supplier_names).to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and the lot code is b (lot: 3b)' do
+          let(:lot_code) { 'b' }
+
+          it 'returns a list of suppliers that includes my_supplier' do
+            expect(supplier_names).to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and the lot code is c (lot: 3c)' do
+          let(:lot_code) { 'c' }
+
+          it 'returns a list of suppliers that includes my_supplier' do
+            expect(supplier_names).to include my_supplier.supplier_name
+          end
+        end
+      end
+    end
+
+    context 'when my_supplier does not provide all the services' do
+      let(:lot_code) { 'a' }
+      let(:supplier_services) { service_codes[..-4] }
+      let(:supplier_regions) { region_codes }
+
+      before { my_supplier }
+
+      context 'when Total FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+        let(:selection_two) { { total: true, hard: false, soft: true } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+
+      context 'when Hard FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+
+      context 'when Soft FM services are selected' do
+        let(:selection_one) { { total: true, hard: false, soft: true } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+    end
+
+    context 'when my_supplier does not provide for all the regions' do
+      let(:lot_code) { 'a' }
+      let(:supplier_services) { service_codes }
+      let(:supplier_regions) { region_codes[-3..] }
+
+      before { my_supplier }
+
+      context 'when Total FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+        let(:selection_two) { { total: true, hard: false, soft: true } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+
+      context 'when Hard FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+
+      context 'when Soft FM services are selected' do
+        let(:selection_one) { { total: true, hard: false, soft: true } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/NestedGroups
 end

--- a/spec/services/facilities_management/rm6232/suppliers_selector_spec.rb
+++ b/spec/services/facilities_management/rm6232/suppliers_selector_spec.rb
@@ -1,0 +1,250 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
+  subject(:suppliers_selector) { described_class.new(service_codes[..-3], region_codes[..2], annual_contract_value) }
+
+  let(:lot_number) { suppliers_selector.lot_number }
+  let(:supplier_names) { suppliers_selector.selected_suppliers.map(&:supplier_name) }
+
+  let!(:my_supplier) do
+    create(:facilities_management_rm6232_supplier) do |supplier|
+      supplier.lot_data = build_list(:facilities_management_rm6232_supplier_lot_data, 1, lot_code: lot_code, service_codes: supplier_services, region_codes: supplier_regions)
+    end
+  end
+
+  let(:selection_one) { { total: false, hard: false, soft: false } }
+  let(:selection_two) { { total: false, hard: false, soft: false } }
+  let(:service_codes) { FacilitiesManagement::RM6232::Service.where(**selection_one).sample(5).pluck(:code) + FacilitiesManagement::RM6232::Service.where(**selection_two).sample(5).pluck(:code) }
+  let(:region_codes) { FacilitiesManagement::Region.all[..-2].sample(5).map(&:code) }
+  let(:supplier_services) { service_codes }
+  let(:supplier_regions) { region_codes }
+
+  describe 'lot number and selected suppliers' do
+    context 'when all services are hard' do
+      let(:selection_one) { { total: true, hard: true, soft: false } }
+
+      context 'and the annual_contract_value is less than 1,500,000' do
+        let(:lot_code) { 'a' }
+        let(:annual_contract_value) { rand(1_500_000) }
+
+        it 'returns 2a for the lot number' do
+          expect(lot_number).to eq '2a'
+        end
+
+        it 'returns a list of suppliers that includes my_supplier' do
+          expect(supplier_names).to include my_supplier.supplier_name
+        end
+      end
+
+      context 'and the annual_contract_value is a more than 1,500,000 and less than 10,000,000' do
+        let(:lot_code) { 'b' }
+        let(:annual_contract_value) { rand(1_500_000...10_000_000) }
+
+        it 'returns 2b for the lot number' do
+          expect(lot_number).to eq '2b'
+        end
+
+        it 'returns a list of suppliers that includes my_supplier' do
+          expect(supplier_names).to include my_supplier.supplier_name
+        end
+      end
+
+      context 'and the annual_contract_value is more than 10,000,000' do
+        let(:lot_code) { 'c' }
+        let(:annual_contract_value) { rand(10_000_000...50_000_000) }
+
+        it 'returns 2c for the lot number' do
+          expect(lot_number).to eq '2c'
+        end
+
+        it 'returns a list of suppliers that includes my_supplier' do
+          expect(supplier_names).to include my_supplier.supplier_name
+        end
+      end
+    end
+
+    context 'when all services are soft' do
+      let(:selection_one) { { total: true, hard: false, soft: true } }
+
+      context 'and the annual_contract_value is less than 1,000,000' do
+        let(:lot_code) { 'a' }
+        let(:annual_contract_value) { rand(1_000_000) }
+
+        it 'returns 3a for the lot number' do
+          expect(lot_number).to eq '3a'
+        end
+
+        it 'returns a list of suppliers that includes my_supplier' do
+          expect(supplier_names).to include my_supplier.supplier_name
+        end
+      end
+
+      context 'and the annual_contract_value is a more than 1,000,000 and less than 7,000,000' do
+        let(:lot_code) { 'b' }
+        let(:annual_contract_value) { rand(1_000_000...7_000_000) }
+
+        it 'returns 3b for the lot number' do
+          expect(lot_number).to eq '3b'
+        end
+
+        it 'returns a list of suppliers that includes my_supplier' do
+          expect(supplier_names).to include my_supplier.supplier_name
+        end
+      end
+
+      context 'and the annual_contract_value is more than 7,000,000' do
+        let(:lot_code) { 'c' }
+        let(:annual_contract_value) { rand(7_000_000...50_000_000) }
+
+        it 'returns 3c for the lot number' do
+          expect(lot_number).to eq '3c'
+        end
+
+        it 'returns a list of suppliers that includes my_supplier' do
+          expect(supplier_names).to include my_supplier.supplier_name
+        end
+      end
+    end
+
+    context 'when there are a mix of hard and soft' do
+      let(:selection_one) { { total: true, hard: true, soft: false } }
+      let(:selection_two) { { total: true, hard: false, soft: true } }
+
+      context 'and the annual_contract_value is less than 1,500,000' do
+        let(:lot_code) { 'a' }
+        let(:annual_contract_value) { rand(1_500_000) }
+
+        it 'returns 1a for the lot number' do
+          expect(lot_number).to eq '1a'
+        end
+
+        it 'returns a list of suppliers that includes my_supplier' do
+          expect(supplier_names).to include my_supplier.supplier_name
+        end
+      end
+
+      context 'and the annual_contract_value is a more than 1,500,000 and less than 10,000,000' do
+        let(:lot_code) { 'b' }
+        let(:annual_contract_value) { rand(1_500_000...10_000_000) }
+
+        it 'returns 1b for the lot number' do
+          expect(lot_number).to eq '1b'
+        end
+
+        it 'returns a list of suppliers that includes my_supplier' do
+          expect(supplier_names).to include my_supplier.supplier_name
+        end
+      end
+
+      context 'and the annual_contract_value is more than 10,000,000' do
+        let(:lot_code) { 'c' }
+        let(:annual_contract_value) { rand(10_000_000...50_000_000) }
+
+        it 'returns 1c for the lot number' do
+          expect(lot_number).to eq '1c'
+        end
+
+        it 'returns a list of suppliers that includes my_supplier' do
+          expect(supplier_names).to include my_supplier.supplier_name
+        end
+      end
+    end
+
+    context 'when my_supplier does not provide the lot' do
+      let(:lot_code) { 'b' }
+      let(:annual_contract_value) { rand(1_000_000) }
+
+      context 'when Total FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+        let(:selection_two) { { total: true, hard: false, soft: true } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(lot_number).to eq '1a'
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+
+      context 'when Hard FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(lot_number).to eq '2a'
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+
+      context 'when Soft FM services are selected' do
+        let(:selection_one) { { total: true, hard: false, soft: true } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(lot_number).to eq '3a'
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+    end
+
+    context 'when my_supplier does not provide all the services' do
+      let(:lot_code) { 'a' }
+      let(:annual_contract_value) { rand(1_500_000) }
+      let(:supplier_services) { service_codes[..-4] }
+      let(:supplier_regions) { region_codes }
+
+      context 'when Total FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+        let(:selection_two) { { total: true, hard: false, soft: true } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+
+      context 'when Hard FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+
+      context 'when Soft FM services are selected' do
+        let(:selection_one) { { total: true, hard: false, soft: true } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+    end
+
+    context 'when my_supplier does not provide for all the regions' do
+      let(:lot_code) { 'a' }
+      let(:annual_contract_value) { rand(1_500_000) }
+      let(:supplier_services) { service_codes }
+      let(:supplier_regions) { region_codes[-3..] }
+
+      context 'when Total FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+        let(:selection_two) { { total: true, hard: false, soft: true } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+
+      context 'when Hard FM services are selected' do
+        let(:selection_one) { { total: true, hard: true, soft: false } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+
+      context 'when Soft FM services are selected' do
+        let(:selection_one) { { total: true, hard: false, soft: true } }
+
+        it 'returns a list of suppliers that does not include my_supplier' do
+          expect(supplier_names).not_to include my_supplier.supplier_name
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: TBA

As the user testing will mainly deal with the frontend, I thought it would be worth developing the service to select the services based on the potential user input.

As part of this I:
- added methods to the service model to determine the lot number
- added a method to the supplier model to search for the suppliers who meet the requirements
- added the SuppliersSelector which deals with the logic of getting the lot number and suppliers