### PR TITLE
FMFR-1168 - Create the functionality to download the 'Selected suppliers' spreadsheet

### DIFF
--- a/app/controllers/facilities_management/rm3830/admin/uploads_controller.rb
+++ b/app/controllers/facilities_management/rm3830/admin/uploads_controller.rb
@@ -29,7 +29,7 @@ module FacilitiesManagement
         def spreadsheet_template
           spreadsheet_builder = SupplierFrameworkDataSpreadsheet.new
           spreadsheet_builder.build
-          send_data spreadsheet_builder.to_xlsx, filename: 'RM30 Supplier Framework Data (template).xlsx', type: 'application/vnd.ms-excel'
+          send_data spreadsheet_builder.to_xlsx, filename: 'RM30 Supplier Framework Data (template).xlsx', type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
         end
 
         def progress

--- a/app/controllers/facilities_management/rm3830/procurements_controller.rb
+++ b/app/controllers/facilities_management/rm3830/procurements_controller.rb
@@ -86,9 +86,9 @@ module FacilitiesManagement
 
       def quick_view_results_spreadsheet
         if @procurement.quick_search?
-          spreadsheet_builder = QuickViewResultsSpreadsheetCreator.new(@procurement.id)
+          spreadsheet_builder = SupplierShortlistSpreadsheetCreator.new(@procurement.id)
           spreadsheet_builder.build
-          send_data spreadsheet_builder.to_xlsx, filename: "Quick view results (#{@procurement.contract_name}).xlsx", type: 'application/vnd.ms-excel'
+          send_data spreadsheet_builder.to_xlsx, filename: "Quick view results (#{@procurement.contract_name}).xlsx", type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
         else
           redirect_to facilities_management_rm3830_procurement_path(id: @procurement.id)
         end
@@ -98,7 +98,7 @@ module FacilitiesManagement
         if @procurement.further_competition?
           spreadsheet_builder = FurtherCompetitionDeliverablesMatrix.new(@procurement.id)
           spreadsheet_builder.build
-          send_data spreadsheet_builder.to_xlsx, filename: 'further_competition_procurement_summary.xlsx', type: 'application/vnd.ms-excel'
+          send_data spreadsheet_builder.to_xlsx, filename: 'further_competition_procurement_summary.xlsx', type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
         else
           redirect_to facilities_management_rm3830_procurement_path(id: @procurement.id)
         end

--- a/app/controllers/facilities_management/rm6232/procurements_controller.rb
+++ b/app/controllers/facilities_management/rm6232/procurements_controller.rb
@@ -1,7 +1,7 @@
 module FacilitiesManagement
   module RM6232
     class ProcurementsController < FacilitiesManagement::FrameworkController
-      before_action :set_procurement, only: %i[show]
+      before_action :set_procurement, only: %i[show supplier_shortlist_spreadsheet]
       before_action :authorize_user
       before_action :build_new_procurement, :set_back_path, only: :new
 
@@ -39,6 +39,16 @@ module FacilitiesManagement
           build_new_procurement
           set_back_path
           render :new
+        end
+      end
+
+      def supplier_shortlist_spreadsheet
+        if @procurement.what_happens_next?
+          spreadsheet_builder = SupplierShortlistSpreadsheetCreator.new(@procurement.id)
+          spreadsheet_builder.build
+          send_data spreadsheet_builder.to_xlsx, filename: "Supplier shortlist (#{@procurement.contract_name}).xlsx", type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        else
+          redirect_to facilities_management_rm6232_procurement_path(id: @procurement.id)
         end
       end
 

--- a/app/services/facilities_management/rm3830/supplier_shortlist_spreadsheet_creator.rb
+++ b/app/services/facilities_management/rm3830/supplier_shortlist_spreadsheet_creator.rb
@@ -1,0 +1,56 @@
+module FacilitiesManagement
+  module RM3830
+    class SupplierShortlistSpreadsheetCreator < SupplierShortlistSpreadsheet
+      def initialize(procurement_id)
+        super(Procurement.find(procurement_id), 'Quick view search name')
+        @region_codes = @procurement.region_codes
+        @service_codes = @procurement.service_codes
+      end
+
+      private
+
+      def set_data
+        @regions = FacilitiesManagement::Region.where(code: @region_codes).map(&:name)
+        @services = @service_codes.index_with { |code| Service.find_by(code: code).name }
+
+        @lot_1a_suppliers = suppliers_for_lot('1a')
+        @lot_1b_suppliers = suppliers_for_lot('1b')
+        @lot_1c_suppliers = suppliers_for_lot('1c')
+      end
+
+      def add_supplier_shortlists
+        @workbook.add_worksheet(name: 'Supplier shortlists') do |sheet|
+          sheet.add_row ['Quick view results', nil, nil], style: @styles[:heading_style], height: LARGE_ROW_HEIGHT
+          sheet.add_row ['Here are the suppliers that can provide your services to your region(s). We are showing you potential suppliers from all three sub-lots, however, your procurement will fall into only one sub-lot dependent on your potential total contract value (which excludes billable works, optional extension periods and VAT).', nil, nil], style: @styles[:standard_column_style], height: LARGE_ROW_HEIGHT
+          sheet.add_row ['To be placed compliantly into a sub-lot, please refer to Framework Schedule 7 - Call-off Procedure and Award Criteria', nil, nil], style: @styles[:standard_column_style], height: LARGE_ROW_HEIGHT
+          sheet.add_row [], height: LARGE_ROW_HEIGHT
+
+          sheet.add_row ['Suppliers shortlists', nil, nil], style: @styles[:underlined_heading_style], height: STANDARD_ROW_HEIGHT
+          sheet.add_row ['Sub-lot 1a', 'Sub-lot 1b', 'Sub-lot 1c'], style: @styles[:heading_style], height: STANDARD_ROW_HEIGHT
+          sheet.add_row ['Total contract value: up to £7m', 'Total contract value: between £7m - £50m', 'Total contract value: over £50m'], style: @styles[:heading_style], height: STANDARD_ROW_HEIGHT
+
+          supplier_names_rows.each do |supplier_names_row|
+            sheet.add_row supplier_names_row, style: @styles[:supplier_shortlist_style], height: STANDARD_ROW_HEIGHT
+          end
+
+          sheet.merge_cells 'A2:C2'
+          sheet.merge_cells 'A3:C3'
+
+          sheet.column_widths(50, 50, 50)
+        end
+      end
+
+      def supplier_names_rows
+        supplier_names = [@lot_1a_suppliers, @lot_1b_suppliers, @lot_1c_suppliers]
+
+        max_size = supplier_names.map(&:size).max
+
+        max_size.times.map { |index| [supplier_names[0][index], supplier_names[1][index], supplier_names[2][index]] }
+      end
+
+      def suppliers_for_lot(lot)
+        SupplierDetail.long_list_suppliers_lot(@region_codes, @service_codes, lot).map { |supplier| supplier['name'] }
+      end
+    end
+  end
+end

--- a/app/services/facilities_management/rm6232/supplier_shortlist_spreadsheet_creator.rb
+++ b/app/services/facilities_management/rm6232/supplier_shortlist_spreadsheet_creator.rb
@@ -1,0 +1,38 @@
+module FacilitiesManagement
+  module RM6232
+    class SupplierShortlistSpreadsheetCreator < SupplierShortlistSpreadsheet
+      def initialize(procurement_id)
+        super(Procurement.find(procurement_id), 'Search name')
+      end
+
+      private
+
+      def set_data
+        @regions = @procurement.regions.map(&:name)
+        @services = @procurement.services.pluck(:code, :name).to_h
+        @supplier_names = @procurement.quick_view_suppliers.selected_suppliers.map(&:supplier_name)
+      end
+
+      def add_supplier_shortlists
+        @workbook.add_worksheet(name: 'Supplier shortlists') do |sheet|
+          sheet.add_row ['Selected suppliers', nil], style: @styles[:heading_style], height: LARGE_ROW_HEIGHT
+          sheet.add_row ['Here are the suppliers that can provide your services to your region(s).', nil, nil], style: @styles[:standard_column_style], height: LARGE_ROW_HEIGHT
+          sheet.add_row ['Estimated annual cost:', @procurement.annual_contract_value], style: @styles[:heading_style], height: LARGE_ROW_HEIGHT
+          sheet.add_row [], height: LARGE_ROW_HEIGHT
+
+          sheet.add_row ['Suppliers shortlists', nil], style: @styles[:underlined_heading_style], height: STANDARD_ROW_HEIGHT
+          sheet.add_row ["Sub-lot #{@procurement.lot_number}", nil], style: @styles[:heading_style], height: STANDARD_ROW_HEIGHT
+
+          @supplier_names.each do |supplier_name|
+            sheet.add_row [sanitize_string_for_excel(supplier_name), nil], style: @styles[:supplier_shortlist_style], height: STANDARD_ROW_HEIGHT
+          end
+
+          sheet.merge_cells 'A2:B2'
+          sheet['B3'].style = @styles[:currency_column_style]
+
+          sheet.column_widths(50, 50, 50)
+        end
+      end
+    end
+  end
+end

--- a/app/services/facilities_management/supplier_shortlist_spreadsheet.rb
+++ b/app/services/facilities_management/supplier_shortlist_spreadsheet.rb
@@ -1,12 +1,9 @@
-module FacilitiesManagement::RM3830
-  class QuickViewResultsSpreadsheetCreator
-    attr_accessor :session_data
-
-    def initialize(procurement_id)
-      @procurement = Procurement.find(procurement_id)
+module FacilitiesManagement
+  class SupplierShortlistSpreadsheet
+    def initialize(procurement, customer_details_title)
+      @procurement = procurement
       @buyer_detail = @procurement.user.buyer_detail
-      @region_codes = @procurement.region_codes
-      @service_codes = @procurement.service_codes
+      @customer_details_title = customer_details_title
     end
 
     def build
@@ -19,15 +16,6 @@ module FacilitiesManagement::RM3830
     end
 
     private
-
-    def set_data
-      @regions = FacilitiesManagement::Region.where(code: @region_codes).map(&:name)
-      @services = @service_codes.index_with { |code| Service.find_by(code: code).name }
-
-      @lot_1a_suppliers = suppliers_for_lot('1a')
-      @lot_1b_suppliers = suppliers_for_lot('1b')
-      @lot_1c_suppliers = suppliers_for_lot('1c')
-    end
 
     def create_spreadsheet
       @package = Axlsx::Package.new
@@ -49,6 +37,7 @@ module FacilitiesManagement::RM3830
         @styles[:bordered_heading_style] = styles.add_style sz: 12, b: true, alignment: { horizontal: :left, vertical: :center }, border: { style: :thin, color: '00000000' }
         @styles[:underlined_heading_style] = styles.add_style sz: 12, b: true, u: true, alignment: { horizontal: :left, vertical: :center }
         @styles[:standard_column_style] = styles.add_style sz: 12, alignment: { wrap_text: true, horizontal: :left, vertical: :center }
+        @styles[:currency_column_style] = styles.add_style sz: 12, alignment: { wrap_text: true, horizontal: :left, vertical: :center }, format_code: '£#,##0;'
         @styles[:standard_bordered_column_style] = styles.add_style sz: 12, alignment: { wrap_text: true, horizontal: :left, vertical: :center }, border: { style: :thin, color: '00000000' }
         @styles[:supplier_shortlist_style] = styles.add_style sz: 12, alignment: { horizontal: :left, vertical: :center }, fg_color: '6E6E6E'
       end
@@ -78,33 +67,11 @@ module FacilitiesManagement::RM3830
       end
     end
 
-    def add_supplier_shortlists
-      @workbook.add_worksheet(name: 'Supplier shortlists') do |sheet|
-        sheet.add_row ['Quick view results', nil, nil], style: @styles[:heading_style], height: LARGE_ROW_HEIGHT
-        sheet.add_row ['Here are the suppliers that can provide your services to your region(s). We are showing you potential suppliers from all three sub-lots, however, your procurement will fall into only one sub-lot dependent on your potential total contract value (which excludes billable works, optional extension periods and VAT).', nil, nil], style: @styles[:standard_column_style], height: LARGE_ROW_HEIGHT
-        sheet.add_row ['To be placed compliantly into a sub-lot, please refer to Framework Schedule 7 - Call-off Procedure and Award Criteria', nil, nil], style: @styles[:standard_column_style], height: LARGE_ROW_HEIGHT
-        sheet.add_row [], height: LARGE_ROW_HEIGHT
-
-        sheet.add_row ['Suppliers shortlists', nil, nil], style: @styles[:underlined_heading_style], height: STANDARD_ROW_HEIGHT
-        sheet.add_row ['Sub-lot 1a', 'Sub-lot 1b', 'Sub-lot 1c'], style: @styles[:heading_style], height: STANDARD_ROW_HEIGHT
-        sheet.add_row ['Total contract value: up to £7m', 'Total contract value: between £7m - £50m', 'Total contract value: over £50m'], style: @styles[:heading_style], height: STANDARD_ROW_HEIGHT
-
-        supplier_names_rows.each do |supplier_names_row|
-          sheet.add_row supplier_names_row, style: @styles[:supplier_shortlist_style], height: STANDARD_ROW_HEIGHT
-        end
-
-        sheet.merge_cells 'A2:C2'
-        sheet.merge_cells 'A3:C3'
-
-        sheet.column_widths(50, 50, 50)
-      end
-    end
-
     # rubocop:disable Metrics/AbcSize
     def add_customer_details
       @workbook.add_worksheet(name: 'Customer Details') do |sheet|
         sheet.add_row ['Date/time production of this document:', Time.now.in_time_zone('London').strftime('%d/%m/%Y - %l:%M%P')], style: @styles[:standard_column_style], height: STANDARD_ROW_HEIGHT
-        sheet.add_row ['Quick view search name', sanitize_string_for_excel(@procurement.contract_name)], style: @styles[:standard_column_style], height: STANDARD_ROW_HEIGHT
+        sheet.add_row [@customer_details_title, sanitize_string_for_excel(@procurement.contract_name)], style: @styles[:standard_column_style], height: STANDARD_ROW_HEIGHT
         sheet.add_row [], height: STANDARD_ROW_HEIGHT
 
         sheet.add_row ['Customer details', nil], style: @styles[:heading_style], height: STANDARD_ROW_HEIGHT
@@ -119,18 +86,6 @@ module FacilitiesManagement::RM3830
       end
     end
     # rubocop:enable Metrics/AbcSize
-
-    def supplier_names_rows
-      supplier_names = [@lot_1a_suppliers, @lot_1b_suppliers, @lot_1c_suppliers]
-
-      max_size = supplier_names.map(&:size).max
-
-      max_size.times.map { |index| [supplier_names[0][index], supplier_names[1][index], supplier_names[2][index]] }
-    end
-
-    def suppliers_for_lot(lot)
-      SupplierDetail.long_list_suppliers_lot(@region_codes, @service_codes, lot).map { |supplier| supplier['name'] }
-    end
 
     def sanitize_string_for_excel(string)
       return "'#{string}" if string.match?(/\A(@|=|\+|-)/)

--- a/app/views/facilities_management/rm6232/procurements/show_partial/_what_happens_next.html.erb
+++ b/app/views/facilities_management/rm6232/procurements/show_partial/_what_happens_next.html.erb
@@ -34,7 +34,7 @@
       </p>
     </div>
     <div class="govuk-!-margin-top-4 govuk-!-margin-bottom-3">
-      <%= link_to_generated_file_for_download('#', :xlsx, t('.selected_suppliers'), true) %>
+      <%= link_to_generated_file_for_download(facilities_management_rm6232_procurement_supplier_shortlist_spreadsheet_path(@procurement.id), :xlsx, t('.selected_suppliers'), true) %>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,7 +263,7 @@ en:
     type_csv: application/csv
     type_doc: application/msword
     type_pdf: application/pdf
-    type_xlsx: application/msexcel
+    type_xlsx: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
     xlsx_html: <abbr title="Microsoft Excel">XLSX</abbr>
   companies:
     unit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,7 @@ Rails.application.routes.draw do
       get '/', to: 'buyer_account#index'
 
       resources :procurements, only: %i[index show new create] do
+        get 'supplier_shortlist_spreadsheet'
       end
 
       namespace :admin, path: 'admin', defaults: { service: 'facilities_management/admin' } do

--- a/features/facilities_management/rm6232/procurements/what_happens_next.feature
+++ b/features/facilities_management/rm6232/procurements/what_happens_next.feature
@@ -1,0 +1,29 @@
+Feature: What happens next
+
+  Background: I navigate to the What happens next page
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have an empty procurement for 'what_happens_next' named 'My WHN procurement'
+    When I navigate to the procurement 'My WHN procurement'
+    And I am on the 'What happens next?' page
+  
+  Scenario: The content is correct
+    And the procurement name is shown to be 'My WHN procurement'
+    And the contract number is visible
+
+  @pipeline
+  Scenario: I can download the spreadsheet
+    And I click on 'Selected suppliers'
+    Then the spreadsheet 'Supplier shortlist (My WHN procurement)' is downloaded
+
+  @wip
+  Scenario: I can continue to entering requirements
+    And I click on 'Save and continue'
+    Then I am on the 'Entering requirements' page
+
+  Scenario: Back button link
+    And I click on 'Return to procurements dashboard'
+    Then I am on the 'Procurements dashboard' page
+
+  Scenario: Return link
+    And I click on 'Return to your account'
+    And I am on the Your account page

--- a/features/step_definitions/facilities_management/common_steps.rb
+++ b/features/step_definitions/facilities_management/common_steps.rb
@@ -111,6 +111,11 @@ When('I visit {string}') do |url|
   visit url
 end
 
+Then('the spreadsheet {string} is downloaded') do |spreadsheet_name|
+  expect(page.response_headers['Content-Type']).to eq 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  expect(page.response_headers['Content-Disposition']).to include "filename=\"#{spreadsheet_name}".gsub('(', '%28').gsub(')', '%29')
+end
+
 And('I start a procurement') do
   step "I click on 'Start a procurement'"
   step "I am on the 'What happens next' page"

--- a/features/step_definitions/facilities_management/rm6232/procurement_steps.rb
+++ b/features/step_definitions/facilities_management/rm6232/procurement_steps.rb
@@ -2,10 +2,21 @@ Given('I have an RM6232 procurement with the name {string}') do |contract_name|
   create(:facilities_management_rm6232_procurement_no_procurement_buildings, :skip_before_create, user: @user, contract_name: contract_name)
 end
 
+Given('I have an empty procurement for {string} named {string}') do |state, contract_name|
+  @procurement = create(:facilities_management_rm6232_procurement_no_procurement_buildings, :skip_before_create, user: @user, contract_name: contract_name, aasm_state: state)
+end
+
 Then('the procurement name is shown to be {string}') do |contract_name|
   expect(page.find('#main-content > div:nth-child(2) > div > span')).to have_content(contract_name)
 end
 
 Then('the RM6232 procurement {string} should have the state {string}') do |contract_name, status|
   expect(procurement_page.find('th', text: contract_name).find(:xpath, '../td[2]')).to have_content(status)
+end
+
+When('the contract number is visible') do
+  contract_number = @procurement.contract_number
+
+  expect(page.find('#main-content > div:nth-child(2) > div > span')).to have_content("#{@procurement.contract_name} - #{contract_number}")
+  expect(page.find('.ccs-panel__body')).to have_content(contract_number)
 end

--- a/spec/controllers/facilities_management/rm6232/procurements_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/procurements_controller_spec.rb
@@ -158,4 +158,29 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementsController, type: :cont
       end
     end
   end
+
+  describe 'GET supplier_shortlist_spreadsheet' do
+    login_fm_buyer_with_details
+
+    let(:state) { 'what_happens_next' }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_no_procurement_buildings, :skip_before_create, aasm_state: state, user: controller.current_user, contract_name: 'New search') }
+
+    before { get :supplier_shortlist_spreadsheet, params: { procurement_id: procurement.id } }
+
+    context 'when the procurement is not in what happens next' do
+      let(:state) { 'entering_requirements' }
+
+      it 'redirects to the show page' do
+        expect(response).to redirect_to facilities_management_rm6232_procurement_path(id: procurement.id)
+      end
+    end
+
+    context 'when the procurement is in what happens next' do
+      let(:state) { 'what_happens_next' }
+
+      it 'does download a spreadsheet' do
+        expect(response.headers['Content-Disposition']).to include 'filename="Supplier shortlist %28New search%29.xlsx"'
+      end
+    end
+  end
 end

--- a/spec/factories/facilities_management/rm6232/procurement.rb
+++ b/spec/factories/facilities_management/rm6232/procurement.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     annual_contract_value { 12345 }
     contract_name { Faker::Name.unique.name }
     lot_number { '2a' }
+    contract_number { 'RM6232-000001-2022' }
     association :user
 
     trait :skip_generate_contract_number do

--- a/spec/models/facilities_management/rm6232/procurement_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
 
   describe 'before_create' do
     context 'when a procurement is created' do
-      let(:procurement) { build(:facilities_management_rm6232_procurement_no_procurement_buildings, lot_number: nil) }
+      let(:procurement) { build(:facilities_management_rm6232_procurement_no_procurement_buildings, lot_number: nil, contract_number: nil) }
 
       # rubocop:disable RSpec/MultipleExpectations
       it 'sets the contract number and lot number' do

--- a/spec/services/facilities_management/rm3830/supplier_shortlist_spreadsheet_creator_spec.rb
+++ b/spec/services/facilities_management/rm3830/supplier_shortlist_spreadsheet_creator_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe FacilitiesManagement::RM3830::QuickViewResultsSpreadsheetCreator do
+RSpec.describe FacilitiesManagement::RM3830::SupplierShortlistSpreadsheetCreator do
   let(:procurement) { create(:facilities_management_rm3830_procurement, user: user, service_codes: ['G.9', 'H.1', 'L.11'], region_codes: ['UKF3', 'UKM28', 'UKM36', 'UKM62', 'UKN03'], contract_name: 'My quick view test', aasm_state: 'quick_search') }
   let(:user) { create(:user, :with_detail) }
   let(:buyer_detail) { user.buyer_detail }

--- a/spec/services/facilities_management/rm6232/supplier_shortlist_spreadsheet_creator_spec.rb
+++ b/spec/services/facilities_management/rm6232/supplier_shortlist_spreadsheet_creator_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::SupplierShortlistSpreadsheetCreator do
+  let(:procurement) { create(:facilities_management_rm6232_procurement_no_procurement_buildings, :skip_before_create, user: user, service_codes: %w[E.5 M.1 P.8], region_codes: %w[UKC1 UKD1 UKF3 UKH3], annual_contract_value: 500_000, contract_name: 'My search test', aasm_state: 'what_happens_next') }
+  let(:user) { create(:user, :with_detail) }
+  let(:buyer_detail) { user.buyer_detail }
+  let(:spreadsheet_builder) { described_class.new(procurement.id) }
+  let(:work_book) do
+    spreadsheet_builder.build
+    IO.write('/tmp/selected_suppliers.xlsx', spreadsheet_builder.to_xlsx, binmode: true)
+    Roo::Excelx.new('/tmp/selected_suppliers.xlsx')
+  end
+
+  context 'when considering the regions sheet' do
+    let(:sheet) { work_book.sheet('Regions') }
+
+    it 'has the correct regions' do
+      expect(sheet.column(1)).to eq ['Regions', 'Tees Valley and Durham', 'Cumbria', 'Lincolnshire', 'Essex']
+    end
+  end
+
+  context 'when considering the services sheet' do
+    let(:sheet) { work_book.sheet('Services') }
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'has the correct services' do
+      expect(sheet.row(1)).to eq ['Service Reference', 'Service Name']
+      expect(sheet.row(2)).to eq ['E.5', 'Lifts, hoists and conveyance systems maintenance']
+      expect(sheet.row(3)).to eq ['M.1', 'On Site / Mobile Classified Waste Shredding Service']
+      expect(sheet.row(4)).to eq ['P.8', 'Accommodation Stores Service']
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+  end
+
+  context 'when considering the Supplier shortlists sheet' do
+    let(:sheet) { work_book.sheet('Supplier shortlists') }
+
+    it 'has the correct suppliers' do
+      expect(sheet.column(1)[6..]).to eq ['Dach Inc', 'Feest Group', 'Harber LLC', 'Hudson, Spinka and Schuppe', 'Metz Inc', "O'Reilly, Emmerich and Reichert", 'Roob-Kessler', 'Skiles LLC', 'Torphy Inc', 'Turner-Pouros']
+    end
+  end
+
+  context 'when considering the Customer Details sheet' do
+    let(:sheet) { work_book.sheet('Customer Details') }
+
+    it 'has the correct buyer details' do
+      buyer_details = ['My search test', nil, nil, buyer_detail.organisation_name, buyer_detail.full_organisation_address, buyer_detail.full_name, buyer_detail.job_title, buyer_detail.email, buyer_detail.telephone_number.to_i]
+
+      expect(sheet.column(2)[1..]).to eq buyer_details
+    end
+  end
+end


### PR DESCRIPTION
Ticket: [FMFR-1168](https://crowncommercialservice.atlassian.net/browse/FMFR-1168)

Add the functionality to download the ‘Selected suppliers’ on the ‘What happens next page’. As this shares a lot of the functionality with the ‘Quick view spreadsheet’ so I refactored both spreadsheet creators to share the code. I also added tests for the spreadsheet download.