### PR TITLE
FMFR-1005 - Add the basic pages for the admin section

### DIFF
--- a/app/controllers/facilities_management/rm6232/admin/home_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/home_controller.rb
@@ -1,0 +1,19 @@
+module FacilitiesManagement
+  module RM6232
+    module Admin
+      class HomeController < FacilitiesManagement::Admin::FrameworkController
+        before_action :redirect_if_needed, :authenticate_user!, :authorize_user
+
+        def index
+          @current_login_email = current_user.email.to_s
+        end
+
+        private
+
+        def redirect_if_needed
+          redirect_to facilities_management_rm6232_admin_new_user_session_path unless user_signed_in?
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/facilities_management/rm6232/admin/passwords_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/passwords_controller.rb
@@ -1,0 +1,21 @@
+module FacilitiesManagement
+  module RM6232
+    module Admin
+      class PasswordsController < Base::PasswordsController
+        protected
+
+        def new_password_path
+          facilities_management_rm6232_admin_new_user_password_path
+        end
+
+        def after_password_reset_path
+          facilities_management_rm6232_admin_password_reset_success_path
+        end
+
+        def after_request_password_path
+          facilities_management_rm6232_admin_edit_user_password_path
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/facilities_management/rm6232/admin/sessions_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/sessions_controller.rb
@@ -1,0 +1,39 @@
+module FacilitiesManagement
+  module RM6232
+    module Admin
+      class SessionsController < Base::SessionsController
+        protected
+
+        def service_challenge_path
+          facilities_management_rm6232_admin_users_challenge_path(challenge_name: @result.challenge_name)
+        end
+
+        # rubocop:disable Lint/UnusedMethodArgument
+        def after_sign_in_path_for(resource)
+          # keep these lines for the moment, to remind us to use the logic as when a regular user signs in
+          #  return edit_facilities_management_buyer_detail_path(FacilitiesManagement::BuyerDetail.find_or_create_by(user: current_user)) if current_user.fm_buyer_details_incomplete?
+
+          # stored_location_for(resource) || facilities_management_6232_path
+          facilities_management_rm6232_admin_path
+        end
+        # rubocop:enable Lint/UnusedMethodArgument
+
+        def after_sign_out_path_for(_resource)
+          facilities_management_rm6232_admin_new_user_session_path
+        end
+
+        def new_session_path
+          facilities_management_rm6232_admin_new_user_session_path
+        end
+
+        def confirm_forgot_password_path
+          facilities_management_rm6232_admin_edit_user_password_path
+        end
+
+        def confirm_email_path
+          facilities_management_rm6232_admin_users_confirm_path
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/facilities_management/rm6232/admin/users_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/users_controller.rb
@@ -1,0 +1,21 @@
+module FacilitiesManagement
+  module RM6232
+    module Admin
+      class UsersController < Base::UsersController
+        private
+
+        def new_service_challenge_path
+          facilities_management_rm6232_admin_users_challenge_path(challenge_name: @challenge.new_challenge_name)
+        end
+
+        def after_sign_in_path_for(resource)
+          stored_location_for(resource) || facilities_management_rm6232_admin_path
+        end
+
+        def confirm_user_registration_path
+          facilities_management_rm6232_admin_users_confirm_path
+        end
+      end
+    end
+  end
+end

--- a/app/views/facilities_management/rm6232/admin/home/index.html.erb
+++ b/app/views/facilities_management/rm6232/admin/home/index.html.erb
@@ -1,0 +1,19 @@
+<%= content_for :page_title, t('.header') %>
+<div class="govuk-body">
+  <div class="govuk-grid-row govuk-!-padding-left-3">
+    <span class="govuk-caption-l"><%= @current_login_email %></span>
+    <h1 class="govuk-heading-xl"><%= t('.header') %></span>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-heading-m govuk-!-margin-top-5 govuk-!-margin-bottom-1"><%= t('.supplier_data') %></span>
+    </div>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
+  <%= ccs_account_panel_row do %>
+    <%= ccs_account_panel(t('.supplier_data'), '#') do %>
+      <%= t('.manage_supplier_data') %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/facilities_management/rm6232/admin/passwords/edit.html.erb
+++ b/app/views/facilities_management/rm6232/admin/passwords/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "shared/passwords/edit", locals: {local_edit_path: facilities_management_rm6232_admin_edit_user_password_path} %>

--- a/app/views/facilities_management/rm6232/admin/passwords/forgot_password_confirmation.html.erb
+++ b/app/views/facilities_management/rm6232/admin/passwords/forgot_password_confirmation.html.erb
@@ -1,0 +1,1 @@
+<%= render "shared/passwords/forgot_password_confirmation" %>>

--- a/app/views/facilities_management/rm6232/admin/passwords/new.html.erb
+++ b/app/views/facilities_management/rm6232/admin/passwords/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "shared/passwords/new", locals: {local_new_path: facilities_management_rm6232_admin_users_password_path} %>

--- a/app/views/facilities_management/rm6232/admin/passwords/password_reset_success.html.erb
+++ b/app/views/facilities_management/rm6232/admin/passwords/password_reset_success.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "shared/passwords/password_reset_success", locals: {local_new_user_session_path: facilities_management_rm6232_admin_new_user_session_path} %>

--- a/app/views/facilities_management/rm6232/admin/sessions/new.html.erb
+++ b/app/views/facilities_management/rm6232/admin/sessions/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "shared/sessions/new", locals: {local_email_hint_text: t('.email_hint_html'), local_header_text: t('.admin_sign_in_header'), local_new_user_session_path: facilities_management_rm6232_admin_new_user_session_path, registration_path: nil, local_new_user_password_path: facilities_management_rm6232_admin_new_user_password_path} %>

--- a/app/views/facilities_management/rm6232/admin/users/_new_password_required.html.erb
+++ b/app/views/facilities_management/rm6232/admin/users/_new_password_required.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'shared/users/new_password_required', locals: { challenge_path: facilities_management_rm6232_admin_users_challenge_path } %>

--- a/app/views/facilities_management/rm6232/admin/users/_sms_mfa.html.erb
+++ b/app/views/facilities_management/rm6232/admin/users/_sms_mfa.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'shared/users/sms_mfa', locals: { challenge_path: facilities_management_rm6232_admin_users_challenge_path, resend_link: facilities_management_rm6232_admin_user_session_path } %>

--- a/app/views/facilities_management/rm6232/admin/users/challenge_new.html.erb
+++ b/app/views/facilities_management/rm6232/admin/users/challenge_new.html.erb
@@ -1,0 +1,1 @@
+<%= render @challenge.challenge_name.downcase %>

--- a/app/views/facilities_management/rm6232/admin/users/confirm_new.html.erb
+++ b/app/views/facilities_management/rm6232/admin/users/confirm_new.html.erb
@@ -1,0 +1,1 @@
+<%= render "shared/users/confirm_new", confirm_path: facilities_management_rm6232_admin_users_confirm_path, resend_path: facilities_management_rm6232_admin_resend_confirmation_email_path %>

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -2,6 +2,16 @@
 en:
   facilities_management:
     rm6232:
+      admin:
+        home:
+          index:
+            header: RM6232 administration dashboard
+            manage_supplier_data: Manage the supplier's details and their lot data
+            supplier_data: Supplier data
+        sessions:
+          new:
+            admin_sign_in_header: Sign in to your administration dashboard
+            email_hint_html: Enter the email address you used to register
       buyer_account:
         index:
           buyer_account_dashboard: Buyer account dashboard

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,9 @@ Rails.application.routes.draw do
       end
       namespace 'rm6232', path: 'RM6232', defaults: { framework: 'RM6232' } do
         concerns %i[authenticatable registrable]
+        namespace :admin, defaults: { service: 'facilities_management/admin' } do
+          concerns :authenticatable
+        end
       end
     end
 
@@ -161,6 +164,10 @@ Rails.application.routes.draw do
     namespace 'rm6232', path: 'RM6232', defaults: { framework: 'RM6232' } do
       get '/start', to: 'home#index'
       get '/', to: 'buyer_account#index'
+
+      namespace :admin, path: 'admin', defaults: { service: 'facilities_management/admin' } do
+        get '/', to: 'home#index'
+      end
     end
 
     get '/:framework', to: 'home#index', as: 'index'

--- a/spec/controllers/facilities_management/rm6232/admin/home_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/home_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::HomeController do
+  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM6232' } }
+
+  describe 'GET #index' do
+    context 'when not logged in' do
+      before { get :index }
+
+      it 'redirects to the sign in page' do
+        expect(response).to redirect_to facilities_management_rm6232_admin_new_user_session_path
+      end
+    end
+
+    context 'when logged in as fm admin' do
+      login_fm_admin
+
+      before { get :index }
+
+      it 'renders the index page' do
+        expect(response).to render_template(:index)
+      end
+    end
+
+    context 'when not logged in as fm admin' do
+      login_fm_buyer
+
+      before { get :index }
+
+      it 'redirects to the not permitted page' do
+        expect(response).to redirect_to not_permitted_path(service: 'facilities_management')
+      end
+    end
+
+    context 'when the framework is not recognised' do
+      let(:default_params) { { service: 'facilities_management/admin', framework: 'RM007' } }
+
+      login_fm_admin
+
+      before { get :index }
+
+      it 'renders the unrecognised framework page with the right http status' do
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'sets the framework variables' do
+        expect(assigns(:unrecognised_framework)).to eq 'RM007'
+        expect(controller.params[:framework]).to eq FacilitiesManagement::Framework.default_framework
+      end
+    end
+  end
+
+  describe 'validate service' do
+    context 'when the service is not a valid service' do
+      let(:default_params) { { service: 'apprenticeships' } }
+
+      it 'renders the erros_not_found page' do
+        get :index
+
+        expect(response).to redirect_to errors_404_path
+      end
+    end
+  end
+end

--- a/spec/controllers/facilities_management/rm6232/admin/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/passwords_controller_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::PasswordsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM6232' } }
+
+  describe 'GET new' do
+    before { get :new }
+
+    it 'renders the new page' do
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST create' do
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+      post :create, params: { email: email }
+      cookies.update(response.cookies)
+    end
+
+    context 'when the email is invalid' do
+      let(:email) { 'testtest.com' }
+
+      it 'redirects to the facilities_management_rm6232_admin_new_user_password_path' do
+        expect(response).to redirect_to facilities_management_rm6232_admin_new_user_password_path
+      end
+
+      it 'does not set the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to be nil
+      end
+    end
+
+    context 'when the email is valid' do
+      let(:email) { 'test@test.com' }
+
+      it 'redirects to facilities_management_rm6232_admin_edit_user_password_path' do
+        expect(response).to redirect_to facilities_management_rm6232_admin_edit_user_password_path
+      end
+
+      it 'sets the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    before do
+      cookies[:crown_marketplace_reset_email] = 'test@email.com'
+      get :edit
+    end
+
+    it 'renders the edit page' do
+      expect(response).to render_template(:edit)
+    end
+
+    it 'the email has been set correctly in the response object' do
+      expect(assigns(:response).email).to eq('test@email.com')
+    end
+  end
+
+  describe 'PUT update' do
+    before do
+      cookies[:crown_marketplace_reset_email] = 'test@email.com'
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:create_user_if_needed).and_return(true)
+      allow_any_instance_of(Cognito::ConfirmPasswordReset).to receive(:confirm_forgot_password).and_return(true)
+      # rubocop:enable RSpec/AnyInstance
+      put :update, params: { email: 'test@test.com', password: password, password_confirmation: password, confirmation_code: '123456' }
+      cookies.update(response.cookies)
+    end
+
+    context 'when the reset password is invalid' do
+      let(:password) { 'Pas12!' }
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'does not delete the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@email.com'
+      end
+    end
+
+    context 'when the reset password is valid' do
+      let(:password) { 'Password12345!' }
+
+      it 'redirects to facilities_management_rm6232_admin_password_reset_success_path' do
+        expect(response).to redirect_to facilities_management_rm6232_admin_password_reset_success_path
+      end
+
+      it 'deletes the crown_marketplace_reset_email cookie' do
+        expect(cookies[:crown_marketplace_reset_email]).to be nil
+      end
+    end
+  end
+
+  describe 'GET password_reset_success' do
+    before { get :password_reset_success }
+
+    it 'renders the password_reset_success page' do
+      expect(response).to render_template(:password_reset_success)
+    end
+  end
+end

--- a/spec/controllers/facilities_management/rm6232/admin/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/sessions_controller_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::SessionsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM6232' } }
+
+  before { request.env['devise.mapping'] = Devise.mappings[:user] }
+
+  describe 'GET new' do
+    before { get :new }
+
+    it 'renders the new page' do
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST create' do
+    let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
+    let(:email) { user.email }
+    let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
+
+    before do
+      cookies['test_marketplace_session'] = 'I AM THE SESSION COOKIE'
+      allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+    end
+
+    context 'when the log in attempt is unsuccessful' do
+      before do
+        allow(aws_client).to receive(:initiate_auth).and_raise(exception)
+
+        post :create, params: { user: { email: email, password: 'Password12345!' } }
+        cookies.update(response.cookies)
+      end
+
+      context 'when the data is invalid' do
+        let(:email) { nil }
+        let(:exception) { nil }
+
+        it 'renders the new page' do
+          expect(response).to render_template(:new)
+        end
+      end
+
+      context 'when the password needs to be reset' do
+        let(:exception) { Aws::CognitoIdentityProvider::Errors::PasswordResetRequiredException.new('oops', 'Oops') }
+
+        it 'redirects to facilities_management_rm6232_admin_edit_user_password_path' do
+          expect(response).to redirect_to facilities_management_rm6232_admin_edit_user_password_path
+        end
+
+        it 'sets the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to eq email
+        end
+      end
+    end
+
+    context 'when the login attempt is successful' do
+      let(:username) { user.cognito_uuid }
+      let(:session) { 'I_AM_THE_SESSION' }
+      let(:cognito_groups) do
+        OpenStruct.new(groups: [
+                         OpenStruct.new(group_name: 'ccs_employee'),
+                         OpenStruct.new(group_name: 'fm_access')
+                       ])
+      end
+
+      before do
+        allow(aws_client).to receive(:initiate_auth).and_return(OpenStruct.new(challenge_name: challenge_name, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
+
+        post :create, params: { user: { email: email, password: 'Password12345!' } }
+        cookies.update(response.cookies)
+      end
+
+      context 'and there is no challenge' do
+        let(:challenge_name) { nil }
+
+        it 'redirects to facilities_management_rm6232_admin_path' do
+          expect(response).to redirect_to facilities_management_rm6232_admin_path
+        end
+      end
+
+      context 'and there is a challenge' do
+        let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+        it 'redirects to facilities_management_rm6232_admin_users_challenge_path' do
+          expect(response).to redirect_to facilities_management_rm6232_admin_users_challenge_path(challenge_name: challenge_name)
+        end
+
+        it 'the cookies are updated correctly' do
+          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        end
+      end
+    end
+  end
+
+  describe 'DELETE destroy' do
+    login_fm_buyer
+
+    it 'signs the user out' do
+      expect(controller.current_user).not_to be nil
+      delete :destroy
+      expect(controller.current_user).to be nil
+    end
+  end
+end

--- a/spec/controllers/facilities_management/rm6232/admin/users_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/users_controller_spec.rb
@@ -1,0 +1,140 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::UsersController, type: :controller do
+  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM6232' } }
+
+  describe 'GET challenge_new' do
+    let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
+
+    before do
+      cookies[:crown_marketplace_challenge_username] = user.cognito_uuid
+      get :challenge_new, params: { challenge_name: challenge_name }
+    end
+
+    render_views
+
+    context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+      let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+
+      it 'renders the new_password_required partial' do
+        expect(response).to render_template('facilities_management/rm6232/admin/users/_new_password_required')
+      end
+    end
+
+    context 'when the challenge is SMS_MFA' do
+      let(:challenge_name) { 'SMS_MFA' }
+
+      it 'renders the sms_mfa partial' do
+        expect(response).to render_template('facilities_management/rm6232/admin/users/_sms_mfa')
+      end
+    end
+  end
+
+  # rubocop:disable RSpec/NestedGroups
+  describe 'POST challenge' do
+    let(:user) { create(:user, cognito_uuid: SecureRandom.uuid, phone_number: Faker::PhoneNumber.cell_phone) }
+    let(:session) { 'I_AM_THE_SESSION' }
+    let(:username) { user.cognito_uuid }
+
+    before do
+      cookies[:crown_marketplace_challenge_session] = session
+      cookies[:crown_marketplace_challenge_username] = username
+    end
+
+    context 'when the challenge is NEW_PASSWORD_REQUIRED' do
+      let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
+      let(:password) { 'Password12345!' }
+      let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
+      let(:new_challenge_name) { nil }
+      let(:new_session) { 'I_AM_THE_NEW_SESSION' }
+
+      before do
+        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new(challenge_name: new_challenge_name, session: new_session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
+
+        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
+        cookies.update(response.cookies)
+      end
+
+      context 'and it is not valid' do
+        let(:password) { 'Pas12!' }
+
+        it 'renders challenge_new' do
+          expect(response).to render_template(:challenge_new)
+        end
+
+        it 'does not delete the cookies' do
+          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        end
+      end
+
+      context 'and it is valid' do
+        context 'and there is an additional challange' do
+          let(:new_challenge_name) { 'SMS_MFA' }
+
+          it 'redirects to facilities_management_rm6232_admin_users_challenge_path' do
+            expect(response).to redirect_to facilities_management_rm6232_admin_users_challenge_path(challenge_name: new_challenge_name)
+          end
+
+          it 'the cookies are updated correctly' do
+            expect(cookies[:crown_marketplace_challenge_session]).to eq(new_session)
+            expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+          end
+        end
+
+        context 'and there is no additional challange' do
+          it 'redirects to facilities_management_rm6232_admin_path' do
+            expect(response).to redirect_to facilities_management_rm6232_admin_path
+          end
+
+          it 'deletes the cookies' do
+            expect(cookies[:crown_marketplace_challenge_session]).to be nil
+            expect(cookies[:crown_marketplace_challenge_username]).to be nil
+          end
+        end
+      end
+    end
+
+    context 'when the challenge is SMS_MFA' do
+      let(:challenge_name) { 'SMS_MFA' }
+      let(:access_code) { '123456' }
+      let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
+
+      before do
+        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+        allow(aws_client).to receive(:respond_to_auth_challenge).and_return(OpenStruct.new)
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(OpenStruct.new(user: user))
+
+        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+        cookies.update(response.cookies)
+      end
+
+      context 'and it is not valid' do
+        let(:access_code) { '123' }
+
+        it 'renders challenge_new' do
+          expect(response).to render_template(:challenge_new)
+        end
+
+        it 'does not delete the cookies' do
+          expect(cookies[:crown_marketplace_challenge_session]).to eq(session)
+          expect(cookies[:crown_marketplace_challenge_username]).to eq(username)
+        end
+      end
+
+      context 'and it is valid' do
+        it 'redirects to facilities_management_rm6232_admin_path' do
+          expect(response).to redirect_to facilities_management_rm6232_admin_path
+        end
+
+        it 'deletes the cookies' do
+          expect(cookies[:crown_marketplace_challenge_session]).to be nil
+          expect(cookies[:crown_marketplace_challenge_username]).to be nil
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/NestedGroups
+end


### PR DESCRIPTION
Ticket: [FMFR-1005](https://crowncommercialservice.atlassian.net/browse/FMFR-1005)

Add the base admin pages for the new RM6232 framework.

This includes:
- Sign in and sign up pages
- Cookie setting, Cookie policy and Accessibility Statement page
- The home page for the admin

In addition, I added the controller tests to make sure everything is working properly