### PR TITLE
FMFR-1170 - Add edit pages for 'contract name' and 'annual contract value'

### DIFF
--- a/app/controllers/concerns/facilities_management/procurement_details_concern.rb
+++ b/app/controllers/concerns/facilities_management/procurement_details_concern.rb
@@ -7,6 +7,8 @@ module FacilitiesManagement::ProcurementDetailsConcern
     before_action :redirect_if_unrecognised_section, only: :show
     before_action :redirect_to_edit_from_show, only: :show
     before_action :redirect_if_unrecognised_edit_section, only: :edit
+
+    helper_method :section
   end
 
   def show
@@ -17,12 +19,20 @@ module FacilitiesManagement::ProcurementDetailsConcern
     render 'facilities_management/shared/details/edit'
   end
 
-  def update; end
+  def update
+    @procurement.assign_attributes(procurement_params)
+
+    if @procurement.save(context: section.to_sym)
+      redirect_to procurement_show_path
+    else
+      render 'facilities_management/shared/details/edit'
+    end
+  end
 
   private
 
   def section
-    @section ||= params['section'].underscore
+    @section ||= params['section'].underscore.to_sym
   end
 
   def section_status
@@ -30,16 +40,29 @@ module FacilitiesManagement::ProcurementDetailsConcern
   end
 
   def redirect_if_unrecognised_section
-    redirect_to "/facilities-management/#{params[:framework]}/procurements/#{params[:procurement_id]}" unless self.class::RECOGNISED_DETAILS_SHOW_PAGES.include? section
+    redirect_to procurement_show_path unless self.class::RECOGNISED_DETAILS_SHOW_PAGES.include? section
   end
 
   def redirect_to_edit_from_show
-    redirect_to "/facilities-management/#{params[:framework]}/procurements/#{params[:procurement_id]}/details/#{params[:section]}/edit" if section_status == :not_started || (section == 'contract_period' && section_status == :incomplete)
+    redirect_to "/facilities-management/#{params[:framework]}/procurements/#{params[:procurement_id]}/details/#{params[:section]}/edit" if section_status == :not_started || (section == :contract_period && section_status == :incomplete)
   end
 
   def redirect_if_unrecognised_edit_section
-    redirect_to "/facilities-management/#{params[:framework]}/procurements/#{params[:procurement_id]}" unless self.class::RECOGNISED_DETAILS_EDIT_STEPS.include? section
+    redirect_to procurement_show_path unless self.class::RECOGNISED_DETAILS_EDIT_STEPS.include? section
   end
+
+  def procurement_show_path
+    "/facilities-management/#{params[:framework]}/procurements/#{params[:procurement_id]}"
+  end
+
+  def procurement_params
+    params.require(@procurement.model_name.param_key).permit(PERMITED_PARAMS[section])
+  end
+
+  PERMITED_PARAMS = {
+    contract_name: [:contract_name],
+    annual_contract_value: [:annual_contract_value]
+  }.freeze
 
   protected
 

--- a/app/controllers/facilities_management/rm6232/details_controller.rb
+++ b/app/controllers/facilities_management/rm6232/details_controller.rb
@@ -9,8 +9,8 @@ module FacilitiesManagement
         @procurement = Procurement.find(params[:procurement_id])
       end
 
-      RECOGNISED_DETAILS_EDIT_STEPS = %w[contract_name annual_contract_value tupe contract_period services buildings].freeze
-      RECOGNISED_DETAILS_SHOW_PAGES = %w[contract_period services buildings buildings_and_services].freeze
+      RECOGNISED_DETAILS_EDIT_STEPS = %i[contract_name annual_contract_value].freeze
+      RECOGNISED_DETAILS_SHOW_PAGES = %i[contract_period services buildings buildings_and_services].freeze
     end
   end
 end

--- a/app/helpers/facilities_management/rm6232/details_helper.rb
+++ b/app/helpers/facilities_management/rm6232/details_helper.rb
@@ -1,0 +1,9 @@
+module FacilitiesManagement::RM6232
+  module DetailsHelper
+    include FacilitiesManagement::RM6232::ProcurementsHelper
+
+    def page_title
+      @page_title ||= t("facilities_management.shared.details.edit.title.#{section}")
+    end
+  end
+end

--- a/app/helpers/facilities_management/rm6232/procurements_helper.rb
+++ b/app/helpers/facilities_management/rm6232/procurements_helper.rb
@@ -3,7 +3,11 @@ module FacilitiesManagement::RM6232
     include FacilitiesManagement::ProcurementsHelper
 
     def page_subtitle
-      "#{@procurement.contract_name} - #{@procurement.contract_number}"
+      "#{current_contract_name} - #{@procurement.contract_number}"
+    end
+
+    def current_contract_name
+      @procurement.errors.include?(:contract_name) ? @procurement.class.find(params[:id] || params[:procurement_id]).contract_name : @procurement.contract_name
     end
 
     def journey_step_url_former(journey_slug:, annual_contract_value: nil, region_codes: nil, service_codes: nil)

--- a/app/helpers/gov_uk_helper.rb
+++ b/app/helpers/gov_uk_helper.rb
@@ -8,4 +8,5 @@ module GovUKHelper
   include NotificationBanner
   include Radios
   include StepByStepNavigation
+  include TextInput
 end

--- a/app/helpers/gov_uk_helper/text_input.rb
+++ b/app/helpers/gov_uk_helper/text_input.rb
@@ -1,0 +1,57 @@
+module GovUKHelper::TextInput
+  def govuk_text_input(form, attribute, text_input_options)
+    class_list = ['govuk-form-group']
+    any_errors = form.object.errors.include? attribute
+    class_list << 'govuk-form-group--error' if any_errors
+
+    tag.div(class: class_list, id: "#{attribute}-form-group") do
+      capture do
+        concat(govuk_label(form, attribute, text_input_options[:label])) if text_input_options[:label]
+        concat(govuk_hint(text_input_options[:hint])) if text_input_options[:hint]
+        concat(govuk_error_message(form, attribute)) if any_errors
+        concat(govuk_input(form, attribute, any_errors, text_input_options[:input]))
+      end
+    end
+  end
+
+  private
+
+  def govuk_label(form, attribute, label_options = {})
+    class_list = ['govuk-label']
+    class_list << label_options[:classes] if label_options[:classes]
+
+    form.label(attribute, label_options[:text], class: class_list, **label_options)
+  end
+
+  def govuk_hint(hint_options = {})
+    tag.div(hint_options[:text], class: 'govuk-hint', **hint_options)
+  end
+
+  def govuk_error_message(form, attribute)
+    error = form.object.errors[attribute].first
+
+    tag.span(id: "#{attribute}-error", class: 'govuk-error-message') do
+      error.to_s
+    end
+  end
+
+  def govuk_input(form, attribute, any_errors, input_options = {})
+    class_list = ['govuk-input']
+    class_list << input_options.delete(:classes) if input_options[:classes]
+    class_list << 'govuk-input--error' if any_errors
+
+    text_field = form.text_field(attribute, class: class_list, **input_options)
+
+    if input_options[:prefix] || input_options[:suffix]
+      tag.div(class: 'govuk-input__wrapper') do
+        capture do
+          concat(tag.div(input_options[:prefix][:text], class: 'govuk-input__prefix', aria: { hidden: true })) if input_options[:prefix]
+          concat(text_field)
+          concat(tag.div(input_options[:suffix][:text], class: 'govuk-input__suffix', aria: { hidden: true })) if input_options[:suffix]
+        end
+      end
+    else
+      text_field
+    end
+  end
+end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -104,7 +104,7 @@ module LayoutHelper
 
     tag.div(**options) do
       capture do
-        concat(govuk_label(builder, builder.object, attribute, label_text)) if require_label
+        concat(govuk_label_old(builder, builder.object, attribute, label_text)) if require_label
         concat(display_error(builder.object, attribute)) if show_errors && !hide_error_text
         block.call(attribute) if block_given?
       end
@@ -171,25 +171,6 @@ module LayoutHelper
   end
   # rubocop:enable Metrics/AbcSize
 
-  INPUT_WIDTH = { tiny: 'govuk-input--width-2',
-                  small: 'govuk-input--width-4',
-                  medium: 'govuk-input--width-10',
-                  large: 'govuk-input--width-20',
-                  one_half: 'govuk-!-width-one-half',
-                  two_thirds: 'govuk-!-width-two-thirds',
-                  one_quarter: 'govuk-!-width-one-quarter' }.freeze
-
-  def govuk_text_input(builder, attribute, text_size, **options)
-    css_classes = ['govuk-input']
-    css_classes += ['govuk-input--error'] if builder.object.errors.key?(attribute)
-    css_classes += [INPUT_WIDTH[text_size]]
-
-    options.merge!(class: css_classes.join(' ')) { |_key, oldval, newval| "#{newval} #{oldval}" }
-    options.merge!('aria-describedby': error_id(attribute)) if builder.object.errors.key?(attribute)
-
-    builder.text_field attribute, options
-  end
-
   def govuk_button(builder, text, options = { submit: true, class: '' })
     css_classes = ['govuk-button']
     css_classes << options[:class]
@@ -202,7 +183,7 @@ module LayoutHelper
     builder.button(value: nil, class: css_classes)
   end
 
-  def govuk_label(builder, model, attribute, label_text = {})
+  def govuk_label_old(builder, model, attribute, label_text = {})
     builder.label attribute, generate_label_text(model, attribute, label_text), class: 'govuk-label govuk-!-margin-bottom-1'
   end
 

--- a/app/models/concerns/facilities_management/rm6232/procurement_validator.rb
+++ b/app/models/concerns/facilities_management/rm6232/procurement_validator.rb
@@ -11,6 +11,8 @@ module FacilitiesManagement::RM6232
         validates :contract_name, length: 1..100
       end
 
+      validates :annual_contract_value, numericality: { only_integer: true, greater_than: 0, less_than: 1_000_000_000_000 }, on: :annual_contract_value
+
       # Validations on entering requirements
       with_options on: :entering_requirements do
         # TODO: Consider adding this

--- a/app/views/facilities_management/buildings/_area.html.erb
+++ b/app/views/facilities_management/buildings/_area.html.erb
@@ -1,30 +1,67 @@
 <p class="govuk-body">
   <%= t('.guidance') %>
 </p>
-<h2 class="govuk-heading-m govuk-!-margin-bottom-1">
-  <%= t('.gia_header') %>
-</h2>
-<p class="govuk-caption-m">
-  <%= t('.description_html') %>
-</p>
-<p class="govuk-caption-m">
-  <%= t('.further_info_html') %>
-</p>
 <input type="hidden" name="step" value="gia"/>
-<%= govuk_start_individual_field(f, :gia, {}, false, true, data: { maxlength: '9', numbertype: 'integer' }) do %>
-  <%= f.label :gia, 'gia', class: "govuk-heading-s govuk-!-margin-bottom-0 govuk-visually-hidden"%>
-  <div class="govuk-input__wrapper">
-    <%= govuk_text_input(f, :gia, :large, type: 'number', pattern: '[0-9]', required: 'true', maxlength: 9, size: 12, class: 'govuk-input govuk-input--width-5 ccs-character-count', style: 'min-width: 10ex', 'aria-live': 'polite', 'aria-describedby': "facilities_management_building_gia") %>
-    <div class="govuk-input__suffix" aria-hidden="true">sqm</div>
-  </div>
-<% end %>
 
-<h2 class="govuk-heading-m govuk-!-margin-bottom-1"><%= t('.external_area_header') %></h2>
-<p class="govuk-caption-m"><%= t('.external_area_description_html') %></p>
-<%= govuk_start_individual_field(f, :external_area, {}, false, true, data: { maxlength: '9', numbertype: 'integer' }) do %>
-  <%= f.label :external_area, 'external_area', class: "govuk-heading-s govuk-!-margin-bottom-0 govuk-visually-hidden"%>
-  <div class="govuk-input__wrapper">
-    <%= govuk_text_input(f, :external_area, :large, type: 'number', pattern: '[0-9]', required: 'true', maxlength: 9, size: 12, class: 'govuk-input govuk-input--width-5 ccs-character-count', style: 'min-width: 10ex', 'aria-live': 'polite', 'aria-describedby': "facilities_management_building_gia") %>
-    <div class="govuk-input__suffix" aria-hidden="true">sqm</div>
-  </div>
-<% end %>
+<% gia_hint_html = capture do 
+  concat(tag.p(t('.description_html'), class: 'govuk-hint'))
+  concat(tag.p(t('.further_info_html'), class: 'govuk-hint'))
+end %>
+
+<%= govuk_text_input(
+  f,
+  :gia,
+  {
+    label: {
+      text: t('.gia_header'),
+      classes: 'govuk-label--m'
+    },
+    hint: {
+      text: gia_hint_html,
+      id: 'gia-hint'
+    },
+    input: {
+      classes: 'govuk-input--width-5',
+      suffix: {
+        text: 'sqm'
+      },
+      attributes: {
+        type: 'number',
+        pattern: '[0-9]',
+        maxlength: 9,
+        aria: {
+          describedby: 'gia-hint'
+        }
+      }
+    }
+  }
+)%>
+
+<%= govuk_text_input(
+  f,
+  :external_area,
+  {
+    label: {
+      text: t('.external_area_header'),
+      classes: 'govuk-label--m'
+    },
+    hint: {
+      text: t('.external_area_description_html'),
+      id: 'external-area-hint'
+    },
+    input: {
+      classes: 'govuk-input--width-5',
+      suffix: {
+        text: 'sqm'
+      },
+      attributes: {
+        type: 'number',
+        pattern: '[0-9]',
+        maxlength: 9,
+        aria: {
+          describedby: 'external-area'
+        }
+      }
+    }
+  }
+)%>

--- a/app/views/facilities_management/rm3830/supplier/contracts/edit.html.erb
+++ b/app/views/facilities_management/rm3830/supplier/contracts/edit.html.erb
@@ -29,7 +29,7 @@
           <%= govuk_radios_conditional_item(f, :contract_response, true, t('.yes')) %>
           <%= govuk_radios_conditional_item(f, :contract_response, false, t('.no')) %>
           <%= govuk_radios_conditional_area(:contract_response, false, class: 'govuk-!-width-one-half') do %>
-            <%= govuk_label(f, f.object, :reason_for_declining, { reason_for_declining: t('.reason_for_declining')}) %>
+            <%= govuk_label_old(f, f.object, :reason_for_declining, { reason_for_declining: t('.reason_for_declining')}) %>
             <%= display_error(f.object, :reason_for_declining) %>
             <hr class="govuk-section-break govuk-!-margin-top-4">
             <%= govuk_character_count(f, :reason_for_declining, 500, 5) %>

--- a/app/views/facilities_management/rm6232/procurements/show.html.erb
+++ b/app/views/facilities_management/rm6232/procurements/show.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <span class="govuk-caption-m govuk-!-font-size-24">
+    <span id="procurement-subtitle" class="govuk-caption-m govuk-!-font-size-24">
       <%= page_subtitle %>
     </span>
     <h1 class="govuk-heading-xl">

--- a/app/views/facilities_management/shared/details/edit.html.erb
+++ b/app/views/facilities_management/shared/details/edit.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, page_title %>
+<%= render partial: 'shared/error_summary', locals: { errors: @procurement.errors } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span id="procurement-subtitle" class="govuk-caption-m govuk-!-font-size-24">
+      <%= page_subtitle %>
+    </span>
+    <h1 class="govuk-heading-xl">
+      <%= page_title %>
+    </h1>
+  </div>
+</div>
+<div>
+
+<%= form_with url: facilities_management_rm6232_procurement_detail_path, model: @procurement, method: :put, local: 'false', html: { specialvalidation: true, novalidate: true } do |f| %>
+  <%= render partial: "facilities_management/shared/details/edit_partials/#{section}", locals: { f: f } %>
+
+  <div class="govuk-grid-row govuk-!-margin-top-5">
+    <div class="govuk-grid-column-full">
+      <%= f.submit(t('.save_and_return'), class: 'govuk-button', data: { module: 'govuk-button' }) %>
+      <p>
+        <%= link_to t('.return_to_requirements'), facilities_management_rm6232_procurement_path(@procurement), class: 'govuk-link--no-visited-state' %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/facilities_management/shared/details/edit_partials/_annual_contract_value.html.erb
+++ b/app/views/facilities_management/shared/details/edit_partials/_annual_contract_value.html.erb
@@ -1,0 +1,28 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_text_input(
+      f,
+      :annual_contract_value,
+      {
+        label: {
+          text: t('.label_text'),
+          classes: 'govuk-label--m'
+        },
+        hint: {
+          text: t('.hint_text'),
+          id: 'annual-contract-value-hint'
+        },
+        input: {
+          classes: 'govuk-input--width-10 ccs-number-field ccs-integer-field',
+          maxlength: 15,
+          prefix: {
+            text: '£'
+          },
+          aria: {
+            describedby: 'annual-contract-value-hint'
+          }
+        }
+      }
+    )%>
+  </div>
+</div>

--- a/app/views/facilities_management/shared/details/edit_partials/_contract_name.html.erb
+++ b/app/views/facilities_management/shared/details/edit_partials/_contract_name.html.erb
@@ -1,0 +1,26 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <%= govuk_text_input(
+      f,
+      :contract_name,
+      {
+        label: {
+          text: t('.label_text'),
+          classes: 'govuk-label--m'
+        },
+        hint: {
+          text: t('.hint_text'),
+          id: 'contract-name-hint'
+        },
+        input: {
+          classes: 'govuk-input--width-20',
+          required: true,
+          maxlength: 100,
+          aria: {
+            describedby: 'contract-name-hint'
+          }
+        }
+      }
+    )%>
+  </div>
+</div>

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -336,6 +336,20 @@ en:
             many: services selected
             none: No services selected
             one: service selected
+      details:
+        edit:
+          return_to_requirements: Return to requirements
+          save_and_return: Save and return
+          title:
+            annual_contract_value: Annual contract value
+            contract_name: Contract name
+        edit_partials:
+          annual_contract_value:
+            hint_text: Enter your estimate for the annual contract value. Include everything in your calculation.
+            label_text: What is your estimate for the annual contract value?
+          contract_name:
+            hint_text: This will help you to refer to your contracts when talking to suppliers.
+            label_text: What do you want to call your contract?
       summary_tables:
         contract_summary_table:
           annual_contract_value: Annual contract value

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -62,6 +62,11 @@ en:
               too_long: The supplier name cannot be more than 100 characters
         facilities_management/rm6232/procurement:
           attributes:
+            annual_contract_value:
+              greater_than: The annual contract value must be a whole number greater than 0
+              less_than: The annual contract value must be less than 1,000,000,000,000 (1 trillion)
+              not_a_number: The annual contract value must be a whole number greater than 0
+              not_an_integer: The annual contract value must be a whole number greater than 0
             base:
               incomplete: Your requirements are incomplete
             contract_name:

--- a/features/step_definitions/facilities_management/rm6232/procurement_steps.rb
+++ b/features/step_definitions/facilities_management/rm6232/procurement_steps.rb
@@ -7,7 +7,7 @@ Given('I have an empty procurement for {string} named {string}') do |state, cont
 end
 
 Then('the procurement name is shown to be {string}') do |contract_name|
-  expect(page.find('#main-content > div:nth-child(2) > div > span')).to have_content(contract_name)
+  expect(page.find('#procurement-subtitle')).to have_content(contract_name)
 end
 
 Then('the RM6232 procurement {string} should have the state {string}') do |contract_name, status|

--- a/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
 
       render_views
 
-      pending 'renders the contract_name partial' do
+      it 'renders the contract_name partial' do
         expect(response).to render_template(partial: '_contract_name')
       end
 
@@ -187,7 +187,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
 
       render_views
 
-      pending 'renders the annual_contract_value partial' do
+      it 'renders the annual_contract_value partial' do
         expect(response).to render_template(partial: '_annual_contract_value')
       end
 
@@ -249,6 +249,104 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
 
       it 'sets the procurement' do
         expect(assigns(:procurement)).to eq procurement
+      end
+    end
+  end
+
+  describe 'PUT update' do
+    before { put :update, params: { procurement_id: procurement.id, section: section_name, facilities_management_rm6232_procurement: update_params } }
+
+    context 'when updating the contract name' do
+      let(:section_name) { 'contract-name' }
+
+      context 'and the data is valid' do
+        let(:update_params) { { contract_name: 'Hello there' } }
+
+        it 'redirects to the procurement show page' do
+          expect(response).to redirect_to facilities_management_rm6232_procurement_path(procurement)
+        end
+
+        it 'updates the contract name' do
+          procurement.reload
+
+          expect(procurement.contract_name).to eq('Hello there')
+        end
+      end
+
+      context 'and the data is not valid' do
+        let(:update_params) { { contract_name: nil } }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'does not update the contract name' do
+          procurement.reload
+
+          expect(procurement.contract_name).not_to be_nil
+        end
+      end
+
+      context 'and an unpermitted parameters are passed in' do
+        let(:update_params) { { annual_contract_value: 87_654 } }
+
+        it 'redirects to the procurement show page' do
+          expect(response).to redirect_to facilities_management_rm6232_procurement_path(procurement)
+        end
+
+        it 'does no update the unpermitted attribute' do
+          procurement.reload
+
+          expect(procurement.annual_contract_value).to eq(12_345)
+        end
+      end
+    end
+
+    context 'when updating the annual contract value' do
+      let(:section_name) { 'annual-contract-value' }
+
+      context 'and the data is valid' do
+        let(:update_params) { { annual_contract_value: '567890' } }
+
+        it 'redirects to the procurement show page' do
+          expect(response).to redirect_to facilities_management_rm6232_procurement_path(procurement)
+        end
+
+        it 'updates the annual contract value' do
+          procurement.reload
+
+          expect(procurement.annual_contract_value).to eq(567_890)
+        end
+      end
+
+      context 'and the data is not valid' do
+        let(:update_params) { { annual_contract_value: nil } }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'does not update the annual contract value' do
+          procurement.reload
+
+          expect(procurement.annual_contract_value).not_to be_nil
+        end
+      end
+
+      context 'and an unpermitted parameters are passed in' do
+        let(:update_params) { { contract_name: 'Hello there' } }
+
+        it 'redirects to the procurement show page' do
+          expect(response).to redirect_to facilities_management_rm6232_procurement_path(procurement)
+        end
+
+        it 'does no update the unpermitted attribute' do
+          origional_contract_name = procurement.contract_name
+          procurement.reload
+
+          expect(procurement.contract_name).not_to eq('Hello there')
+          expect(procurement.contract_name).to eq(origional_contract_name)
+        end
       end
     end
   end

--- a/spec/factories/facilities_management/rm6232/procurement.rb
+++ b/spec/factories/facilities_management/rm6232/procurement.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :facilities_management_rm6232_procurement_no_procurement_buildings, class: 'FacilitiesManagement::RM6232::Procurement' do
     service_codes { ['E.1', 'E.2'] }
     region_codes { ['UKI4', 'UKI5'] }
-    annual_contract_value { 12345 }
+    annual_contract_value { 12_345 }
     contract_name { Faker::Name.unique.name }
     association :user
 

--- a/spec/models/facilities_management/rm6232/procurement_validations_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_validations_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
   describe 'validations' do
-    describe '#contract_name' do
+    describe 'contract_name' do
       let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, user: user) }
       let(:user) { create(:user) }
 
@@ -61,6 +61,63 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
 
         it 'expected to be valid' do
           expect(procurement.valid?(:contract_name)).to eq true
+        end
+      end
+    end
+
+    describe 'annual_contract_value' do
+      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, annual_contract_value: annual_contract_value) }
+
+      context 'when no annual contract value is present' do
+        let(:annual_contract_value) { nil }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement.valid?(:annual_contract_value)).to be false
+          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+        end
+      end
+
+      context 'when the annual contract value is not a number' do
+        let(:annual_contract_value) { 'Camuvari' }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement.valid?(:annual_contract_value)).to be false
+          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+        end
+      end
+
+      context 'when the annual contract value is not an integer' do
+        let(:annual_contract_value) { 1_000_000.67 }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement.valid?(:annual_contract_value)).to be false
+          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+        end
+      end
+
+      context 'when the annual contract value is less than 1' do
+        let(:annual_contract_value) { 0 }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement.valid?(:annual_contract_value)).to be false
+          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+        end
+      end
+
+      context 'when the annual contract value is more than 999,999,999,999' do
+        let(:annual_contract_value) { 1_000_000_000_000 }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement.valid?(:annual_contract_value)).to be false
+          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract value must be less than 1,000,000,000,000 (1 trillion)'
+        end
+      end
+
+      context 'when annual contract value is present' do
+        let(:annual_contract_value) { 123_456 }
+
+        it 'is valid' do
+          expect(procurement.valid?(:annual_contract_value)).to be true
         end
       end
     end


### PR DESCRIPTION
Part of ticket: [FMFR-1170](https://crowncommercialservice.atlassian.net/browse/FMFR-1170)

This commit contains the first working edit pages for the contract details:
- The contract name
- Annual contract value

To prevent the commits getting too large, I am splitting them up for each page that is added.

I will add the feature tests for this work in a later PR dedicated to adding them.