### PR TITLE
FMFR-1012 - Add the ability to edit the suppliers regions in the admin tool

### DIFF
--- a/app/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller.rb
@@ -3,9 +3,22 @@ module FacilitiesManagement
     module Admin
       class SupplierLotDataController < FacilitiesManagement::Admin::FrameworkController
         before_action :set_supplier_data, only: :show
+        before_action :set_lot_data, :set_lot_data_type_and_redirect_if_unrecognised, only: %i[edit update]
+        before_action :set_data, only: :edit
 
-        def show
-          @suppliers = Supplier.order(:supplier_name).select(:id, :supplier_name)
+        def show; end
+
+        def edit; end
+
+        def update
+          @lot_data.assign_attributes(lot_data_params)
+
+          if @lot_data.save(context: @lot_data_type.to_sym)
+            redirect_to facilities_management_rm6232_admin_supplier_lot_datum_path(id: @supplier.id)
+          else
+            set_data
+            render :edit
+          end
         end
 
         private
@@ -21,6 +34,43 @@ module FacilitiesManagement
             }
           end
         end
+
+        def set_lot_data
+          @lot_data = Supplier::LotData.find(params[:supplier_lot_datum_id])
+          @lot_code = @lot_data.lot_code
+          @supplier = @lot_data.supplier
+        end
+
+        def set_lot_data_type_and_redirect_if_unrecognised
+          @lot_data_type = params[:lot_data_type]
+
+          redirect_to facilities_management_rm6232_admin_path unless RECOGNISED_LOT_DATA_TYPES.include? @lot_data_type
+        end
+
+        def set_data
+          case @lot_data_type
+          when 'service_codes'
+            # TODO: Add method for services
+          when 'region_codes'
+            set_regions
+          end
+        end
+
+        def set_regions
+          @regions = Nuts1Region.all.map { |nuts_1_region| [nuts_1_region.name, Region.all.select { |region| region.code.starts_with? nuts_1_region.code }] }.to_h
+        end
+
+        def lot_data_params
+          if params[:facilities_management_rm6232_supplier_lot_data]
+            params.require(:facilities_management_rm6232_supplier_lot_data).permit(
+              region_codes: [],
+            )
+          else
+            { @lot_data_type => [] }
+          end
+        end
+
+        RECOGNISED_LOT_DATA_TYPES = %w[region_codes].freeze
       end
     end
   end

--- a/app/models/facilities_management/rm6232/supplier/lot_data.rb
+++ b/app/models/facilities_management/rm6232/supplier/lot_data.rb
@@ -5,6 +5,8 @@ module FacilitiesManagement
 
       delegate :supplier_name, to: :supplier
 
+      validates :region_codes, length: { minimum: 1 }, on: :region_codes
+
       def services
         Service.where(code: service_codes)
       end

--- a/app/views/facilities_management/rm6232/admin/supplier_lot_data/_region_codes.html.erb
+++ b/app/views/facilities_management/rm6232/admin/supplier_lot_data/_region_codes.html.erb
@@ -1,0 +1,27 @@
+<% @regions.each do |nuts_1_region, regions| %>
+  <fieldset class="govuk-fieldset">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-font-weight-bold">
+          <legend class="govuk-padding-left-0">
+            <%= nuts_1_region %>
+          </legend>
+        </th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <%= f.collection_check_boxes(:region_codes, regions, :code, :name, include_hidden: false) do |check_box_field| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header govuk-!-width-one-quarter govuk-!-font-weight-regular supplier-rates-td">
+              <div class="govuk-checkboxes__item">
+                <%= check_box_field.check_box(class: 'govuk-checkboxes__input') %>
+                <%= check_box_field.label(class: 'govuk-label govuk-checkboxes__label') %>
+              </div>
+            </th>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </fieldset>
+<% end %>

--- a/app/views/facilities_management/rm6232/admin/supplier_lot_data/edit.html.erb
+++ b/app/views/facilities_management/rm6232/admin/supplier_lot_data/edit.html.erb
@@ -1,0 +1,34 @@
+<%= content_for :page_title, t(".heading.#{@lot_data_type}", lot_code: @lot_code) %>
+<%= admin_breadcrumbs(
+  { text: t('facilities_management.rm6232.admin.supplier_data.index.heading'), link: facilities_management_rm6232_admin_supplier_data_path },
+  { text: t('facilities_management.rm6232.admin.supplier_lot_data.show.heading'), link:  facilities_management_rm6232_admin_supplier_lot_datum_path(id: @supplier.id) },
+  { text: t(".heading.#{@lot_data_type}", lot_code: @lot_code) }
+)%>
+
+<%= render partial: 'shared/error_summary', locals: { errors: @lot_data.errors } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">
+      <%= @supplier.supplier_name %>
+    </span>
+    <h1 class="govuk-heading-xl">
+      <%= t(".heading.#{@lot_data_type}", lot_code: @lot_code) %>
+    </h1>
+    <p class="govuk-hint">
+      <%= t(".the_check_boxes.#{@lot_data_type}") %>
+    </p>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @lot_data, url: facilities_management_rm6232_admin_supplier_lot_datum_update_path, method: :put, local: 'false', html: { specialvalidation: true, novalidate: true } do |f| %>
+      <%= form_group_with_error(f.object, @lot_data_type.to_sym) do |displayed_error, any_errors| %>
+        <%= displayed_error %>
+        <%= render(partial: "#{@lot_data_type}", locals: { f: f }) %>
+      <% end %>
+
+      <%= f.submit t('.save_and_return'), class: "govuk-button", 'aria-label': t('.save_and_return') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/facilities_management/rm6232/admin/supplier_lot_data/show.html.erb
+++ b/app/views/facilities_management/rm6232/admin/supplier_lot_data/show.html.erb
@@ -19,7 +19,7 @@
 </div>
 
 <% @lot_data.each do |lot_data| %>
-  <div class="govuk-grid-row lot-data-table">
+  <div id="lot-data_table--lot-<%= lot_data[:lot_code] %>" class="govuk-grid-row lot-data-table">
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">
         <%= t('.lot_code', lot_code: lot_data[:lot_code]) %>
@@ -42,7 +42,7 @@
             <% end %>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <%= link_to '#', class: 'govuk-link--no-visited-state' do %>
+            <%= link_to facilities_management_rm6232_admin_supplier_lot_datum_edit_path(supplier_lot_datum_id: lot_data[:id], lot_data_type: 'service_codes'), class: 'govuk-link--no-visited-state' do %>
               <%= t('.change') %> <span class="govuk-visually-hidden"><%= t('.lot_services', lot_code: lot_data[:lot_code]) %></span>
             <% end %>
           </dd>
@@ -63,7 +63,7 @@
             <% end %>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <%= link_to '#', class: 'govuk-link--no-visited-state' do %>
+            <%= link_to facilities_management_rm6232_admin_supplier_lot_datum_edit_path(supplier_lot_datum_id: lot_data[:id], lot_data_type: 'region_codes'), class: 'govuk-link--no-visited-state' do %>
               <%= t('.change') %> <span class="govuk-visually-hidden"><%= t('.lot_regions', lot_code: lot_data[:lot_code]) %></span>
             <% end %>
           </dd>

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -39,6 +39,10 @@ en:
               blank: You must enter a supplier name
               taken: A supplier with this name already exists
               too_long: The supplier name cannot be more than 100 characters
+        facilities_management/rm6232/supplier/lot_data:
+          attributes:
+            region_codes:
+              too_short: You must select at least one region for this lot
   facilities_management:
     rm6232:
       admin:
@@ -64,6 +68,12 @@ en:
           index:
             heading: Supplier data
         supplier_lot_data:
+          edit:
+            heading:
+              region_codes: Lot %{lot_code} regions
+            save_and_return: Save and return
+            the_check_boxes:
+              region_codes: The check boxes in the first column indicate what regions the supplier can provide their services in.
           show:
             change: Change
             heading: View lot data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,7 +170,10 @@ Rails.application.routes.draw do
       namespace :admin, path: 'admin', defaults: { service: 'facilities_management/admin' } do
         get '/', to: 'home#index'
         resources :supplier_data, path: 'supplier-data', only: :index
-        resources :supplier_lot_data, path: 'supplier-lot-data', only: :show
+        resources :supplier_lot_data, path: 'supplier-lot-data', only: :show do
+          get '/:lot_data_type/edit', action: :edit, as: :edit
+          put '/:lot_data_type', action: :update, as: :update
+        end
       end
     end
 

--- a/features/accessibility/facilities_management/rm6232/admin/view_lot_data_accessibility.feature
+++ b/features/accessibility/facilities_management/rm6232/admin/view_lot_data_accessibility.feature
@@ -1,0 +1,16 @@
+@accessibility @javascript
+Feature: View lot data - accessibility
+
+  Background: Navigate to the Supplier lot data
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    Then I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    Then I click on 'View lot data' for 'Heidenreich Inc'
+    And I am on the 'View lot data' page
+    And the supplier name shown is 'Heidenreich Inc'
+
+  Scenario: Regions page
+    And I change the 'regions' for lot 'c'
+    Then I am on the 'Lot c regions' page
+    And the supplier name shown is 'Heidenreich Inc'
+    Then the page should be axe clean

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/region_codes.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/region_codes.feature
@@ -1,0 +1,94 @@
+Feature: Selecting region codes
+
+  Background: I navigate to the supplier data page
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+
+  Scenario Outline: I can got to all lots and change the regions
+    Then I click on 'View lot data' for '<supplier_name>'
+    And I am on the 'View lot data' page
+    And I change the 'regions' for lot '<lot>'
+    Then I am on the '<title>' page
+    And the supplier name shown is '<supplier_name>'
+
+    Examples:
+      | supplier_name               | lot | title         |
+      | Abshire, Schumm and Farrell | a   | Lot a regions |
+      | Terry-Greenholt             | b   | Lot b regions |
+      | Schultz-Wilkinson           | c   | Lot c regions |
+
+  @pipline
+  Scenario: I change the regions and it changes on View lot data - lot a
+    Then I click on 'View lot data' for 'Brakus, Lueilwitz and Blanda'
+    And I am on the 'View lot data' page
+    And I change the 'regions' for lot 'a'
+    Then I am on the 'Lot a regions' page
+    And the supplier name shown is 'Brakus, Lueilwitz and Blanda'
+    And I deselect all checkboxes
+    And I select the following items:
+      | South Yorkshire                                               |
+      | Surrey, East and West Sussex                                  |
+      | South West Wales (Ceredigion, Carmarthenshire, Pembrokeshire) |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I should see the following 'regions' selected for lot 'a':
+      | South Yorkshire                                               |
+      | Surrey, East and West Sussex                                  |
+      | South West Wales (Ceredigion, Carmarthenshire, Pembrokeshire) |    
+
+  Scenario: I change the regions and it changes on View lot data - lot b
+    Then I click on 'View lot data' for 'Donnelly, Wiegand and Krajcik'
+    And I am on the 'View lot data' page
+    And I change the 'regions' for lot 'b'
+    Then I am on the 'Lot b regions' page
+    And the supplier name shown is 'Donnelly, Wiegand and Krajcik'
+    And I deselect all checkboxes
+    And I select the following items:
+      | Essex                                             |
+      | Gloucestershire, Wiltshire and Bristol/Bath area  |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I should see the following 'regions' selected for lot 'b':
+      | Essex                                             |
+      | Gloucestershire, Wiltshire and Bristol/Bath area  | 
+
+  Scenario: I change the regions and it changes on View lot data - lot c
+    Then I click on 'View lot data' for 'Lind, Stehr and Dickinson'
+    And I am on the 'View lot data' page
+    And I change the 'regions' for lot 'c'
+    Then I am on the 'Lot c regions' page
+    And the supplier name shown is 'Lind, Stehr and Dickinson'
+    And I deselect all checkboxes
+    And I select the following items:
+      | Tees Valley and Durham  |
+      | North Yorkshire         |
+      | Inner London - East     |
+      | Powys                   |
+      | Falkirk                 |
+      | Belfast                 |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I should see the following 'regions' selected for lot 'c':
+      | Tees Valley and Durham  |
+      | North Yorkshire         |
+      | Inner London - East     |
+      | Powys                   |
+      | Falkirk                 |
+      | Belfast                 |
+
+  @pipline
+  Scenario Outline: Breadcrumb links work from regions
+    Then I click on 'View lot data' for 'Yost LLC'
+    And I am on the 'View lot data' page
+    And I change the 'regions' for lot 'c'
+    Then I am on the 'Lot c regions' page
+    And the supplier name shown is 'Yost LLC'
+    And I click on '<link_text>'
+    Then I am on the '<page_title>' page
+
+    Examples:
+      | link_text     | page_title                    |
+      | Home          | RM6232 administration dashboard |
+      | Supplier data | Supplier data                   |
+      | View lot data | View lot data                   |

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/validations/region_codes_validations.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/validations/region_codes_validations.feature
@@ -1,0 +1,16 @@
+@pipline
+Feature: Selecting region codes validations
+
+  Scenario: No region codes are selected
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    Then I click on 'View lot data' for 'Skiles LLC'
+    And I am on the 'View lot data' page
+    And the supplier name shown is 'Skiles LLC'
+    And I change the 'regions' for lot 'a'
+    Then I am on the 'Lot a regions' page
+    And I deselect all checkboxes
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | You must select at least one region for this lot  |

--- a/features/step_definitions/facilities_management/common_steps.rb
+++ b/features/step_definitions/facilities_management/common_steps.rb
@@ -89,6 +89,20 @@ Then('I am on a {string} page') do |option|
   expect(page.find('#wrapper > header > div > div.govuk-header__content > span')).to have_content(PAGE_HEADING[option])
 end
 
+Then('I show all sections') do
+  step('I click on "Show all sections"') if @javascript
+end
+
+Then('I select {string}') do |item|
+  page.check(item)
+end
+
+Then('I select the following items:') do |items|
+  items.raw.flatten.each do |item|
+    page.check(item)
+  end
+end
+
 Then('I refresh the page') do
   page.driver.browser.navigate.refresh
 end

--- a/features/step_definitions/facilities_management/rm3830/quick_view_results_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/quick_view_results_steps.rb
@@ -1,17 +1,3 @@
-Then('I show all sections') do
-  step('I click on "Show all sections"') if @javascript
-end
-
-Then('I select {string}') do |item|
-  page.check(item)
-end
-
-Then('I select the following items:') do |items|
-  items.raw.flatten.each do |item|
-    page.check(item)
-  end
-end
-
 Then('I select all for {string}') do |item_group|
   page.find("[data-sectionname='#{item_group}']").find('input[name="section-checkbox_select_all"]').check
 end

--- a/features/step_definitions/facilities_management/rm6232/admin_steps.rb
+++ b/features/step_definitions/facilities_management/rm6232/admin_steps.rb
@@ -27,3 +27,18 @@ Then('they have services and regions for the following lots:') do |lots|
     expect(element).to have_content(value)
   end
 end
+
+Then('I change the {string} for lot {string}') do |lot_data_type, lot_code|
+  admin_rm6232_page.lot_data.send("lot_#{lot_code}").send(lot_data_type).change_link.click
+end
+
+Then('I deselect all checkboxes') do
+  admin_rm6232_page.all('input[type="checkbox"][checked="checked"]').each(&:uncheck)
+end
+
+Then('I should see the following {string} selected for lot {string}:') do |lot_data_type, lot_code, items|
+  expected_names = items.raw.flatten
+  actual_names = admin_rm6232_page.lot_data.send("lot_#{lot_code}").send(lot_data_type).names.map(&:text)
+
+  expect(actual_names).to eq expected_names
+end

--- a/features/support/pages/rm6232/admin.rb
+++ b/features/support/pages/rm6232/admin.rb
@@ -22,5 +22,40 @@ module Pages::RM6232
       element :'DUNS number', '#facilities_management_rm6232_admin_suppliers_admin_duns'
       element :'Company registration number', '#facilities_management_rm6232_admin_suppliers_admin_registration_number'
     end
+
+    section :lot_data, '#main-content' do
+      section :lot_a, '#lot-data_table--lot-a' do
+        section :services, 'dl > div:nth-child(1)' do
+          elements :names, 'details > div > ul > li'
+          element :change_link, 'dd.govuk-summary-list__actions > a'
+        end
+        section :regions, 'dl > div:nth-child(2)' do
+          elements :names, 'details > div > ul > li'
+          element :change_link, 'dd.govuk-summary-list__actions > a'
+        end
+      end
+
+      section :lot_b, '#lot-data_table--lot-b' do
+        section :services, 'dl > div:nth-child(1)' do
+          elements :names, 'details > div > ul > li'
+          element :change_link, 'dd.govuk-summary-list__actions > a'
+        end
+        section :regions, 'dl > div:nth-child(2)' do
+          elements :names, 'details > div > ul > li'
+          element :change_link, 'dd.govuk-summary-list__actions > a'
+        end
+      end
+
+      section :lot_c, '#lot-data_table--lot-c' do
+        section :services, 'dl > div:nth-child(1)' do
+          elements :names, 'details > div > ul > li'
+          element :change_link, 'dd.govuk-summary-list__actions > a'
+        end
+        section :regions, 'dl > div:nth-child(2)' do
+          elements :names, 'details > div > ul > li'
+          element :change_link, 'dd.govuk-summary-list__actions > a'
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller_spec.rb
@@ -33,4 +33,103 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierLotDataController, t
       end
     end
   end
+
+  describe 'GET edit' do
+    let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier) }
+
+    render_views
+
+    before { get :edit, params: { supplier_lot_datum_id: lot_data.id, lot_data_type: lot_data_type } }
+
+    context 'when the lot data type is region codes' do
+      let(:lot_data_type) { 'region_codes' }
+
+      it 'renders the edit template' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'renders the region_codes partial' do
+        expect(response).to render_template(partial: 'facilities_management/rm6232/admin/supplier_lot_data/_region_codes')
+      end
+
+      it 'sets the lot data' do
+        expect(assigns(:lot_data)).to eq lot_data
+        expect(assigns(:lot_code)).to eq lot_data.lot_code
+        expect(assigns(:supplier).supplier_name).to eq lot_data.supplier_name
+      end
+
+      it 'sets the region data' do
+        expect(assigns(:regions)).not_to be_nil
+      end
+    end
+
+    context 'when the lot data type is not recognised' do
+      let(:lot_data_type) { 'unrecognised' }
+
+      it 'redirects back to the admin dashboard' do
+        expect(response).to redirect_to facilities_management_rm6232_admin_path
+      end
+    end
+  end
+
+  describe 'PUT update' do
+    let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier) }
+    let(:attributes) { {} }
+
+    before { put :update, params: { supplier_lot_datum_id: lot_data.id, lot_data_type: lot_data_type, facilities_management_rm6232_supplier_lot_data: attributes } }
+
+    context 'when the lot data type is region codes' do
+      let(:lot_data_type) { 'region_codes' }
+
+      context 'and the data is valid' do
+        let(:attributes) { { region_codes: %w[UKD1 UKD2] } }
+
+        it 'redirects to facilities_management_rm6232_admin_supplier_lot_datum_path' do
+          expect(response).to redirect_to facilities_management_rm6232_admin_supplier_lot_datum_path(lot_data.supplier.id)
+        end
+
+        it 'sets the lot data' do
+          expect(assigns(:lot_data)).to eq lot_data
+          expect(assigns(:lot_code)).to eq lot_data.lot_code
+          expect(assigns(:supplier).supplier_name).to eq lot_data.supplier_name
+        end
+
+        it 'does not set the region data' do
+          expect(assigns(:regions)).to be_nil
+        end
+      end
+
+      context 'and the data is invalid' do
+        let(:attributes) { { region_codes: [] } }
+
+        render_views
+
+        it 'renders the edit template' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the region_codes partial' do
+          expect(response).to render_template(partial: 'facilities_management/rm6232/admin/supplier_lot_data/_region_codes')
+        end
+
+        it 'sets the lot data' do
+          expect(assigns(:lot_data)).to eq lot_data
+          expect(assigns(:lot_code)).to eq lot_data.lot_code
+          expect(assigns(:supplier).supplier_name).to eq lot_data.supplier_name
+        end
+
+        it 'sets the region data' do
+          expect(assigns(:regions)).not_to be_nil
+        end
+      end
+    end
+
+    context 'when the lot data type is not recognised' do
+      let(:lot_data_type) { 'something else' }
+
+      it 'redirects back to the admin dashboard' do
+        expect(response).to redirect_to facilities_management_rm6232_admin_path
+      end
+    end
+  end
 end

--- a/spec/factories/facilities_management/rm6232/supplier/lot_data.rb
+++ b/spec/factories/facilities_management/rm6232/supplier/lot_data.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     lot_code { 'a' }
     service_codes { %w[E.16 H.6 P.11] }
     region_codes { %w[UKC1 UKD1 UKE1] }
+
+    trait :with_supplier do
+      supplier { build :facilities_management_rm6232_supplier }
+    end
   end
 end

--- a/spec/models/facilities_management/rm6232/supplier/lot_data_spec.rb
+++ b/spec/models/facilities_management/rm6232/supplier/lot_data_spec.rb
@@ -37,4 +37,27 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData, type: :model do
       expect(random_lot_data.region_codes.count).to be >= 1
     end
   end
+
+  describe 'validations' do
+    context 'when validating the region codes' do
+      let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier, region_codes: region_codes) }
+
+      context 'and there are none' do
+        let(:region_codes) { [] }
+
+        it 'is not valid and has the correct error message' do
+          expect(lot_data.valid?(:region_codes)).to be false
+          expect(lot_data.errors[:region_codes].first).to eq 'You must select at least one region for this lot'
+        end
+      end
+
+      context 'and there are some' do
+        let(:region_codes) { %w[UKC1 UKC2] }
+
+        it 'is valid' do
+          expect(lot_data.valid?(:region_codes)).to be true
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: [FMFR-1012](https://crowncommercialservice.atlassian.net/browse/FMFR-1012)

Add the ability to edit the suppliers regions in the admin tool

To do this I:
- Add the routes for editing and updating lot data
- Created a base edit page and then the region codes page
- add validation to the lot data model
- Add controller and model specs
- Add feature and accessibility tests