### PR TITLE
FMFR-1011 - Add the ability to edit the suppliers services in the admin tool

### DIFF
--- a/app/assets/stylesheets/ccs/facilities-management/_all.scss
+++ b/app/assets/stylesheets/ccs/facilities-management/_all.scss
@@ -3,4 +3,5 @@
 @import "procurement-buildings.scss";
 @import "service-specification.scss";
 @import "summary-list.scss";
+@import "supplier_lot_data";
 @import "supplier-lot-list.scss";

--- a/app/assets/stylesheets/ccs/facilities-management/_supplier_lot_data.scss
+++ b/app/assets/stylesheets/ccs/facilities-management/_supplier_lot_data.scss
@@ -1,0 +1,21 @@
+.supplier-lot-data {
+  position: relative;
+}
+
+.supplier-lot-data__true:after {
+  content: "";
+  box-sizing: border-box;
+  display: block;
+  position: absolute;
+  top: 19px;
+  left: 9px;
+  width: 23px;
+  height: 12px;
+
+  transform: rotate(-45deg);
+  border: solid;
+  border-width: 0 0 5px 5px;
+  // // Fix bug in IE11 caused by transform rotate (-45deg).
+  // // See: alphagov/govuk_elements/issues/518
+  border-top-color: transparent;
+}

--- a/app/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller.rb
@@ -50,10 +50,14 @@ module FacilitiesManagement
         def set_data
           case @lot_data_type
           when 'service_codes'
-            # TODO: Add method for services
+            set_work_packages
           when 'region_codes'
             set_regions
           end
+        end
+
+        def set_work_packages
+          @work_packages = WorkPackage.selectable.index_with(&:services)
         end
 
         def set_regions
@@ -63,6 +67,7 @@ module FacilitiesManagement
         def lot_data_params
           if params[:facilities_management_rm6232_supplier_lot_data]
             params.require(:facilities_management_rm6232_supplier_lot_data).permit(
+              service_codes: [],
               region_codes: [],
             )
           else
@@ -70,7 +75,7 @@ module FacilitiesManagement
           end
         end
 
-        RECOGNISED_LOT_DATA_TYPES = %w[region_codes].freeze
+        RECOGNISED_LOT_DATA_TYPES = %w[service_codes region_codes].freeze
       end
     end
   end

--- a/app/models/facilities_management/rm6232/service.rb
+++ b/app/models/facilities_management/rm6232/service.rb
@@ -3,6 +3,10 @@ module FacilitiesManagement
     class Service < ApplicationRecord
       belongs_to :work_package, foreign_key: :work_package_code, inverse_of: :services
 
+      def label_name
+        "#{code} #{name}"
+      end
+
       def self.find_lot_number(service_codes, annual_contract_value)
         lot_number = determine_lot_number(service_codes)
 

--- a/app/views/facilities_management/rm6232/admin/supplier_lot_data/_service_codes.html.erb
+++ b/app/views/facilities_management/rm6232/admin/supplier_lot_data/_service_codes.html.erb
@@ -1,0 +1,54 @@
+<% @work_packages.each do |work_package, services| %>
+  <fieldset class="govuk-fieldset">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">
+          <legend class="govuk-padding-left-0">
+            <%= work_package.name %>
+          </legend>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          Total
+        </th>
+        <th scope="col" class="govuk-table__header">
+          Hard
+        </th>
+        <th scope="col" class="govuk-table__header">
+          Soft
+        </th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <%= f.collection_check_boxes(:service_codes, services, :code, :label_name, include_hidden: false) do |check_box_field| %>
+          <tr class="govuk-table__row">
+            <% if check_box_field.object.core %>
+              <%= f.hidden_field :service_codes, multiple: true, value: check_box_field.object.code, id: "facilities_management_rm6232_supplier_lot_data_service_codes_hidden-#{check_box_field.object.code}" %>
+            <% end %>
+            <th scope="row" class="govuk-table__header govuk-!-width-one-quarter govuk-!-font-weight-regular supplier-rates-td">
+              <div class="govuk-checkboxes__item">
+                <%= check_box_field.check_box(class: 'govuk-checkboxes__input', disabled: check_box_field.object.core) %>
+                <%= check_box_field.label(class: 'govuk-label govuk-checkboxes__label') %>
+              </div>
+            </th>
+            <td class="govuk-table__cell supplier-rates-td supplier-lot-data">
+              <% if check_box_field.object.total %>
+                <span class="supplier-lot-data__true"></span>
+              <% end %>
+            </td>
+            <td class="govuk-table__cell supplier-rates-td supplier-lot-data">
+              <% if check_box_field.object.hard %>
+                <span class="supplier-lot-data__true"></span>
+              <% end %>
+            </td>
+            <td class="govuk-table__cell supplier-rates-td supplier-lot-data">
+             <% if check_box_field.object.soft %>
+                <span class="supplier-lot-data__true"></span>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </fieldset>
+<% end %>

--- a/app/views/facilities_management/rm6232/admin/supplier_lot_data/edit.html.erb
+++ b/app/views/facilities_management/rm6232/admin/supplier_lot_data/edit.html.erb
@@ -21,7 +21,7 @@
   </div>
 </div>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <%= form_with model: @lot_data, url: facilities_management_rm6232_admin_supplier_lot_datum_update_path, method: :put, local: 'false', html: { specialvalidation: true, novalidate: true } do |f| %>
       <%= form_group_with_error(f.object, @lot_data_type.to_sym) do |displayed_error, any_errors| %>
         <%= displayed_error %>

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -71,9 +71,11 @@ en:
           edit:
             heading:
               region_codes: Lot %{lot_code} regions
+              service_codes: Lot %{lot_code} services
             save_and_return: Save and return
             the_check_boxes:
               region_codes: The check boxes in the first column indicate what regions the supplier can provide their services in.
+              service_codes: The check boxes in the first column indicate what services the supplier can provide. This is in addition to the core services which are greyed out.
           show:
             change: Change
             heading: View lot data

--- a/features/accessibility/facilities_management/rm6232/admin/view_lot_data_accessibility.feature
+++ b/features/accessibility/facilities_management/rm6232/admin/view_lot_data_accessibility.feature
@@ -14,3 +14,9 @@ Feature: View lot data - accessibility
     Then I am on the 'Lot c regions' page
     And the supplier name shown is 'Heidenreich Inc'
     Then the page should be axe clean
+
+  Scenario: Services page
+    And I change the 'services' for lot 'c'
+    Then I am on the 'Lot c services' page
+    And the supplier name shown is 'Heidenreich Inc'
+    Then the page should be axe clean

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/region_codes.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/region_codes.feature
@@ -32,7 +32,7 @@ Feature: Selecting region codes
       | South West Wales (Ceredigion, Carmarthenshire, Pembrokeshire) |
     And I click on 'Save and return'
     And I am on the 'View lot data' page
-    And I should see the following 'regions' selected for lot 'a':
+    And I should see the following regions selected for lot 'a':
       | South Yorkshire                                               |
       | Surrey, East and West Sussex                                  |
       | South West Wales (Ceredigion, Carmarthenshire, Pembrokeshire) |    
@@ -49,7 +49,7 @@ Feature: Selecting region codes
       | Gloucestershire, Wiltshire and Bristol/Bath area  |
     And I click on 'Save and return'
     And I am on the 'View lot data' page
-    And I should see the following 'regions' selected for lot 'b':
+    And I should see the following regions selected for lot 'b':
       | Essex                                             |
       | Gloucestershire, Wiltshire and Bristol/Bath area  | 
 
@@ -69,7 +69,7 @@ Feature: Selecting region codes
       | Belfast                 |
     And I click on 'Save and return'
     And I am on the 'View lot data' page
-    And I should see the following 'regions' selected for lot 'c':
+    And I should see the following regions selected for lot 'c':
       | Tees Valley and Durham  |
       | North Yorkshire         |
       | Inner London - East     |
@@ -88,7 +88,7 @@ Feature: Selecting region codes
     Then I am on the '<page_title>' page
 
     Examples:
-      | link_text     | page_title                    |
+      | link_text     | page_title                      |
       | Home          | RM6232 administration dashboard |
       | Supplier data | Supplier data                   |
       | View lot data | View lot data                   |

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/service_codes.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/service_codes.feature
@@ -1,0 +1,115 @@
+Feature: Selecting service codes
+
+  Background: I navigate to the supplier data page
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+
+  Scenario Outline: I can got to all lots and change the services
+    Then I click on 'View lot data' for '<supplier_name>'
+    And I am on the 'View lot data' page
+    And I change the 'services' for lot '<lot>'
+    Then I am on the '<title>' page
+    And the supplier name shown is '<supplier_name>'
+
+    Examples:
+      | supplier_name               | lot | title           |
+      | Abshire, Schumm and Farrell | a   | Lot a services  |
+      | Terry-Greenholt             | b   | Lot b services  |
+      | Schultz-Wilkinson           | c   | Lot c services  |
+
+  Scenario: I change the services and it changes on View lot data - lot a
+    Then I click on 'View lot data' for 'Conn, Hayes and Lakin'
+    And I am on the 'View lot data' page
+    And I change the 'services' for lot 'a'
+    Then I am on the 'Lot a services' page
+    And the supplier name shown is 'Conn, Hayes and Lakin'
+    And I deselect all checkboxes
+    And I select the following items:
+      | E.14 Catering equipment maintenance |
+      | G.3 Tree Surgery (Arboriculture)    |
+      | H.8 Trolley service                 |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I should see the following services selected for lot 'a':
+      | Catering equipment maintenance  |
+      | Tree Surgery (Arboriculture)    |
+      | Trolley service                 |
+
+  @pipline
+  Scenario: I change the services and it changes on View lot data - lot b
+    Then I click on 'View lot data' for 'Terry-Greenholt'
+    And I am on the 'View lot data' page
+    And I change the 'services' for lot 'b'
+    Then I am on the 'Lot b services' page
+    And the supplier name shown is 'Terry-Greenholt'
+    And I deselect all checkboxes
+    And I select the following items:
+      | I.9 Cleaning of communications and equipment rooms          |
+      | I.10 Reactive cleaning (outside cleaning operational hours) |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I should see the following services selected for lot 'b':
+      | Cleaning of communications and equipment rooms          |
+      | Reactive cleaning (outside cleaning operational hours)  |
+
+  Scenario: I change the services and it changes on View lot data - lot c
+    Then I click on 'View lot data' for 'Cummerata, Lubowitz and Ebert'
+    And I am on the 'View lot data' page
+    And I change the 'services' for lot 'c'
+    Then I am on the 'Lot c services' page
+    And the supplier name shown is 'Cummerata, Lubowitz and Ebert'
+    And I deselect all checkboxes
+    And I select the following items:
+      | E.20 Locksmith Services                                         |
+      | F.9 Building Information Modelling and Government Soft Landings |
+      | G.7 Internal planting                                           |
+      | H.8 Trolley service                                             |
+      | I.15 Medical and clinical cleaning                              |
+      | J.9 Archiving (on-site)                                         |
+      | K.4 Voice announcement system operation                         |
+      | L.14 Remote CCTV / alarm monitoring                             |
+      | M.7 Clinical Waste                                              |
+      | N.6 Journal, magazine and newspaper supply                      |
+      | O.4 Rural Estate Maintenance (REM) Services                     |
+      | P.12 Future Accommodation Model (FAM)                           |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I should see the following services selected for lot 'c':
+      | Locksmith Services                                          |
+      | Building Information Modelling and Government Soft Landings |
+      | Internal planting                                           |
+      | Trolley service                                             |
+      | Medical and clinical cleaning                               |
+      | Archiving (on-site)                                         |
+      | Voice announcement system operation                         |
+      | Remote CCTV / alarm monitoring                              |
+      | Clinical Waste                                              |
+      | Journal, magazine and newspaper supply                      |
+      | Rural Estate Maintenance (REM) Services                     |
+      | Future Accommodation Model (FAM)                            |
+
+  @pipline
+  Scenario Outline: Breadcrumb links work from services
+    Then I click on 'View lot data' for 'Yost LLC'
+    And I am on the 'View lot data' page
+    And I change the 'services' for lot 'c'
+    Then I am on the 'Lot c services' page
+    And the supplier name shown is 'Yost LLC'
+    And I click on '<link_text>'
+    Then I am on the '<page_title>' page
+
+    Examples:
+      | link_text     | page_title                      |
+      | Home          | RM6232 administration dashboard |
+      | Supplier data | Supplier data                   |
+      | View lot data | View lot data                   |
+
+  @pipline
+  Scenario: I can't select core services
+    Then I click on 'View lot data' for 'Skiles LLC'
+    And I am on the 'View lot data' page
+    And I change the 'services' for lot 'a'
+    Then I am on the 'Lot a services' page
+    And the supplier name shown is 'Skiles LLC'
+    And I can't select any core services

--- a/features/step_definitions/facilities_management/rm6232/admin_steps.rb
+++ b/features/step_definitions/facilities_management/rm6232/admin_steps.rb
@@ -36,9 +36,29 @@ Then('I deselect all checkboxes') do
   admin_rm6232_page.all('input[type="checkbox"][checked="checked"]').each(&:uncheck)
 end
 
-Then('I should see the following {string} selected for lot {string}:') do |lot_data_type, lot_code, items|
-  expected_names = items.raw.flatten
-  actual_names = admin_rm6232_page.lot_data.send("lot_#{lot_code}").send(lot_data_type).names.map(&:text)
+Then('I should see the following regions selected for lot {string}:') do |lot_code, regions|
+  expected_regions = regions.raw.flatten
+  actual_regions = admin_rm6232_page.lot_data.send("lot_#{lot_code}").regions.names.map(&:text)
 
-  expect(actual_names).to eq expected_names
+  expect(actual_regions).to eq expected_regions
+end
+
+Then('I should see the following services selected for lot {string}:') do |lot_code, services|
+  expected_services = services.raw.flatten
+  actual_services = admin_rm6232_page.lot_data.send("lot_#{lot_code}").services.names.map(&:text)
+  core_service_names = core_services.map(&:name)
+
+  expect(core_service_names - actual_services).to be_empty
+  expect(actual_services - core_service_names).to eq expected_services
+end
+
+Then("I can't select any core services") do
+  core_service_labels = admin_rm6232_page.all('input[type="checkbox"][disabled]').map { |element| element.find(:xpath, '../label').text }
+  core_service_names = core_services.map(&:label_name)
+
+  expect(core_service_labels).to eq core_service_names
+end
+
+def core_services
+  FacilitiesManagement::RM6232::WorkPackage.selectable.map { |work_package| work_package.services.select(&:core) }.flatten
 end

--- a/spec/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller_spec.rb
@@ -41,6 +41,28 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierLotDataController, t
 
     before { get :edit, params: { supplier_lot_datum_id: lot_data.id, lot_data_type: lot_data_type } }
 
+    context 'when the lot data type is service codes' do
+      let(:lot_data_type) { 'service_codes' }
+
+      it 'renders the edit template' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'renders the service_codes partial' do
+        expect(response).to render_template(partial: 'facilities_management/rm6232/admin/supplier_lot_data/_service_codes')
+      end
+
+      it 'sets the lot data' do
+        expect(assigns(:lot_data)).to eq lot_data
+        expect(assigns(:lot_code)).to eq lot_data.lot_code
+        expect(assigns(:supplier).supplier_name).to eq lot_data.supplier_name
+      end
+
+      it 'sets the work_packages data' do
+        expect(assigns(:work_packages)).not_to be_nil
+      end
+    end
+
     context 'when the lot data type is region codes' do
       let(:lot_data_type) { 'region_codes' }
 
@@ -121,6 +143,25 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierLotDataController, t
         it 'sets the region data' do
           expect(assigns(:regions)).not_to be_nil
         end
+      end
+    end
+
+    context 'when the lot data type is service codes' do
+      let(:lot_data_type) { 'service_codes' }
+      let(:attributes) { { service_codes: %w[E.1 F.1] } }
+
+      it 'redirects to facilities_management_rm6232_admin_supplier_lot_datum_path' do
+        expect(response).to redirect_to facilities_management_rm6232_admin_supplier_lot_datum_path(lot_data.supplier.id)
+      end
+
+      it 'sets the lot data' do
+        expect(assigns(:lot_data)).to eq lot_data
+        expect(assigns(:lot_code)).to eq lot_data.lot_code
+        expect(assigns(:supplier).supplier_name).to eq lot_data.supplier_name
+      end
+
+      it 'does not set the work_packages data' do
+        expect(assigns(:work_packages)).to be_nil
       end
     end
 


### PR DESCRIPTION
Ticket: [FMFR-1011](https://crowncommercialservice.atlassian.net/browse/FMFR-1011)

Add the ability to edit the suppliers services in the admin tool

To do this I:
- Add some config for the services to the controller
- Add the service codes page
- Add controller specs
- Add feature and accessibility tests