### PR TITLE
FMFR-1003 - Quick view - Results

### DIFF
--- a/app/assets/stylesheets/ccs/facilities-management/_all.scss
+++ b/app/assets/stylesheets/ccs/facilities-management/_all.scss
@@ -2,6 +2,7 @@
 @import "filter-component.scss";
 @import "procurement-buildings.scss";
 @import "service-specification.scss";
+@import "summary-box";
 @import "summary-list.scss";
 @import "supplier_lot_data";
 @import "supplier-lot-list.scss";

--- a/app/assets/stylesheets/ccs/facilities-management/_summary-box.scss
+++ b/app/assets/stylesheets/ccs/facilities-management/_summary-box.scss
@@ -1,0 +1,36 @@
+.ccs-summary-box {
+  @extend %govuk-body-m;
+
+  background-color: #f8f8f8;
+  padding: govuk-spacing(3);
+}
+
+.ccs-summary-box__headings {
+  margin-bottom: govuk-spacing(2);
+
+  &:after {
+    content: "";
+    display: block;
+    clear: both;
+  }
+}
+
+.ccs-summary-box__title {
+  @include govuk-typography-weight-bold;
+
+  float: left;
+  width: 66%;
+}
+
+.ccs-summary-box__change {  
+  float: right;
+}
+
+.ccs-summary-box__content {
+  background-color: #ffffff;
+  padding: govuk-spacing(2);
+
+  & details {
+    margin-bottom: 0px
+  }
+}

--- a/app/controllers/facilities_management/rm3830/procurements/contract_details_controller.rb
+++ b/app/controllers/facilities_management/rm3830/procurements/contract_details_controller.rb
@@ -44,7 +44,7 @@ module FacilitiesManagement
         private
 
         def set_procurement
-          @procurement = current_user.procurements.find(params[:id] || params[:procurement_id])
+          @procurement = current_user.rm3830_procurements.find(params[:id] || params[:procurement_id])
         end
 
         def redirect_if_not_da_draft

--- a/app/controllers/facilities_management/rm3830/procurements/contracts/closed_controller.rb
+++ b/app/controllers/facilities_management/rm3830/procurements/contracts/closed_controller.rb
@@ -10,7 +10,7 @@ module FacilitiesManagement
           private
 
           def set_contract_and_procurement
-            @procurement = @current_user.procurements.find_by(id: params[:procurement_id])
+            @procurement = @current_user.rm3830_procurements.find_by(id: params[:procurement_id])
             authorize! :manage, @procurement
             @contract = @procurement&.procurement_suppliers&.find_by(id: params[:contract_id])
           end

--- a/app/controllers/facilities_management/rm3830/procurements/contracts/sent_controller.rb
+++ b/app/controllers/facilities_management/rm3830/procurements/contracts/sent_controller.rb
@@ -4,7 +4,7 @@ module FacilitiesManagement
       module Contracts
         class SentController < FacilitiesManagement::FrameworkController
           def index
-            @procurement = @current_user.procurements.find_by(id: params[:procurement_id])
+            @procurement = @current_user.rm3830_procurements.find_by(id: params[:procurement_id])
             authorize! :manage, @procurement
             @contract = @procurement&.procurement_suppliers&.find_by(id: params[:contract_id])
             @supplier = @contract&.supplier

--- a/app/controllers/facilities_management/rm3830/procurements/copy_procurement_controller.rb
+++ b/app/controllers/facilities_management/rm3830/procurements/copy_procurement_controller.rb
@@ -26,7 +26,7 @@ module FacilitiesManagement
         private
 
         def set_procurement_data
-          @procurement = current_user.procurements.find_by(id: params[:procurement_id])
+          @procurement = current_user.rm3830_procurements.find_by(id: params[:procurement_id])
         end
 
         def set_contract_data

--- a/app/controllers/facilities_management/rm3830/procurements_controller.rb
+++ b/app/controllers/facilities_management/rm3830/procurements_controller.rb
@@ -19,12 +19,12 @@ module FacilitiesManagement
       before_action :redirect_to_edit_from_summary, :set_summary_data, only: :summary
 
       def index
-        @searches = current_user.procurements.where(aasm_state: Procurement::SEARCH).order(updated_at: :asc).sort_by { |search| Procurement::SEARCH_ORDER.index(search.aasm_state) }
-        @in_draft = current_user.procurements.da_draft.order(updated_at: :asc)
+        @searches = current_user.rm3830_procurements.where(aasm_state: Procurement::SEARCH).order(updated_at: :asc).sort_by { |search| Procurement::SEARCH_ORDER.index(search.aasm_state) }
+        @in_draft = current_user.rm3830_procurements.da_draft.order(updated_at: :asc)
         @sent_offers = sent_offers
         @contracts = live_contracts
         @closed_contracts = closed_contracts
-        @further_competition_contracts = current_user.procurements.further_competition.order(updated_at: :asc)
+        @further_competition_contracts = current_user.rm3830_procurements.further_competition.order(updated_at: :asc)
       end
 
       def show
@@ -35,13 +35,13 @@ module FacilitiesManagement
       def summary; end
 
       def new
-        @procurement = current_user.procurements.build(service_codes: params[:service_codes], region_codes: params[:region_codes])
+        @procurement = current_user.rm3830_procurements.build(service_codes: params[:service_codes], region_codes: params[:region_codes])
         @back_path = back_path
         @back_text = 'Return to regions'
       end
 
       def create
-        @procurement = current_user.procurements.build(procurement_params)
+        @procurement = current_user.rm3830_procurements.build(procurement_params)
 
         if @procurement.save(context: :contract_name)
           if @procurement.region_codes.empty?
@@ -367,15 +367,15 @@ module FacilitiesManagement
       RECOGNISED_SUMMARY_PAGES = %w[contract_period services buildings buildings_and_services service_requirements].freeze
 
       def sent_offers
-        current_user.procurements.direct_award&.map(&:sent_offers)&.flatten&.sort_by { |each| [ProcurementSupplier::SENT_OFFER_ORDER.index(each.aasm_state), each.offer_sent_date] }
+        current_user.rm3830_procurements.direct_award&.map(&:sent_offers)&.flatten&.sort_by { |each| [ProcurementSupplier::SENT_OFFER_ORDER.index(each.aasm_state), each.offer_sent_date] }
       end
 
       def live_contracts
-        current_user.procurements.direct_award.map(&:live_contracts)&.flatten&.sort_by(&:contract_signed_date)
+        current_user.rm3830_procurements.direct_award.map(&:live_contracts)&.flatten&.sort_by(&:contract_signed_date)
       end
 
       def closed_contracts
-        current_user.procurements.where(aasm_state: ['direct_award', 'closed']).map(&:closed_contracts)&.flatten&.sort_by { |sent_offer| [sent_offer.contract_closed_date ? 1 : 0, sent_offer.contract_closed_date] }&.reverse
+        current_user.rm3830_procurements.where(aasm_state: ['direct_award', 'closed']).map(&:closed_contracts)&.flatten&.sort_by { |sent_offer| [sent_offer.contract_closed_date ? 1 : 0, sent_offer.contract_closed_date] }&.reverse
       end
 
       def procurement_route_params

--- a/app/controllers/facilities_management/rm6232/procurements_controller.rb
+++ b/app/controllers/facilities_management/rm6232/procurements_controller.rb
@@ -1,0 +1,24 @@
+module FacilitiesManagement
+  module RM6232
+    class ProcurementsController < FacilitiesManagement::FrameworkController
+      def new
+        @procurement = current_user.rm6232_procurements.build(service_codes: params[:service_codes],
+                                                              region_codes: params[:region_codes],
+                                                              annual_contract_value: params[:annual_contract_value])
+
+        @procurement.lot_number = @procurement.quick_view_suppliers.lot_number
+        @suppliers = @procurement.quick_view_suppliers.selected_suppliers
+        @back_path = back_path
+        @back_text = t('.return_to_contract_cost')
+      end
+
+      def create; end
+
+      private
+
+      def back_path
+        helpers.journey_step_url_former(journey_slug: 'annual-contract-value', annual_contract_value: @procurement.annual_contract_value, region_codes: @procurement.region_codes, service_codes: @procurement.service_codes)
+      end
+    end
+  end
+end

--- a/app/helpers/facilities_management/rm6232/procurements_helper.rb
+++ b/app/helpers/facilities_management/rm6232/procurements_helper.rb
@@ -1,0 +1,7 @@
+module FacilitiesManagement::RM6232
+  module ProcurementsHelper
+    def journey_step_url_former(journey_slug:, annual_contract_value: nil, region_codes: nil, service_codes: nil)
+      facilities_management_journey_question_path(framework: 'RM6232', slug: journey_slug, annual_contract_value: annual_contract_value, region_codes: region_codes, service_codes: service_codes)
+    end
+  end
+end

--- a/app/models/facilities_management/rm3830/procurement.rb
+++ b/app/models/facilities_management/rm3830/procurement.rb
@@ -6,8 +6,7 @@ module FacilitiesManagement
       include ServiceQuestionsConcern
 
       # buyer
-      belongs_to :user,
-                 inverse_of: :procurements
+      belongs_to :user, inverse_of: :rm3830_procurements
 
       before_save :update_procurement_building_services, if: :service_codes_changed?
       before_save :set_state_to_results, if: :buyer_selected_contract_value?

--- a/app/models/facilities_management/rm6232/journey/annual_contract_value.rb
+++ b/app/models/facilities_management/rm6232/journey/annual_contract_value.rb
@@ -8,7 +8,7 @@ module FacilitiesManagement
       validates :annual_contract_value, numericality: { only_integer: true, greater_than: 0, less_than: 1_000_000_000_000 }
 
       def next_step_class
-        # Journey::Procurement
+        Journey::Procurement
       end
     end
   end

--- a/app/models/facilities_management/rm6232/journey/procurement.rb
+++ b/app/models/facilities_management/rm6232/journey/procurement.rb
@@ -1,0 +1,7 @@
+module FacilitiesManagement
+  module RM6232
+    class Journey::Procurement
+      include Steppable
+    end
+  end
+end

--- a/app/models/facilities_management/rm6232/procurement.rb
+++ b/app/models/facilities_management/rm6232/procurement.rb
@@ -1,0 +1,43 @@
+module FacilitiesManagement
+  module RM6232
+    class Procurement < ApplicationRecord
+      include AASM
+
+      belongs_to :user, inverse_of: :rm6232_procurements
+
+      # The service CAFM – Soft FM Requirements (Q.1) can only be selected when all other services are soft.
+      # Because we don't want to pass that logic onto the user, we determine which CAFM service they need for them.
+      # To make the selection easier we have added the Q.3 service for the user to select,
+      # which we can then replace with the correct CAFM service at the appropriate time.
+      # You can read more information at: https://crowncommercialservice.atlassian.net/l/c/XW2DSi72
+
+      def quick_view_suppliers
+        @quick_view_suppliers ||= SuppliersSelector.new(service_codes_without_cafm, region_codes, annual_contract_value)
+      end
+
+      def services
+        @services ||= Service.where(code: true_service_codes).order(:work_package_code, :sort_order)
+      end
+
+      def regions
+        @regions ||= Region.where(code: region_codes)
+      end
+
+      private
+
+      def service_codes_without_cafm
+        service_codes - ['Q.3']
+      end
+
+      def true_service_codes
+        return service_codes unless service_codes.include?('Q.3')
+
+        if lot_number.start_with? '3'
+          service_codes_without_cafm + ['Q.1']
+        else
+          service_codes_without_cafm + ['Q.2']
+        end
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,15 @@
 class User < ApplicationRecord
   include RoleModel
 
-  has_many  :procurements,
-            inverse_of: :user,
-            class_name: 'FacilitiesManagement::RM3830::Procurement',
-            dependent: :destroy
+  has_many :rm3830_procurements,
+           inverse_of: :user,
+           class_name: 'FacilitiesManagement::RM3830::Procurement',
+           dependent: :destroy
+
+  has_many :rm6232_procurements,
+           inverse_of: :user,
+           class_name: 'FacilitiesManagement::RM6232::Procurement',
+           dependent: :destroy
 
   has_one :buyer_detail,
           inverse_of: :user,

--- a/app/views/facilities_management/rm6232/procurements/new.html.erb
+++ b/app/views/facilities_management/rm6232/procurements/new.html.erb
@@ -1,0 +1,127 @@
+<% content_for :page_title, t('.heading') %>
+
+<%= render partial: 'shared/error_summary', locals: { errors: @procurement.errors } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t('.heading') %>
+    </h1>
+    <p class="govuk-body-l">
+      <%= t('.based_on_info') %>
+    </p>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-m">
+      <%= t('.selection_summary') %>
+    </h2>
+    <div class="ccs-summary-box">
+      <div class="ccs-summary-box__headings">
+        <span class="ccs-summary-box__title">
+          <%= t('.services') %>
+        </span>
+        <span class="ccs-summary-box__change">
+          <%= link_to t('.change'), journey_step_url_former(journey_slug: 'choose-services', annual_contract_value: @procurement.annual_contract_value, region_codes: @procurement.region_codes, service_codes: @procurement.service_codes), class: 'govuk-link--no-visited-state' %>
+        </span>
+      </div>
+      <div class="ccs-summary-box__content">
+        <%= govuk_details("#{@procurement.services.count} selected") do %>
+          <ul class="govuk-list govuk-list--bullet">
+            <% @procurement.services.each do |service| %>
+              <li>
+                <%= service.name %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+    </div>
+    <div class="ccs-summary-box">
+      <div class="ccs-summary-box__headings">
+        <span class="ccs-summary-box__title">
+          <%= t('.regions') %>
+        </span>
+        <span class="ccs-summary-box__change">
+          <%= link_to t('.change'), journey_step_url_former(journey_slug: 'choose-locations', annual_contract_value: @procurement.annual_contract_value, region_codes: @procurement.region_codes, service_codes: @procurement.service_codes), class: 'govuk-link--no-visited-state' %>
+        </span>
+      </div>
+      <div class="ccs-summary-box__content">
+        <%= govuk_details("#{@procurement.regions.count} selected") do %>
+          <ul class="govuk-list govuk-list--bullet">
+            <% @procurement.regions.each do |region| %>
+              <li>
+                <%= region.name %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+    </div>
+    <div class="ccs-summary-box">
+      <div class="ccs-summary-box__headings">
+        <div class="ccs-summary-box__title">
+          <%= t('.estimated_annual_contract_value') %>
+        </div>
+        <div class="ccs-summary-box__change">
+          <%= link_to t('.change'), journey_step_url_former(journey_slug: 'annual-contract-value', annual_contract_value: @procurement.annual_contract_value, region_codes: @procurement.region_codes, service_codes: @procurement.service_codes), class: 'govuk-link--no-visited-state' %>
+        </div>
+      </div>
+      <div class="ccs-summary-box__content">
+        <%= format_money(@procurement.annual_contract_value, 0) %>
+      </div>
+    </div>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">
+      <%= t('.sub_lot', sub_lot: @procurement.lot_number) %>
+    </h2>
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-0">
+      <%= t('.suppliers_shortlisted', number_of_suppliers: @suppliers.length) %>
+    </h3>
+    <p class="govuk-body govuk-!-font-weight-bold">
+      <%= t('.who_can_provide') %>
+    </p>
+    <ul class="govuk-list">
+      <% @suppliers.each do |supplier| %>
+        <li class="govuk-!-width-one-half">
+          <%= supplier.supplier_name %>
+          <% if supplier != @suppliers.last  %>
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>
+<hr class="govuk-section-break govuk-section-break--l govuk-!-margin-top-0"/>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: facilities_management_rm6232_procurements_path, model: @procurement, method: :post, local: true, html: { specialvalidation: true, novalidate: true } do |f| %>
+      <% f.object.service_codes.each do |service_code| %>
+        <%= f.hidden_field :service_codes, value: service_code, multipart: true %>
+      <% end %>
+
+      <% f.object.region_codes.each do |region_code| %>
+        <%= f.hidden_field :region_codes, value: region_code, multipart: true %>
+      <% end %>
+
+      <%= f.hidden_field :annual_contract_value %>
+
+      <%= form_group_with_error(f.object, :contract_name) do |displayed_error, any_errors| %>
+        <%= f.label :contract_name, t('.contract_name_label'), class: 'govuk-label govuk-label--m' %>
+        <div class="govuk-hint">
+          <%= t('.contract_name_hint') %>
+        </div>
+        <%= f.text_field :contract_name, class: "govuk-input govuk-input--width-20 #{'govuk-input--error' if any_errors}" %>
+      <% end %>
+
+      <%= f.submit t('.save_and_continue'), class: 'govuk-button govuk-!-margin-right-4', name: 'after_save' %>
+      <%= f.submit t('.save_and_return'), class: 'govuk-button govuk-button--secondary', name: 'after_save' %>
+      <p>
+        <%= link_to t('.return_to_dashboard'), facilities_management_rm6232_path, class: 'govuk-body govuk-link--no-visited-state' %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -190,6 +190,24 @@ en:
               item_2: other spreadsheets
             title: Final results
           the_steps_shown: The steps shown below outline the process that you'll follow creating your facilities management procurement.
+      procurements:
+        new:
+          based_on_info: 'Based on information provided, this procurement is eligible for the following sub-lot:'
+          change: Change
+          contract_name_hint: Enter a name or reference to save this search. You will then be able to download your shortlist.
+          contract_name_label: Save your search
+          estimated_annual_contract_value: Estimated annual contract value
+          heading: Results
+          regions: Regions
+          return_to_contract_cost: Return to annual contract value
+          return_to_dashboard: Return to your account
+          save_and_continue: Save and continue
+          save_and_return: Save and return to procurements dashboard
+          selection_summary: Selection summary
+          services: Services
+          sub_lot: Sub-lot %{sub_lot}
+          suppliers_shortlisted: "%{number_of_suppliers} supplier(s) shortlisted"
+          who_can_provide: who can provide the services you require in your
       sessions:
         new:
           email_hint_html: Enter the email address you used to set up your account.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,9 @@ Rails.application.routes.draw do
       get '/start', to: 'home#index'
       get '/', to: 'buyer_account#index'
 
+      resources :procurements, only: %i[new create] do
+      end
+
       namespace :admin, path: 'admin', defaults: { service: 'facilities_management/admin' } do
         concerns :shared_pages
 

--- a/db/migrate/20220517142407_create_rm6232_procurement.rb
+++ b/db/migrate/20220517142407_create_rm6232_procurement.rb
@@ -1,0 +1,14 @@
+class CreateRM6232Procurement < ActiveRecord::Migration[6.0]
+  def change
+    create_table :facilities_management_rm6232_procurements, id: :uuid do |t|
+      t.references :user, foreign_key: true, type: :uuid, null: false, index: { name: 'index_fm_rm6232_procurements_on_user_id' }
+      t.string :aasm_state, limit: 30
+      t.text :service_codes, array: true, default: []
+      t.text :region_codes, array: true, default: []
+      t.bigint :annual_contract_value
+      t.string :contract_name, limit: 100
+      t.string :lot_number, limit: 2
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_05_092624) do
+ActiveRecord::Schema.define(version: 2022_05_17_142407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -363,6 +363,19 @@ ActiveRecord::Schema.define(version: 2022_04_05_092624) do
     t.text "service_usage", array: true
   end
 
+  create_table "facilities_management_rm6232_procurements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.string "aasm_state", limit: 30
+    t.text "service_codes", default: [], array: true
+    t.text "region_codes", default: [], array: true
+    t.bigint "annual_contract_value"
+    t.string "contract_name", limit: 100
+    t.string "lot_number", limit: 2
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_fm_rm6232_procurements_on_user_id"
+  end
+
   create_table "facilities_management_rm6232_services", primary_key: "code", id: :string, limit: 5, force: :cascade do |t|
     t.string "work_package_code", limit: 1, null: false
     t.string "name", limit: 150
@@ -571,6 +584,7 @@ ActiveRecord::Schema.define(version: 2022_04_05_092624) do
   add_foreign_key "facilities_management_rm3830_procurements", "users"
   add_foreign_key "facilities_management_rm3830_spreadsheet_imports", "facilities_management_rm3830_procurements"
   add_foreign_key "facilities_management_rm3830_supplier_details", "users"
+  add_foreign_key "facilities_management_rm6232_procurements", "users"
   add_foreign_key "facilities_management_rm6232_services", "facilities_management_rm6232_work_packages", column: "work_package_code", primary_key: "code"
   add_foreign_key "facilities_management_rm6232_supplier_lot_data", "facilities_management_rm6232_suppliers"
 end

--- a/spec/controllers/facilities_management/rm6232/procurements_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/procurements_controller_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::ProcurementsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management', framework: 'RM6232' } }
+
+  login_fm_buyer_with_details
+
+  context 'without buyer details' do
+    login_fm_buyer
+
+    it 'will redirect to buyer details' do
+      get :new
+
+      expect(response).to redirect_to edit_facilities_management_buyer_detail_path(id: controller.current_user.buyer_detail.id)
+    end
+  end
+
+  describe 'GET new' do
+    before { get :new, params: { annual_contract_value: 123_456, region_codes: ['UKC1'], service_codes: ['E.1'] } }
+
+    it 'renders the correct template' do
+      expect(response).to render_template('new')
+    end
+
+    it 'sets the back path and text correctly' do
+      expect(assigns(:back_path)).to eq '/facilities-management/RM6232/annual-contract-value?annual_contract_value=123456&region_codes%5B%5D=UKC1&service_codes%5B%5D=E.1'
+      expect(assigns(:back_text)).to eq 'Return to annual contract value'
+    end
+
+    it 'sets the suppliers' do
+      expect(assigns(:suppliers).class.to_s).to eq 'FacilitiesManagement::RM6232::Supplier::ActiveRecord_Relation'
+    end
+
+    it 'sets the procurement with the correct details' do
+      expect(
+        assigns(:procurement).attributes.slice('user_id', 'service_codes', 'region_codes', 'annual_contract_value', 'lot_number')
+      ).to eq(
+        { 'user_id' => controller.current_user.id,
+          'service_codes' => ['E.1'],
+          'region_codes' => ['UKC1'],
+          'annual_contract_value' => 123_456,
+          'lot_number' => '2a' }
+      )
+    end
+  end
+end

--- a/spec/factories/facilities_management/rm6232/procurement.rb
+++ b/spec/factories/facilities_management/rm6232/procurement.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :facilities_management_rm6232_procurement_no_procurement_buildings, class: 'FacilitiesManagement::RM6232::Procurement' do
+    service_codes { ['E.1', 'E.2'] }
+    region_codes { ['UKI4', 'UKI5'] }
+    annual_contract_value { 12345 }
+    contract_name { Faker::Name.unique.name }
+    lot_number { '2a' }
+    association :user
+  end
+end

--- a/spec/helpers/facilities_management/rm6232/procurements_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm6232/procurements_helper_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::ProcurementsHelper, type: :helper do
+  describe '.journey_step_url_former' do
+    let(:service_codes) { ['E.1', 'F.1', 'G.1'] }
+    let(:region_codes) { ['UKI3', 'UKI4'] }
+    let(:annual_contract_value) { 500_000 }
+    let(:result) { helper.journey_step_url_former(journey_slug: journey_slug, annual_contract_value: annual_contract_value, region_codes: region_codes, service_codes: service_codes) }
+
+    context 'when the journey_slug is choose-services' do
+      let(:journey_slug) { 'choose-services' }
+
+      it 'returns the correct URL' do
+        expect(result).to eq '/facilities-management/RM6232/choose-services?annual_contract_value=500000&region_codes%5B%5D=UKI3&region_codes%5B%5D=UKI4&service_codes%5B%5D=E.1&service_codes%5B%5D=F.1&service_codes%5B%5D=G.1'
+      end
+
+      context 'when the service codes are empty' do
+        let(:service_codes) { [] }
+
+        it 'returns the correct URL without service codes' do
+          expect(result).to eq '/facilities-management/RM6232/choose-services?annual_contract_value=500000&region_codes%5B%5D=UKI3&region_codes%5B%5D=UKI4'
+        end
+      end
+
+      context 'when the region codes are empty' do
+        let(:region_codes) { [] }
+
+        it 'returns the correct URL without region codes' do
+          expect(result).to eq '/facilities-management/RM6232/choose-services?annual_contract_value=500000&service_codes%5B%5D=E.1&service_codes%5B%5D=F.1&service_codes%5B%5D=G.1'
+        end
+      end
+
+      context 'when the annual contract value is nil' do
+        let(:annual_contract_value) { nil }
+
+        it 'returns the correct URL without the annual contract value' do
+          expect(result).to eq '/facilities-management/RM6232/choose-services?region_codes%5B%5D=UKI3&region_codes%5B%5D=UKI4&service_codes%5B%5D=E.1&service_codes%5B%5D=F.1&service_codes%5B%5D=G.1'
+        end
+      end
+    end
+
+    context 'when the journey_slug is choose-locations' do
+      let(:journey_slug) { 'choose-locations' }
+
+      it 'returns the correct URL' do
+        expect(result).to eq '/facilities-management/RM6232/choose-locations?annual_contract_value=500000&region_codes%5B%5D=UKI3&region_codes%5B%5D=UKI4&service_codes%5B%5D=E.1&service_codes%5B%5D=F.1&service_codes%5B%5D=G.1'
+      end
+    end
+
+    context 'when the journey_slug is annual-contract-value' do
+      let(:journey_slug) { 'annual-contract-value' }
+
+      it 'returns the correct URL' do
+        expect(result).to eq '/facilities-management/RM6232/annual-contract-value?annual_contract_value=500000&region_codes%5B%5D=UKI3&region_codes%5B%5D=UKI4&service_codes%5B%5D=E.1&service_codes%5B%5D=F.1&service_codes%5B%5D=G.1'
+      end
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/journey/annual_contract_value_spec.rb
+++ b/spec/models/facilities_management/rm6232/journey/annual_contract_value_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe FacilitiesManagement::RM6232::Journey::AnnualContractValue, type:
   end
 
   describe '.next_step_class' do
-    pending 'returns Journey::Procurement' do
+    it 'returns Journey::Procurement' do
       expect(annual_contract_value.next_step_class).to be FacilitiesManagement::RM6232::Journey::Procurement
     end
   end
@@ -88,7 +88,7 @@ RSpec.describe FacilitiesManagement::RM6232::Journey::AnnualContractValue, type:
   end
 
   describe '.final?' do
-    pending 'returns false' do
+    it 'returns false' do
       expect(annual_contract_value.final?).to be false
     end
   end

--- a/spec/models/facilities_management/rm6232/journey/procurement_spec.rb
+++ b/spec/models/facilities_management/rm6232/journey/procurement_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Journey::Procurement, type: :model do
+  let(:procurement) { described_class.new }
+
+  describe '.next_step_class' do
+    it 'returns nil' do
+      expect(procurement.next_step_class).to be nil
+    end
+  end
+
+  describe '.final?' do
+    it 'returns true' do
+      expect(procurement.final?).to be true
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/procurement_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_spec.rb
@@ -1,0 +1,196 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
+  it { is_expected.to belong_to(:user) }
+
+  describe '.quick_view_suppliers' do
+    let(:procurement) { create(:facilities_management_rm6232_procurement_no_procurement_buildings, service_codes: service_codes) }
+    let(:base_service_codes) { ['E.1', 'E.2'] }
+    let(:service_codes) { base_service_codes }
+
+    it 'returns a FacilitiesManagement::RM6232::SuppliersSelector' do
+      expect(procurement.quick_view_suppliers).to be_a FacilitiesManagement::RM6232::SuppliersSelector
+    end
+
+    context 'when the service codes contain Q.3' do
+      let(:service_codes) { base_service_codes + ['Q.3'] }
+
+      it 'does not use that service code in the call to SuppliersSelector' do
+        allow(FacilitiesManagement::RM6232::SuppliersSelector).to receive(:new)
+
+        procurement.quick_view_suppliers
+
+        expect(FacilitiesManagement::RM6232::SuppliersSelector).to have_received(:new).with(base_service_codes, procurement.region_codes, procurement.annual_contract_value)
+      end
+    end
+  end
+
+  describe '.services' do
+    let(:procurement) { create(:facilities_management_rm6232_procurement_no_procurement_buildings, service_codes: service_codes, lot_number: lot_number) }
+    let(:base_service_codes) { ['E.1', 'E.2'] }
+    let(:service_codes) { base_service_codes }
+    let(:lot_number) { '1a' }
+
+    it 'returns an array of FacilitiesManagement::RM6232::Service' do
+      expect(procurement.services.length).to eq 2
+      expect(procurement.services.first).to be_a FacilitiesManagement::RM6232::Service
+    end
+
+    context 'when the service codes contain Q.3' do
+      let(:service_codes) { base_service_codes + ['Q.3'] }
+      let(:service_Q1) { FacilitiesManagement::RM6232::Service.find('Q.1') }
+      let(:service_Q2) { FacilitiesManagement::RM6232::Service.find('Q.2') }
+      let(:service_Q3) { FacilitiesManagement::RM6232::Service.find('Q.3') }
+
+      context 'and it is a total sub lot' do
+        let(:lot_number) { '1a' }
+
+        it 'returns services with Q.2 instead of Q.3' do
+          expect(procurement.services).not_to include service_Q3
+          expect(procurement.services).to include service_Q2
+        end
+      end
+
+      context 'and it is a hard sub lot' do
+        let(:lot_number) { '2a' }
+
+        it 'returns services with Q.2 instead of Q.3' do
+          expect(procurement.services).not_to include service_Q3
+          expect(procurement.services).to include service_Q2
+        end
+      end
+
+      context 'and it is a soft sub lot' do
+        let(:lot_number) { '3a' }
+
+        it 'returns services with Q.1 instead of Q.3' do
+          expect(procurement.services).not_to include service_Q3
+          expect(procurement.services).to include service_Q1
+        end
+      end
+    end
+  end
+
+  describe '.regions' do
+    let(:procurement) { create(:facilities_management_rm6232_procurement_no_procurement_buildings) }
+
+    it 'returns an array of FacilitiesManagement::Region' do
+      expect(procurement.regions.length).to eq 2
+      expect(procurement.regions.first).to be_a FacilitiesManagement::Region
+    end
+  end
+
+  describe '.service_codes_without_cafm' do
+    let(:procurement) { create(:facilities_management_rm6232_procurement_no_procurement_buildings, service_codes: service_codes) }
+    let(:base_service_codes) { ['E.1', 'E.2', 'F.1', 'F.2', 'H.1'] }
+
+    context 'when the service codes contain Q.3' do
+      let(:service_codes) { base_service_codes + ['Q.3'] }
+
+      it 'returns the service codes without Q.3' do
+        expect(procurement.service_codes).to eq service_codes
+        expect(procurement.send(:service_codes_without_cafm)).to eq base_service_codes
+      end
+    end
+
+    context 'when the service codes do not contain Q.3' do
+      let(:service_codes) { base_service_codes }
+
+      it 'returns the service codes unchanged' do
+        expect(procurement.service_codes).to eq service_codes
+        expect(procurement.send(:service_codes_without_cafm)).to eq service_codes
+      end
+    end
+  end
+
+  describe '.true_service_codes' do
+    let(:procurement) { create(:facilities_management_rm6232_procurement_no_procurement_buildings, service_codes: service_codes, lot_number: lot_number) }
+    let(:base_service_codes) { ['E.1', 'E.2', 'F.1', 'F.2', 'H.1'] }
+    let(:lot_number) { '1a' }
+
+    context 'when the service codes contain Q.3' do
+      let(:service_codes) { base_service_codes + ['Q.3'] }
+
+      context 'and the lot is 1a' do
+        let(:lot_number) { '1a' }
+
+        it 'returns the services with Q.2 instead of Q.3' do
+          expect(procurement.send(:true_service_codes)).to eq base_service_codes + ['Q.2']
+        end
+      end
+
+      context 'and the lot is 2a' do
+        let(:lot_number) { '2a' }
+
+        it 'returns the services with Q.2 instead of Q.3' do
+          expect(procurement.send(:true_service_codes)).to eq base_service_codes + ['Q.2']
+        end
+      end
+
+      context 'and the lot is 3a' do
+        let(:lot_number) { '3a' }
+
+        it 'returns the services with Q.1 instead of Q.3' do
+          expect(procurement.send(:true_service_codes)).to eq base_service_codes + ['Q.1']
+        end
+      end
+
+      context 'and the lot is 1b' do
+        let(:lot_number) { '1b' }
+
+        it 'returns the services with Q.2 instead of Q.3' do
+          expect(procurement.send(:true_service_codes)).to eq base_service_codes + ['Q.2']
+        end
+      end
+
+      context 'and the lot is 2b' do
+        let(:lot_number) { '2b' }
+
+        it 'returns the services with Q.2 instead of Q.3' do
+          expect(procurement.send(:true_service_codes)).to eq base_service_codes + ['Q.2']
+        end
+      end
+
+      context 'and the lot is 3b' do
+        let(:lot_number) { '3b' }
+
+        it 'returns the services with Q.1 instead of Q.3' do
+          expect(procurement.send(:true_service_codes)).to eq base_service_codes + ['Q.1']
+        end
+      end
+
+      context 'and the lot is 1c' do
+        let(:lot_number) { '1c' }
+
+        it 'returns the services with Q.2 instead of Q.3' do
+          expect(procurement.send(:true_service_codes)).to eq base_service_codes + ['Q.2']
+        end
+      end
+
+      context 'and the lot is 2c' do
+        let(:lot_number) { '2c' }
+
+        it 'returns the services with Q.2 instead of Q.3' do
+          expect(procurement.send(:true_service_codes)).to eq base_service_codes + ['Q.2']
+        end
+      end
+
+      context 'and the lot is 3c' do
+        let(:lot_number) { '3c' }
+
+        it 'returns the services with Q.1 instead of Q.3' do
+          expect(procurement.send(:true_service_codes)).to eq base_service_codes + ['Q.1']
+        end
+      end
+    end
+
+    context 'when the service codes do not contain Q.3' do
+      let(:service_codes) { base_service_codes }
+
+      it 'returns the service codes unchanged' do
+        expect(procurement.service_codes).to eq service_codes
+        expect(procurement.send(:true_service_codes)).to eq service_codes
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of [FMFR-1003](https://crowncommercialservice.atlassian.net/browse/FMFR-1003)

This adds the results page to the journey. On this page a user can see their results (sub lot and the suppliers who can provide the services) and go back and change them.

The main thing of note is that we have additional logic to determine what version of CAFM should be selected. There is more information on this in [Why we only show one CAFM service to suppliers](https://crowncommercialservice.atlassian.net/l/c/XW2DSi72)