### PR TITLE
FMFR-1170 - Add edit page for 'tupe'

### DIFF
--- a/app/controllers/concerns/facilities_management/procurement_details_concern.rb
+++ b/app/controllers/concerns/facilities_management/procurement_details_concern.rb
@@ -56,12 +56,17 @@ module FacilitiesManagement::ProcurementDetailsConcern
   end
 
   def procurement_params
-    params.require(@procurement.model_name.param_key).permit(PERMITED_PARAMS[section])
+    if params[@procurement.model_name.param_key]
+      params.require(@procurement.model_name.param_key).permit(PERMITED_PARAMS[section])
+    else
+      {}
+    end
   end
 
   PERMITED_PARAMS = {
     contract_name: [:contract_name],
-    annual_contract_value: [:annual_contract_value]
+    annual_contract_value: [:annual_contract_value],
+    tupe: [:tupe]
   }.freeze
 
   protected

--- a/app/controllers/facilities_management/rm6232/details_controller.rb
+++ b/app/controllers/facilities_management/rm6232/details_controller.rb
@@ -9,7 +9,7 @@ module FacilitiesManagement
         @procurement = Procurement.find(params[:procurement_id])
       end
 
-      RECOGNISED_DETAILS_EDIT_STEPS = %i[contract_name annual_contract_value].freeze
+      RECOGNISED_DETAILS_EDIT_STEPS = %i[contract_name annual_contract_value tupe].freeze
       RECOGNISED_DETAILS_SHOW_PAGES = %i[contract_period services buildings buildings_and_services].freeze
     end
   end

--- a/app/models/concerns/facilities_management/rm6232/procurement_validator.rb
+++ b/app/models/concerns/facilities_management/rm6232/procurement_validator.rb
@@ -3,7 +3,6 @@ module FacilitiesManagement::RM6232
     extend ActiveSupport::Concern
 
     included do
-      # Validations on the contract name
       with_options on: :contract_name do
         before_validation :remove_excess_whitespace_from_name
         validates :contract_name, presence: true
@@ -12,6 +11,8 @@ module FacilitiesManagement::RM6232
       end
 
       validates :annual_contract_value, numericality: { only_integer: true, greater_than: 0, less_than: 1_000_000_000_000 }, on: :annual_contract_value
+
+      validates :tupe, inclusion: [true, false], on: :tupe
 
       # Validations on entering requirements
       with_options on: :entering_requirements do

--- a/app/models/facilities_management/rm6232/procurement.rb
+++ b/app/models/facilities_management/rm6232/procurement.rb
@@ -53,9 +53,7 @@ module FacilitiesManagement
       end
 
       def tupe_status
-        # TODO: Add in when appropriate
-        # tupe.nil? ? :not_started : :completed
-        :not_started
+        tupe.nil? ? :not_started : :completed
       end
 
       def contract_period_status

--- a/app/views/facilities_management/shared/details/edit_partials/_tupe.html.erb
+++ b/app/views/facilities_management/shared/details/edit_partials/_tupe.html.erb
@@ -1,0 +1,30 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <fieldset class="govuk-fieldset">
+      <%= form_group_with_error(f.object, :tupe) do |displayed_error| %>
+        <%= hint_details(t('.first_question'), t('.body_text_html')) %>
+
+        <div class="govuk-!-margin-top-4 govuk-!-margin-bottom-4">
+          <%= govuk_details(t('.what_you_need_to_know_title')) do %>
+            <%= t('.what_you_need_to_know_html') %>
+            <%= link_to t('.tupe_link_text'), t('.tupe_link'), class: 'govuk-link', tabIndex: -1, target: :blank %>
+          <% end %>
+        </div>
+
+        <div class="govuk-!-margin-top-3">
+          <%= displayed_error %>
+          <div class="govuk-radios govuk-radios--inline">
+            <div class="govuk-radios__item">
+              <%= f.radio_button :tupe, true, class: 'govuk-radios__input', required: true %>
+              <%= f.label :tupe, 'Yes', value: true, class: 'govuk-label govuk-radios__label' %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= f.radio_button :tupe, false, class: 'govuk-radios__input', required: true %>
+              <%= f.label :tupe, 'No', value: false , class: 'govuk-label govuk-radios__label' %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </fieldset>
+  </div>
+</div>

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -343,6 +343,7 @@ en:
           title:
             annual_contract_value: Annual contract value
             contract_name: Contract name
+            tupe: Tupe
         edit_partials:
           annual_contract_value:
             hint_text: Enter your estimate for the annual contract value. Include everything in your calculation.
@@ -350,6 +351,13 @@ en:
           contract_name:
             hint_text: This will help you to refer to your contracts when talking to suppliers.
             label_text: What do you want to call your contract?
+          tupe:
+            body_text_html: When a supplier changes, the original service provider’s workers may be protected under TUPE.<br/> For example, a new supplier is awarded the contract to provide cleaning services to a building.</br> The cleaners, who are employed by the current service provider, may be protected under TUPE.
+            first_question: Do you believe that Transfer of Undertakings (TUPE) Regulations applies to your contract?
+            tupe_link: https://www.gov.uk/transfers-takeovers
+            tupe_link_text: Find out when TUPE applies (opens in a new tab)
+            what_you_need_to_know_html: TUPE, the Transfer of Undertakings (Protection of Employment) protects the rights of employees when the business or commercial contract that they are working on changes to new ownership.<br/>It ensures that employees who find themselves transferred to a new business, retain exactly the same hours and rate of pay as they were contracted to with the old employer.
+            what_you_need_to_know_title: What you need to know about TUPE
       summary_tables:
         contract_summary_table:
           annual_contract_value: Annual contract value

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -74,6 +74,9 @@ en:
               taken: This contract name is already in use
               too_long: Your contract name must be 100 characters or fewer
               too_short: Enter your contract name
+            tupe:
+              inclusion: Select one option
+              not_present: You must answer the question about ‘TUPE’
         facilities_management/rm6232/supplier/lot_data:
           attributes:
             region_codes:

--- a/db/migrate/20220526114902_add_tupe_to_rm6232_procurement.rb
+++ b/db/migrate/20220526114902_add_tupe_to_rm6232_procurement.rb
@@ -1,0 +1,5 @@
+class AddTupeToRM6232Procurement < ActiveRecord::Migration[6.0]
+  def change
+    add_column :facilities_management_rm6232_procurements, :tupe, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_23_075127) do
+ActiveRecord::Schema.define(version: 2022_05_26_114902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -374,6 +374,7 @@ ActiveRecord::Schema.define(version: 2022_05_23_075127) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "contract_number"
+    t.boolean "tupe"
     t.index ["user_id", "contract_name"], name: "index_rm6232_procurement_name_and_user_id", unique: true
     t.index ["user_id"], name: "index_fm_rm6232_procurements_on_user_id"
   end

--- a/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
 
       render_views
 
-      pending 'renders the tupe partial' do
+      it 'renders the tupe partial' do
         expect(response).to render_template(partial: '_tupe')
       end
 
@@ -267,7 +267,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
         end
 
         it 'updates the contract name' do
-          procurement.reload
+          expect { procurement.reload }.to change(procurement, :contract_name)
 
           expect(procurement.contract_name).to eq('Hello there')
         end
@@ -281,9 +281,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
         end
 
         it 'does not update the contract name' do
-          procurement.reload
-
-          expect(procurement.contract_name).not_to be_nil
+          expect { procurement.reload }.not_to change(procurement, :contract_name)
         end
       end
 
@@ -295,9 +293,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
         end
 
         it 'does no update the unpermitted attribute' do
-          procurement.reload
-
-          expect(procurement.annual_contract_value).to eq(12_345)
+          expect { procurement.reload }.not_to change(procurement, :annual_contract_value)
         end
       end
     end
@@ -313,7 +309,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
         end
 
         it 'updates the annual contract value' do
-          procurement.reload
+          expect { procurement.reload }.to change(procurement, :annual_contract_value)
 
           expect(procurement.annual_contract_value).to eq(567_890)
         end
@@ -327,9 +323,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
         end
 
         it 'does not update the annual contract value' do
-          procurement.reload
-
-          expect(procurement.annual_contract_value).not_to be_nil
+          expect { procurement.reload }.not_to change(procurement, :annual_contract_value)
         end
       end
 
@@ -341,11 +335,49 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
         end
 
         it 'does no update the unpermitted attribute' do
-          origional_contract_name = procurement.contract_name
-          procurement.reload
+          expect { procurement.reload }.not_to change(procurement, :contract_name)
+        end
+      end
+    end
 
-          expect(procurement.contract_name).not_to eq('Hello there')
-          expect(procurement.contract_name).to eq(origional_contract_name)
+    context 'when updating tupe' do
+      let(:section_name) { 'tupe' }
+
+      context 'and the data is valid' do
+        let(:update_params) { { tupe: true } }
+
+        it 'redirects to the procurement show page' do
+          expect(response).to redirect_to facilities_management_rm6232_procurement_path(procurement)
+        end
+
+        it 'updates tupe' do
+          expect { procurement.reload }.to change(procurement, :tupe)
+
+          expect(procurement.tupe).to be true
+        end
+      end
+
+      context 'and the data is not valid' do
+        let(:update_params) { { tupe: nil } }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'does not update tupe' do
+          expect { procurement.reload }.not_to change(procurement, :tupe)
+        end
+      end
+
+      context 'and an unpermitted parameters are passed in' do
+        let(:update_params) { { contract_name: 'Hello there' } }
+
+        it 'redirects to the procurement show page' do
+          expect(response).to redirect_to facilities_management_rm6232_procurement_path(procurement)
+        end
+
+        it 'does no update the unpermitted attribute' do
+          expect { procurement.reload }.not_to change(procurement, :contract_name)
         end
       end
     end

--- a/spec/factories/facilities_management/rm6232/procurement.rb
+++ b/spec/factories/facilities_management/rm6232/procurement.rb
@@ -39,5 +39,6 @@ FactoryBot.define do
 
   factory :facilities_management_rm6232_procurement_entering_requirements, parent: :facilities_management_rm6232_procurement_what_happens_next do
     aasm_state { 'entering_requirements' }
+    tupe { false }
   end
 end

--- a/spec/models/facilities_management/rm6232/procurement_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_spec.rb
@@ -450,7 +450,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
     context 'when the tupe section has not been completed' do
       let(:tupe) { nil }
 
-      pending 'has a status of not_started' do
+      it 'has a status of not_started' do
         expect(status).to eq(:not_started)
       end
     end
@@ -458,7 +458,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
     context 'when the tupe section has been completed' do
       let(:tupe) { true }
 
-      pending 'has a status of completed' do
+      it 'has a status of completed' do
         expect(status).to eq(:completed)
       end
     end

--- a/spec/models/facilities_management/rm6232/procurement_validations_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_validations_spec.rb
@@ -121,5 +121,51 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
         end
       end
     end
+
+    describe 'tupe' do
+      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, tupe: tupe) }
+
+      context 'when it is blank' do
+        let(:tupe) { '' }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement.valid?(:tupe)).to be false
+          expect(procurement.errors[:tupe].first).to eq 'Select one option'
+        end
+      end
+
+      context 'when it is nil' do
+        let(:tupe) { nil }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement.valid?(:tupe)).to be false
+          expect(procurement.errors[:tupe].first).to eq 'Select one option'
+        end
+      end
+
+      context 'when it is a string' do
+        let(:tupe) { 'I am a string' }
+
+        it 'is valid as it evaluates to truthy' do
+          expect(procurement.valid?(:tupe)).to be true
+        end
+      end
+
+      context 'when it is true' do
+        let(:tupe) { true }
+
+        it 'is valid' do
+          expect(procurement.valid?(:tupe)).to be true
+        end
+      end
+
+      context 'when it is false' do
+        let(:tupe) { false }
+
+        it 'is valid' do
+          expect(procurement.valid?(:tupe)).to be true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Part of ticket: [FMFR-1170](https://crowncommercialservice.atlassian.net/browse/FMFR-1170)

This commit contains the working edit pages in contract details for:
- tupe

To prevent the commits getting too large, I am splitting them up for each page that is added.

I will add the feature tests for this work in a later PR dedicated to adding them.