### PR TITLE
FMFR-1008 - Add the ability to change the supplier status

### DIFF
--- a/app/controllers/facilities_management/admin/supplier_details_controller.rb
+++ b/app/controllers/facilities_management/admin/supplier_details_controller.rb
@@ -49,7 +49,8 @@ module FacilitiesManagement
         supplier_contact_information: %i[contact_name contact_email contact_phone],
         additional_supplier_information: %i[duns registration_number],
         supplier_address: %i[address_line_1 address_line_2 address_town address_county address_postcode],
-        supplier_user: %i[user_email]
+        supplier_user: %i[user_email],
+        supplier_status: %i[active]
       }.freeze
 
       SUPPLIER_ADMIN_MODULES = {

--- a/app/models/facilities_management/rm3830/admin/suppliers_admin.rb
+++ b/app/models/facilities_management/rm3830/admin/suppliers_admin.rb
@@ -17,6 +17,10 @@ module FacilitiesManagement
           true
         end
 
+        def suspendable?
+          false
+        end
+
         def replace_services_for_lot(new_services, target_lot)
           lot_data[target_lot]['services'] = new_services || []
         end

--- a/app/models/facilities_management/rm6232/admin/suppliers_admin.rb
+++ b/app/models/facilities_management/rm6232/admin/suppliers_admin.rb
@@ -6,8 +6,22 @@ module FacilitiesManagement
 
         include FacilitiesManagement::Admin::SuppliersAdmin
 
+        validates :active, inclusion: { in: [true, false] }, on: :supplier_status
+
         def user_information_required?
           false
+        end
+
+        def suspendable?
+          true
+        end
+
+        def current_status
+          if active
+            [:blue, 'ACTIVE']
+          else
+            [:red, 'INACTIVE']
+          end
         end
       end
     end

--- a/app/models/facilities_management/rm6232/supplier.rb
+++ b/app/models/facilities_management/rm6232/supplier.rb
@@ -4,7 +4,8 @@ module FacilitiesManagement
       has_many :lot_data, inverse_of: :supplier, class_name: 'FacilitiesManagement::RM6232::Supplier::LotData', dependent: :destroy, foreign_key: :facilities_management_rm6232_supplier_id
 
       def self.select_suppliers(lot_code, service_codes, region_codes)
-        joins(:lot_data)
+        where(active: true)
+          .joins(:lot_data)
           .where('facilities_management_rm6232_supplier_lot_data.lot_code': lot_code)
           .where('facilities_management_rm6232_supplier_lot_data.service_codes @> ?', "{#{service_codes.join(',')}}")
           .where('facilities_management_rm6232_supplier_lot_data.region_codes @> ?', "{#{region_codes.join(',')}}")

--- a/app/views/facilities_management/admin/supplier_details/_supplier_status.html.erb
+++ b/app/views/facilities_management/admin/supplier_details/_supplier_status.html.erb
@@ -1,0 +1,20 @@
+<%= form_group_with_error(f.object, :active) do |displayed_error, any_errors| %>
+  <%= f.hidden_field :active %>
+  <%= f.label(:active, t('.supplier_status_question'), class: 'govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-left-0') %>
+  <p class="govuk-body govuk-!-margin-top-4"><%= t('.status_hint') %></p>
+  <%= displayed_error %>
+  <div class="govuk-radios govuk-radios--inline">
+    <div class="govuk-radios__item">
+      <%= f.radio_button :active, true, class: 'govuk-radios__input', required: true %>
+      <%= f.label :active, value: true, class: 'govuk-label govuk-radios__label' do %>
+        <%= govuk_tag_with_text(:blue, t('.active')) %>
+      <% end %>
+    </div>
+    <div class="govuk-radios__item">
+      <%= f.radio_button :active, false, class: 'govuk-radios__input', required: true %>
+      <%= f.label :active, value: false , class: 'govuk-label govuk-radios__label' do %>
+        <%= govuk_tag_with_text(:red, t('.inactive')) %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/facilities_management/admin/supplier_details/edit.html.erb
+++ b/app/views/facilities_management/admin/supplier_details/edit.html.erb
@@ -5,7 +5,7 @@
   { text: t(".page_title.#{@page}") }
 ) %>
 
-<%= form_with model: @supplier, url: facilities_management_admin_supplier_detail_path(page: @page), local: 'false', html: { specialvalidation: true } do |f| %>
+<%= form_with model: @supplier, url: facilities_management_admin_supplier_detail_path(page: @page), local: 'false', html: { specialvalidation: true, novalidate: true } do |f| %>
   <%= render partial: 'shared/error_summary', locals: { errors: f.object.errors } %>
   <%= govuk_page_header(FacilitiesManagement::PageDetail::Heading.new(t(".page_title.#{@page}"), current_supplier_name, nil, nil, nil)) %>
   <div class="govuk-grid-row">

--- a/app/views/facilities_management/admin/supplier_details/show.html.erb
+++ b/app/views/facilities_management/admin/supplier_details/show.html.erb
@@ -33,6 +33,30 @@
   </div>
 <% end %>
 
+<% if @supplier.suspendable? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-l">
+        <%= t('.supplier_status')%>
+      </h2>
+      <hr class="govuk-section-break govuk-section-break--visible">
+      <dl class="govuk-summary-list">
+        <div id="supplier-details--supplier_status" class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= t('.current_status') %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= govuk_tag_with_text(*@supplier.current_status) %>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :supplier_status), class: 'govuk-link--no-visited-state') %>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l">

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -140,6 +140,7 @@ en:
             supplier_address: Supplier address
             supplier_contact_information: Supplier contact information
             supplier_name: Supplier name
+            supplier_status: Supplier status
             supplier_user: Supplier user account
           save_and_return: Save and return
         show:
@@ -148,6 +149,7 @@ en:
           contact_email: Contact email
           contact_name: Contact name
           contact_phone: Contact telephone number
+          current_status: Current status
           current_user: Current user
           duns: DUNS number
           edit_supplier_details: You can edit the details for the supplier by clicking on change
@@ -158,6 +160,7 @@ en:
           supplier_contact_information: Supplier contact information
           supplier_details: Supplier details
           supplier_name: Supplier name
+          supplier_status: Supplier status
         supplier_address:
           building_and_street: Building and street
           county: County (optional)
@@ -170,6 +173,11 @@ en:
           contact_phone_question: Enter the telephone number for the supplier
         supplier_name:
           supplier_name_question: Enter the name for the supplier
+        supplier_status:
+          active: Active
+          inactive: Inactive
+          status_hint: To prevent the supplier from appearing in search results, change the supplier status to 'INACTIVE'
+          supplier_status_question: What is the status of the supplier?
         supplier_user:
           email_must: 'This user must:'
           email_must_1: be a registered user with the facilities management service

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -5,6 +5,8 @@ en:
       models:
         facilities_management/rm6232/admin/suppliers_admin:
           attributes:
+            active:
+              inclusion: You must select a status for the supplier
             address_county:
               too_long: The county must be 50 characters or less
             address_line_1:

--- a/features/accessibility/facilities_management/rm6232/admin/supplier_details_accessibility.feature
+++ b/features/accessibility/facilities_management/rm6232/admin/supplier_details_accessibility.feature
@@ -12,6 +12,11 @@ Feature: Supplier details - accessibility
   Scenario: Supplier detail page
     Then the page should be axe clean
 
+  Scenario: Supplier status page
+    And I change the 'Supplier status' for the supplier details
+    Then I am on the 'Supplier status' page
+    Then the page should be axe clean
+
   Scenario: Supplier name page
     And I change the 'Supplier name' for the supplier details
     Then I am on the 'Supplier name' page

--- a/features/facilities_management/rm3830/admin/supplier_data/supplier_details/supplier_details.feature
+++ b/features/facilities_management/rm3830/admin/supplier_data/supplier_details/supplier_details.feature
@@ -20,13 +20,17 @@ Feature: Supplier details
     And I change the '<supplier_detail>' for the supplier details
     Then I am on the '<current_page>' page
     Given I click on '<text>'
-    Then I am on the '<page>' page
+    Then I am on the 'Supplier details' page
 
     Examples:
-      | supplier_detail | current_page                    | text                                      | page              |
-      | Current user    | Supplier user account           | Ullrich, Ratke and Botsford               | Supplier details  |
-      | Current user    | Supplier user account           | Cancel and return to the supplier details | Supplier details  |
-      | Supplier name   | Supplier name                   | Cancel and return to the supplier details | Supplier details  |
-      | Contact name    | Supplier contact information    | Cancel and return to the supplier details | Supplier details  |
-      | DUNS number     | Additional supplier information | Cancel and return to the supplier details | Supplier details  |
-      | Full address    | Supplier address                | Cancel and return to the supplier details | Supplier details  |
+      | supplier_detail | current_page                    | text                                      |
+      | Current user    | Supplier user account           | Ullrich, Ratke and Botsford               |
+      | Current user    | Supplier user account           | Cancel and return to the supplier details |
+      | Supplier name   | Supplier name                   | Ullrich, Ratke and Botsford               |
+      | Supplier name   | Supplier name                   | Cancel and return to the supplier details |
+      | Contact name    | Supplier contact information    | Ullrich, Ratke and Botsford               |
+      | Contact name    | Supplier contact information    | Cancel and return to the supplier details |
+      | DUNS number     | Additional supplier information | Ullrich, Ratke and Botsford               |
+      | DUNS number     | Additional supplier information | Cancel and return to the supplier details |
+      | Full address    | Supplier address                | Ullrich, Ratke and Botsford               |
+      | Full address    | Supplier address                | Cancel and return to the supplier details |

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_details/supplier_details.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_details/supplier_details.feature
@@ -21,11 +21,17 @@ Feature: Supplier details
     And I change the '<supplier_detail>' for the supplier details
     Then I am on the '<current_page>' page
     Given I click on '<text>'
-    Then I am on the '<page>' page
+    Then I am on the 'Supplier details' page
 
     Examples:
-      | supplier_detail | current_page                    | text                                      | page              |
-      | Supplier name   | Supplier name                   | Cancel and return to the supplier details | Supplier details  |
-      | Contact name    | Supplier contact information    | Cancel and return to the supplier details | Supplier details  |
-      | DUNS number     | Additional supplier information | Cancel and return to the supplier details | Supplier details  |
-      | Full address    | Supplier address                | Cancel and return to the supplier details | Supplier details  |
+      | supplier_detail | current_page                    | text                                      |
+      | Supplier status | Supplier status                 | Zboncak and Sons                          |
+      | Supplier status | Supplier status                 | Cancel and return to the supplier details |
+      | Supplier name   | Supplier name                   | Zboncak and Sons                          |
+      | Supplier name   | Supplier name                   | Cancel and return to the supplier details |
+      | Contact name    | Supplier contact information    | Zboncak and Sons                          |
+      | Contact name    | Supplier contact information    | Cancel and return to the supplier details |
+      | DUNS number     | Additional supplier information | Zboncak and Sons                          |
+      | DUNS number     | Additional supplier information | Cancel and return to the supplier details |
+      | Full address    | Supplier address                | Zboncak and Sons                          |
+      | Full address    | Supplier address                | Cancel and return to the supplier details |

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_details/supplier_status.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_details/supplier_status.feature
@@ -1,0 +1,21 @@
+Feature: Supplier status
+
+  Background: Sign in
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+
+  Scenario: Changing the supplier status is saved
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    Then I click on 'View details' for 'Hudson, Spinka and Schuppe'
+    And I am on the 'Supplier details' page
+    And the supplier name on the details page is 'Hudson, Spinka and Schuppe'
+    And the 'Supplier status' is 'ACTIVE' on the supplier details page
+    And I change the 'Supplier status' for the supplier details
+    Then I am on the 'Supplier status' page
+    And I select 'INACTIVE' for the supplier status
+    And I click on 'Save and return'
+    Then I am on the 'Supplier details' page
+    And the 'Supplier status' is 'INACTIVE' on the supplier details page
+
+  # TODO: Add feature when quick view has been developed
+  

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_details/validations/supplier_status_validations.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_details/validations/supplier_status_validations.feature
@@ -1,0 +1,16 @@
+@pipeline
+Feature: Supplier status - validations
+
+  Scenario: Validate supplier status
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I have an inactive supplier called 'Argentum INC.'
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    Then I click on 'View details' for 'Argentum INC.'
+    And I am on the 'Supplier details' page
+    And the supplier name on the details page is 'Argentum INC.'
+    And I change the 'Supplier status' for the supplier details
+    Then I am on the 'Supplier status' page
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | You must select a status for the supplier |

--- a/features/step_definitions/facilities_management/rm6232/admin_steps.rb
+++ b/features/step_definitions/facilities_management/rm6232/admin_steps.rb
@@ -1,3 +1,7 @@
+Given('I have an inactive supplier called {string}') do |supplier_name|
+  create(:facilities_management_rm6232_admin_suppliers_admin, supplier_name: supplier_name, active: nil, address_county: 'Essex')
+end
+
 Then('I should see all the suppliers') do
   expect(admin_rm6232_page.suppliers.length).to eq 50
 end
@@ -57,6 +61,15 @@ Then("I can't select any core services") do
   core_service_names = core_services.map(&:label_name)
 
   expect(core_service_labels).to eq core_service_names
+end
+
+Then('I select {string} for the supplier status') do |option|
+  case option
+  when 'ACTIVE'
+    admin_rm6232_page.active_true.choose
+  when 'INACTIVE'
+    admin_rm6232_page.active_false.choose
+  end
 end
 
 def core_services

--- a/features/support/pages/admin.rb
+++ b/features/support/pages/admin.rb
@@ -8,6 +8,11 @@ module Pages
         element :detail, 'dd.govuk-summary-list__value'
       end
 
+      section :'Supplier status', '#supplier-details--supplier_status' do
+        element :change_link, 'dd.govuk-summary-list__actions > a'
+        element :detail, 'dd.govuk-summary-list__value'
+      end
+
       section :'Supplier name', '#supplier-details--supplier_name' do
         element :change_link, 'dd.govuk-summary-list__actions > a'
         element :detail, 'dd.govuk-summary-list__value'

--- a/features/support/pages/rm6232/admin.rb
+++ b/features/support/pages/rm6232/admin.rb
@@ -57,5 +57,8 @@ module Pages::RM6232
         end
       end
     end
+
+    element :active_true, '#facilities_management_rm6232_admin_suppliers_admin_active_true'
+    element :active_false, '#facilities_management_rm6232_admin_suppliers_admin_active_false'
   end
 end

--- a/spec/controllers/facilities_management/admin/supplier_details_controller_rm6232_spec.rb
+++ b/spec/controllers/facilities_management/admin/supplier_details_controller_rm6232_spec.rb
@@ -120,6 +120,26 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController, type: :co
         expect(assigns(:page)).to eq page
       end
     end
+
+    context 'when on the supplier status page' do
+      let(:page) { :supplier_status }
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'renders the correct partial' do
+        expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_status')
+      end
+
+      it 'sets the supplier' do
+        expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+      end
+
+      it 'sets the page' do
+        expect(assigns(:page)).to eq page
+      end
+    end
   end
 
   describe 'PUT update' do
@@ -204,6 +224,27 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController, type: :co
 
       context 'and the data is valid' do
         let(:address_postcode) { 'AA1 1AA' }
+
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+        end
+      end
+    end
+
+    context 'when updating on the supplier status page' do
+      let(:page) { :supplier_status }
+      let(:supplier_params) { { active: supplier_status } }
+
+      context 'and the data is not valid' do
+        let(:supplier_status) { '' }
+
+        it 'renders the edit page' do
+          expect(response).to render_template :edit
+        end
+      end
+
+      context 'and the data is valid' do
+        let(:supplier_status) { 'true' }
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')

--- a/spec/models/facilities_management/rm3830/admin/suppliers_admin_spec.rb
+++ b/spec/models/facilities_management/rm3830/admin/suppliers_admin_spec.rb
@@ -918,4 +918,12 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SuppliersAdmin, type: :model
       expect(supplier.user_information_required?).to be true
     end
   end
+
+  describe '.suspendable?' do
+    let(:supplier) { create(:facilities_management_rm3830_admin_supplier_detail) }
+
+    it 'returns false' do
+      expect(supplier.suspendable?).to be false
+    end
+  end
 end

--- a/spec/models/facilities_management/rm6232/admin/suppliers_admin_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/suppliers_admin_spec.rb
@@ -760,9 +760,83 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SuppliersAdmin, type: :model
     end
   end
 
+  context 'when considering supplier_status' do
+    before { supplier.active = supplier_status }
+
+    context 'when the status is nil' do
+      let(:supplier_status) { nil }
+
+      it 'is invalid' do
+        expect(supplier.valid?(:supplier_status)).to eq false
+      end
+
+      it 'has the correct error message' do
+        supplier.valid?(:supplier_status)
+
+        expect(supplier.errors[:active].first).to eq 'You must select a status for the supplier'
+      end
+    end
+
+    context 'when the status is not present' do
+      let(:supplier_status) { '' }
+
+      it 'is invalid' do
+        expect(supplier.valid?(:supplier_status)).to eq false
+      end
+
+      it 'has the correct error message' do
+        supplier.valid?(:supplier_status)
+
+        expect(supplier.errors[:active].first).to eq 'You must select a status for the supplier'
+      end
+    end
+
+    context 'when the status is true' do
+      let(:supplier_status) { true }
+
+      it 'is valid' do
+        expect(supplier.valid?(:supplier_status)).to be true
+      end
+    end
+
+    context 'when the status is false' do
+      let(:supplier_status) { false }
+
+      it 'is valid' do
+        expect(supplier.valid?(:supplier_status)).to be true
+      end
+    end
+  end
+
   describe '.user_information_required?' do
     it 'returns false' do
       expect(supplier.user_information_required?).to be false
+    end
+  end
+
+  describe '.suspendable?' do
+    it 'returns true' do
+      expect(supplier.suspendable?).to be true
+    end
+  end
+
+  describe '.current_status' do
+    let(:supplier) { create(:facilities_management_rm6232_admin_suppliers_admin, active: active) }
+
+    context 'when the supplier is active' do
+      let(:active) { true }
+
+      it 'returns blue and ACTIVE' do
+        expect(supplier.current_status).to eq [:blue, 'ACTIVE']
+      end
+    end
+
+    context 'when the supplier is not active' do
+      let(:active) { false }
+
+      it 'returns red and INACTIVE' do
+        expect(supplier.current_status).to eq [:red, 'INACTIVE']
+      end
     end
   end
 end

--- a/spec/models/facilities_management/rm6232/supplier_spec.rb
+++ b/spec/models/facilities_management/rm6232/supplier_spec.rb
@@ -58,6 +58,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
           it 'returns a list of suppliers that includes my_supplier' do
             expect(supplier_names).to include my_supplier.supplier_name
           end
+
+          context 'and my_supplier is not active' do
+            before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is b (lot: 1b)' do
@@ -66,6 +74,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
           it 'returns a list of suppliers that includes my_supplier' do
             expect(supplier_names).to include my_supplier.supplier_name
           end
+
+          context 'and my_supplier is not active' do
+            before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is c (lot: 1c)' do
@@ -73,6 +89,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
 
           it 'returns a list of suppliers that includes my_supplier' do
             expect(supplier_names).to include my_supplier.supplier_name
+          end
+
+          context 'and my_supplier is not active' do
+            before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
           end
         end
       end
@@ -86,6 +110,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
           it 'returns a list of suppliers that includes my_supplier' do
             expect(supplier_names).to include my_supplier.supplier_name
           end
+
+          context 'and my_supplier is not active' do
+            before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is b (lot: 2b)' do
@@ -94,6 +126,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
           it 'returns a list of suppliers that includes my_supplier' do
             expect(supplier_names).to include my_supplier.supplier_name
           end
+
+          context 'and my_supplier is not active' do
+            before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is c (lot: 2c)' do
@@ -101,6 +141,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
 
           it 'returns a list of suppliers that includes my_supplier' do
             expect(supplier_names).to include my_supplier.supplier_name
+          end
+
+          context 'and my_supplier is not active' do
+            before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
           end
         end
       end
@@ -114,6 +162,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
           it 'returns a list of suppliers that includes my_supplier' do
             expect(supplier_names).to include my_supplier.supplier_name
           end
+
+          context 'and my_supplier is not active' do
+            before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is b (lot: 3b)' do
@@ -122,6 +178,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
           it 'returns a list of suppliers that includes my_supplier' do
             expect(supplier_names).to include my_supplier.supplier_name
           end
+
+          context 'and my_supplier is not active' do
+            before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is c (lot: 3c)' do
@@ -129,6 +193,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
 
           it 'returns a list of suppliers that includes my_supplier' do
             expect(supplier_names).to include my_supplier.supplier_name
+          end
+
+          context 'and my_supplier is not active' do
+            before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
           end
         end
       end

--- a/spec/services/facilities_management/rm6232/suppliers_selector_spec.rb
+++ b/spec/services/facilities_management/rm6232/suppliers_selector_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
   let(:supplier_services) { service_codes }
   let(:supplier_regions) { region_codes }
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'lot number and selected suppliers' do
     context 'when all services are hard' do
       let(:selection_one) { { total: true, hard: true, soft: false } }
@@ -34,6 +35,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
         it 'returns a list of suppliers that includes my_supplier' do
           expect(supplier_names).to include my_supplier.supplier_name
         end
+
+        context 'and my_supplier is not active' do
+          before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
       end
 
       context 'and the annual_contract_value is a more than 1,500,000 and less than 10,000,000' do
@@ -47,6 +56,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
         it 'returns a list of suppliers that includes my_supplier' do
           expect(supplier_names).to include my_supplier.supplier_name
         end
+
+        context 'and my_supplier is not active' do
+          before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
       end
 
       context 'and the annual_contract_value is more than 10,000,000' do
@@ -59,6 +76,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
 
         it 'returns a list of suppliers that includes my_supplier' do
           expect(supplier_names).to include my_supplier.supplier_name
+        end
+
+        context 'and my_supplier is not active' do
+          before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
         end
       end
     end
@@ -77,6 +102,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
         it 'returns a list of suppliers that includes my_supplier' do
           expect(supplier_names).to include my_supplier.supplier_name
         end
+
+        context 'and my_supplier is not active' do
+          before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
       end
 
       context 'and the annual_contract_value is a more than 1,000,000 and less than 7,000,000' do
@@ -90,6 +123,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
         it 'returns a list of suppliers that includes my_supplier' do
           expect(supplier_names).to include my_supplier.supplier_name
         end
+
+        context 'and my_supplier is not active' do
+          before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
       end
 
       context 'and the annual_contract_value is more than 7,000,000' do
@@ -102,6 +143,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
 
         it 'returns a list of suppliers that includes my_supplier' do
           expect(supplier_names).to include my_supplier.supplier_name
+        end
+
+        context 'and my_supplier is not active' do
+          before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
         end
       end
     end
@@ -121,6 +170,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
         it 'returns a list of suppliers that includes my_supplier' do
           expect(supplier_names).to include my_supplier.supplier_name
         end
+
+        context 'and my_supplier is not active' do
+          before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
       end
 
       context 'and the annual_contract_value is a more than 1,500,000 and less than 10,000,000' do
@@ -134,6 +191,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
         it 'returns a list of suppliers that includes my_supplier' do
           expect(supplier_names).to include my_supplier.supplier_name
         end
+
+        context 'and my_supplier is not active' do
+          before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
       end
 
       context 'and the annual_contract_value is more than 10,000,000' do
@@ -146,6 +211,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
 
         it 'returns a list of suppliers that includes my_supplier' do
           expect(supplier_names).to include my_supplier.supplier_name
+        end
+
+        context 'and my_supplier is not active' do
+          before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
         end
       end
     end
@@ -247,4 +320,5 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 end


### PR DESCRIPTION
Ticket: [FMFR-1008](https://crowncommercialservice.atlassian.net/browse/FMFR-1008)

The supplier status can be changed between active and inactive.
If the status is inactive then the supplier will not appear in search results.

To do this I:
- Added the Supplier status sections to the show and edit pages
- Added specs, feature and accessibility tests for changing the status
- Added the active condition to the `select_suppliers` method in the suppliers model
- Added tests to make sure the supplier does not appear if it is inactive