### PR TITLE
FMFR-1003 - Quick view - Choose Services

### DIFF
--- a/app/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller.rb
@@ -57,7 +57,7 @@ module FacilitiesManagement
         end
 
         def set_work_packages
-          @work_packages = WorkPackage.selectable.index_with(&:services)
+          @work_packages = WorkPackage.selectable.index_with(&:supplier_services)
         end
 
         def set_regions

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -357,5 +357,25 @@ module ApplicationHelper
       ]
     end
   end
+
+  def rm6232_accordion_service_items(service_codes)
+    FacilitiesManagement::RM6232::WorkPackage.selectable.map do |work_package|
+      [
+        work_package.code,
+        {
+          name: work_package.name,
+          items: work_package.selectable_services.map do |service|
+            {
+              code: service.code.tr('.', '-'),
+              value: service.code,
+              name: service.name,
+              selected: service_codes&.include?(service.code),
+              description: service.description
+            }
+          end
+        }
+      ]
+    end
+  end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/app/models/facilities_management/rm6232/journey/choose_services.rb
+++ b/app/models/facilities_management/rm6232/journey/choose_services.rb
@@ -1,0 +1,26 @@
+module FacilitiesManagement
+  module RM6232
+    class Journey::ChooseServices
+      include Steppable
+
+      attribute :service_codes, Array
+      validates :service_codes, length: { minimum: 1 }
+      validate :validate_not_all_mandatory
+
+      attribute :region_codes, Array
+      attribute :annual_contract_value, Numeric
+
+      def next_step_class
+        # Journey::ChooseLocations
+      end
+
+      private
+
+      def validate_not_all_mandatory
+        errors.add(:service_codes, :invalid_cafm_helpdesk_billable) if (service_codes - MANDATORY_SERVICES).empty?
+      end
+
+      MANDATORY_SERVICES = %w[Q.3 R.1 S.1].freeze
+    end
+  end
+end

--- a/app/models/facilities_management/rm6232/journey/start_a_procurement.rb
+++ b/app/models/facilities_management/rm6232/journey/start_a_procurement.rb
@@ -3,8 +3,12 @@ module FacilitiesManagement
     class Journey::StartAProcurement
       include Steppable
 
+      attribute :service_codes, Array
+      attribute :region_codes, Array
+      attribute :annual_contract_value, Numeric
+
       def next_step_class
-        Journey::StartAProcurement
+        Journey::ChooseServices
       end
     end
   end

--- a/app/models/facilities_management/rm6232/work_package.rb
+++ b/app/models/facilities_management/rm6232/work_package.rb
@@ -4,6 +4,20 @@ module FacilitiesManagement
       scope :selectable, -> { where(selectable: true).order(:code) }
 
       has_many :services, foreign_key: :work_package_code, inverse_of: :work_package, dependent: :destroy
+
+      # This is because of the nature of CAFM services
+      # You can find more information at https://crowncommercialservice.atlassian.net/l/c/XW2DSi72
+      def selectable_services
+        return services.order(:sort_order) unless code == 'Q'
+
+        services.where(code: 'Q.3').order(:sort_order)
+      end
+
+      def supplier_services
+        return services.order(:sort_order) unless code == 'Q'
+
+        services.where.not(code: 'Q.3').order(:sort_order)
+      end
     end
   end
 end

--- a/app/models/generic_journey.rb
+++ b/app/models/generic_journey.rb
@@ -92,8 +92,7 @@ class GenericJourney
     },
     'RM6232' => {
       'start-a-procurement' => 'Return to your account',
-      'choose-services' => 'Return to your account',
-      'choose-locations' => 'Return to services'
+      'choose-services' => "Return to 'Start a procurement'"
     }
   }.freeze
 end

--- a/app/views/facilities_management/rm6232/journey/choose_services.html.erb
+++ b/app/views/facilities_management/rm6232/journey/choose_services.html.erb
@@ -1,0 +1,64 @@
+<% content_for :page_title, t('.question') %>
+<%= render partial: 'shared/error_summary', locals: { errors: @journey.errors } %>
+
+<div class="procurement">
+  <div class="services chooser-component">
+    <div id="ccs-accordion-with-basket" class="govuk-grid-row">
+      <%= form_with url: @form_path, method: :get, local: true, html: { specialvalidation: true, novalidate: true } do %>
+        <div class="govuk-grid-column-two-thirds">
+          <%= hidden_fields_for_previous_steps_and_responses(@journey) %>
+          <%= govuk_form_group_with_optional_error(@journey, :service_codes) do %>
+            <%= govuk_fieldset_with_optional_error(@journey, :service_codes) do %>
+              <div>
+                <legend>
+                  <h1 class="govuk-heading-xl">
+                    <%= t('.heading') %>
+                  </h1>
+                </legend>
+                <h2 class="govuk-heading-m">
+                  <%= t('.question') %>
+                </h2>
+                <p class="govuk-caption-m">
+                  <%= t('.caption') %>
+                </p>
+                <p>
+                  <%#= service_specification_document('rm3830') %>
+                </p>
+              </div>
+              <div class="govuk-grid-column-full" style="padding-left:0">
+                <%= form_tag 'choose-services/answer', method: :get do %>
+                  <%= display_potential_errors(@journey.steps[0], :service_codes, '')%>
+                  <div class="chooser-input">
+                    <%= govuk_accordion_with_checkboxes(
+                      'choose-services',
+                      rm6232_accordion_service_items(@journey.current_step.service_codes),
+                      'service',
+                      'service_codes'
+                    ) do %>
+                      <%= link_to t('.learn_more'), '#' %>
+                    <% end %>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          <% end %>
+          <div>
+            <% params[:region_codes]&.split(" ") do |region_code| %>
+              <%= hidden_field_tag "region_codes[]", region_code %>
+            <% end %>
+            <%= hidden_field_tag :annual_contract_value, params[:annual_contract_value] if params[:annual_contract_value] %>
+          </div>
+          <div>
+            <%= submit_tag t('common.submit'), class: "govuk-button govuk-!-margin-bottom-4", aria: { label: t('common.submit') } %>
+            <p>
+              <%= link_to t('.return_text'), facilities_management_rm6232_path, class: 'govuk-link' %>
+            </p>
+          </div>
+        </div>
+        <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
+          <%= render partial: 'facilities_management/shared/baskets/services_basket' %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/facilities_management/rm6232/journey/start_a_procurement.html.erb
+++ b/app/views/facilities_management/rm6232/journey/start_a_procurement.html.erb
@@ -111,7 +111,16 @@
   </div>
 </div>
 
-<%= form_tag @form_path, method: :get do %>
+<%= form_with url: @form_path, method: :get, local: true, html: { specialvalidation: true, novalidate: true } do %>
+  <div>
+    <% params[:service_codes]&.split(" ") do |service_code| %>
+      <%= hidden_field_tag "service_codes[]", service_code %>
+    <% end %>
+    <% params[:region_codes]&.split(" ") do |region_code| %>
+      <%= hidden_field_tag "region_codes[]", region_code %>
+    <% end %>
+    <%= hidden_field_tag :annual_contract_value, params[:annual_contract_value] if params[:annual_contract_value] %>  <div class="govuk-grid-row">
+  </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= submit_tag t('common.submit'), class: 'govuk-button', aria: { label: t('common.submit') } %>

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -1,5 +1,13 @@
 ---
 en:
+  activemodel:
+    errors:
+      models:
+        facilities_management/rm6232/journey/choose_services:
+          attributes:
+            service_codes:
+              invalid_cafm_helpdesk_billable: You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'
+              too_short: Select at least one service you need to include in your procurement
   activerecord:
     errors:
       models:
@@ -122,6 +130,12 @@ en:
             <li>shortlist suppliers ready for further competition</li>
           youneedtoknow: 'You need to know:'
       journey:
+        choose_services:
+          caption: Choose all facilities management services required within your estate, even if you want services in just one building.
+          heading: Services
+          learn_more: Further details (opens in a new tab)
+          question: Select the facilities management services that you need
+          return_text: Return to your account
         start_a_procurement:
           heading: Start a procurement
           return_text: Return to your account

--- a/data/facilities_management/rm6232/services.csv
+++ b/data/facilities_management/rm6232/services.csv
@@ -168,5 +168,6 @@ P.14,Accommodation Compliance Services,Manage all activities relating to complia
 P.15,Accommodation Maintenance Services,Provide vacant/unoccupied property preparation and management services,FALSE,P,TRUE,FALSE,FALSE,13
 Q.1,CAFM – Soft FM Requirements,Provide the system and software required to deliver the Services when provision of a Soft FM service is included,TRUE,Q,FALSE,FALSE,TRUE,0
 Q.2,TFM & Hard FM CAFM Requirements,Provide the system and software required to deliver the Services when provision of a TFM and / or Hard FM service is included,TRUE,Q,TRUE,TRUE,FALSE,1
+Q.3,CAFM system,"CAFM system and associated software required to deliver FM services, aligned to asset requirements and SFG20",TRUE,Q,TRUE,TRUE,TRUE,0
 R.1,Helpdesk Services,"Fully staffed, supervised helpdesk service for all FM related service requests and fault reporting",TRUE,R,TRUE,TRUE,TRUE,0
 S.1,"Management of Billable Works; Small Works, Projects, Installation Works and Reactive Maintenance Works",Chargeable services delivered outside the agreed overall contract price for example small/large projects,TRUE,S,TRUE,TRUE,TRUE,0

--- a/spec/models/facilities_management/rm6232/journey/choose_services_spec.rb
+++ b/spec/models/facilities_management/rm6232/journey/choose_services_spec.rb
@@ -1,0 +1,184 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Journey::ChooseServices, type: :model do
+  let(:choose_services) { described_class.new(service_codes: service_codes, region_codes: region_codes, annual_contract_value: annual_contract_value) }
+  let(:service_codes) { %w[E.1 E.2] }
+  let(:region_codes) {  %w[UKC1 UKC2] }
+  let(:annual_contract_value) { 123_456 }
+
+  describe 'validations' do
+    context 'when no service codes are present' do
+      let(:service_codes) { [] }
+
+      it 'is not valid and has the correct error message' do
+        expect(choose_services.valid?).to be false
+        expect(choose_services.errors[:service_codes].first).to eq 'Select at least one service you need to include in your procurement'
+      end
+    end
+
+    # rubocop:disable RSpec/NestedGroups
+    context 'when validateing that not all services are mandatory' do
+      context 'when the only code is Q.3' do
+        let(:service_codes) { %w[Q.3] }
+
+        it 'is not valid and has the correct error message' do
+          expect(choose_services.valid?).to be false
+          expect(choose_services.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { choose_services.service_codes << 'H.1' }
+
+          it 'will be valid' do
+            expect(choose_services.valid?).to be true
+          end
+        end
+      end
+
+      context 'when the only code is R.1' do
+        let(:service_codes) { %w[R.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(choose_services.valid?).to be false
+          expect(choose_services.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { choose_services.service_codes << 'J.1' }
+
+          it 'will be valid' do
+            expect(choose_services.valid?).to be true
+          end
+        end
+      end
+
+      context 'when the only code is S.1' do
+        let(:service_codes) { %w[S.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(choose_services.valid?).to be false
+          expect(choose_services.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { choose_services.service_codes << 'K.1' }
+
+          it 'will be valid' do
+            expect(choose_services.valid?).to be true
+          end
+        end
+      end
+
+      context 'when the only codes are Q.3 and R.1' do
+        let(:service_codes) { %w[Q.3 R.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(choose_services.valid?).to be false
+          expect(choose_services.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { choose_services.service_codes << 'L.1' }
+
+          it 'will be valid' do
+            expect(choose_services.valid?).to be true
+          end
+        end
+      end
+
+      context 'when the only codes are Q.3 and S.1' do
+        let(:service_codes) { %w[Q.3 S.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(choose_services.valid?).to be false
+          expect(choose_services.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { choose_services.service_codes << 'M.1' }
+
+          it 'will be valid' do
+            expect(choose_services.valid?).to be true
+          end
+        end
+      end
+
+      context 'when the only codes are S.1 and R.1' do
+        let(:service_codes) { %w[S.1 R.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(choose_services.valid?).to be false
+          expect(choose_services.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { choose_services.service_codes << 'J.2' }
+
+          it 'will be valid' do
+            expect(choose_services.valid?).to be true
+          end
+        end
+      end
+
+      context 'when the only codes are Q.3, S.1 and R.1' do
+        let(:service_codes) { %w[Q.3 S.1 R.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(choose_services.valid?).to be false
+          expect(choose_services.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { choose_services.service_codes << 'K.2' }
+
+          it 'will be valid' do
+            expect(choose_services.valid?).to be true
+          end
+        end
+      end
+    end
+    # rubocop:enable RSpec/NestedGroups
+
+    context 'when service codes are present' do
+      it 'is valid' do
+        expect(choose_services.valid?).to be true
+      end
+    end
+  end
+
+  describe '.next_step_class' do
+    pending 'returns Journey::ChooseLocations' do
+      expect(choose_services.next_step_class).to be FacilitiesManagement::RM6232::Journey::ChooseLocations
+    end
+  end
+
+  describe '.permit_list' do
+    it 'returns a list of the permitted attributes' do
+      expect(described_class.permit_list).to eq [:annual_contract_value, { service_codes: [], region_codes: [] }]
+    end
+  end
+
+  describe '.permitted_keys' do
+    it 'returns a list of the permitted keys' do
+      expect(described_class.permitted_keys).to eq %i[service_codes region_codes annual_contract_value]
+    end
+  end
+
+  describe '.slug' do
+    it 'returns choose-services' do
+      expect(choose_services.slug).to eq 'choose-services'
+    end
+  end
+
+  describe '.template' do
+    it 'returns journey/choose_services' do
+      expect(choose_services.template).to eq 'journey/choose_services'
+    end
+  end
+
+  describe '.final?' do
+    pending 'returns false' do
+      expect(choose_services.final?).to be false
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/journey/start_a_procurement_spec.rb
+++ b/spec/models/facilities_management/rm6232/journey/start_a_procurement_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Journey::StartAProcurement, type: :model do
+  let(:start_a_procurement) { described_class.new }
+
+  describe 'validations' do
+    it 'is valid' do
+      expect(start_a_procurement.valid?).to be true
+    end
+  end
+
+  describe '.next_step_class' do
+    it 'returns Journey::ChooseServices' do
+      expect(start_a_procurement.next_step_class).to be FacilitiesManagement::RM6232::Journey::ChooseServices
+    end
+  end
+
+  describe '.permit_list' do
+    it 'returns a list of the permitted attributes' do
+      expect(described_class.permit_list).to eq [:annual_contract_value, { service_codes: [], region_codes: [] }]
+    end
+  end
+
+  describe '.permitted_keys' do
+    it 'returns a list of the permitted keys' do
+      expect(described_class.permitted_keys).to eq %i[service_codes region_codes annual_contract_value]
+    end
+  end
+
+  describe '.slug' do
+    it 'returns start-a-procurement' do
+      expect(start_a_procurement.slug).to eq 'start-a-procurement'
+    end
+  end
+
+  describe '.template' do
+    it 'returns journey/start_a_procurement' do
+      expect(start_a_procurement.template).to eq 'journey/start_a_procurement'
+    end
+  end
+
+  describe '.final?' do
+    it 'returns false' do
+      expect(start_a_procurement.final?).to be false
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/work_package_spec.rb
+++ b/spec/models/facilities_management/rm6232/work_package_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe FacilitiesManagement::RM6232::WorkPackage, type: :model do
       'N': 13,
       'O': 5,
       'P': 14,
-      'Q': 2,
+      'Q': 3,
       'R': 1,
       'S': 1
     }
@@ -49,6 +49,86 @@ RSpec.describe FacilitiesManagement::RM6232::WorkPackage, type: :model do
         it "has #{number_of_services} services" do
           expect(described_class.find(code).services.count).to eq number_of_services
         end
+      end
+    end
+  end
+
+  describe '.selectable_services' do
+    context 'when checking the number of services' do
+      work_packages_with_num_of_services = {
+        'A': 18,
+        'B': 1,
+        'C': 1,
+        'D': 1,
+        'E': 21,
+        'F': 13,
+        'G': 8,
+        'H': 10,
+        'I': 18,
+        'J': 16,
+        'K': 5,
+        'L': 15,
+        'M': 8,
+        'N': 13,
+        'O': 5,
+        'P': 14,
+        'Q': 1,
+        'R': 1,
+        'S': 1
+      }
+
+      work_packages_with_num_of_services.each do |code, number_of_services|
+        context "and the code is #{code}" do
+          it "has #{number_of_services} services" do
+            expect(described_class.find(code).selectable_services.count).to eq number_of_services
+          end
+        end
+      end
+    end
+
+    context 'when checking CAFM (Q) services' do
+      it 'has the right services' do
+        expect(described_class.find('Q').selectable_services.map(&:code)).to eq ['Q.3']
+      end
+    end
+  end
+
+  describe '.supplier_services' do
+    context 'when checking the number of services' do
+      work_packages_with_num_of_services = {
+        'A': 18,
+        'B': 1,
+        'C': 1,
+        'D': 1,
+        'E': 21,
+        'F': 13,
+        'G': 8,
+        'H': 10,
+        'I': 18,
+        'J': 16,
+        'K': 5,
+        'L': 15,
+        'M': 8,
+        'N': 13,
+        'O': 5,
+        'P': 14,
+        'Q': 2,
+        'R': 1,
+        'S': 1
+      }
+
+      work_packages_with_num_of_services.each do |code, number_of_services|
+        context "and the code is #{code}" do
+          it "has #{number_of_services} services" do
+            expect(described_class.find(code).supplier_services.count).to eq number_of_services
+          end
+        end
+      end
+    end
+
+    context 'when checking CAFM (Q) services' do
+      it 'has the right services' do
+        expect(described_class.find('Q').supplier_services.map(&:code)).to eq ['Q.1', 'Q.2']
       end
     end
   end


### PR DESCRIPTION
Part of [FMFR-1003](https://crowncommercialservice.atlassian.net/browse/FMFR-1003)

This is the choose services section of quick view.

I think the only additional point of note is with regards to CAFM. This has a bit more of an impact later on but for now we have just added a third generic CAFM service that we allow the user to select. More information can be found in [Why we only show one CAFM service to suppliers](https://crowncommercialservice.atlassian.net/l/c/XW2DSi72)