### PR TITLE
FMFR-1172 - Edit buildings in the procurement

### DIFF
--- a/app/controllers/concerns/facilities_management/procurement_details_concern.rb
+++ b/app/controllers/concerns/facilities_management/procurement_details_concern.rb
@@ -66,6 +66,11 @@ module FacilitiesManagement::ProcurementDetailsConcern
 
   def set_procurement_data
     @procurement.build_call_off_extensions if section == :contract_period
+    set_buildings if section == :buildings
+  end
+
+  def set_buildings
+    @buildings = current_user.buildings.order_by_building_name.page(params[:page])
   end
 
   def procurement_params

--- a/app/controllers/facilities_management/rm6232/buildings_controller.rb
+++ b/app/controllers/facilities_management/rm6232/buildings_controller.rb
@@ -26,10 +26,6 @@ module FacilitiesManagement
       def start_a_procurement_path
         facilities_management_journey_question_path(slug: 'start-a-procurement')
       end
-
-      def set_procurement
-        @procurement = current_user.rm6232_procurements.find(params[:procurement_id])
-      end
     end
   end
 end

--- a/app/controllers/facilities_management/rm6232/details_controller.rb
+++ b/app/controllers/facilities_management/rm6232/details_controller.rb
@@ -9,9 +9,8 @@ module FacilitiesManagement
         @procurement = Procurement.find(params[:procurement_id])
       end
 
-      RECOGNISED_DETAILS_EDIT_STEPS = %i[contract_name annual_contract_value tupe contract_period services].freeze
-      # buildings
-      RECOGNISED_DETAILS_SHOW_PAGES = %i[contract_period services].freeze
+      RECOGNISED_DETAILS_EDIT_STEPS = %i[contract_name annual_contract_value tupe contract_period services buildings].freeze
+      RECOGNISED_DETAILS_SHOW_PAGES = %i[contract_period services buildings].freeze
       # buildings buildings_and_services
     end
   end

--- a/app/controllers/facilities_management/rm6232/edit_buildings_controller.rb
+++ b/app/controllers/facilities_management/rm6232/edit_buildings_controller.rb
@@ -1,0 +1,35 @@
+module FacilitiesManagement
+  module RM6232
+    class EditBuildingsController < FacilitiesManagement::BuildingsController
+      private
+
+      def index_path
+        edit_facilities_management_rm6232_procurement_detail_path(@procurement, section: :buildings)
+      end
+
+      def show_path(building = @building)
+        facilities_management_rm6232_procurement_edit_building_path(@procurement, building)
+      end
+
+      def edit_path(building, section)
+        edit_facilities_management_rm6232_procurement_edit_building_path(@procurement, building, section: section)
+      end
+
+      def create_path
+        facilities_management_rm6232_procurement_edit_buildings_path(@procurement)
+      end
+
+      def update_path
+        facilities_management_rm6232_procurement_edit_building_path(@procurement, @building, section: section)
+      end
+
+      def start_a_procurement_path
+        facilities_management_journey_question_path(slug: 'start-a-procurement')
+      end
+
+      def set_procurement
+        @procurement = Procurement.find(params[:procurement_id])
+      end
+    end
+  end
+end

--- a/app/helpers/facilities_management/details_helper.rb
+++ b/app/helpers/facilities_management/details_helper.rb
@@ -56,5 +56,36 @@ module FacilitiesManagement
         rm6232_accordion_service_items(@procurement.service_codes)
       end
     end
+
+    def procurement_building_row(_form, building)
+      # TODO: To add when doing this section
+      # if building.status == 'Ready'
+      #   tag.div(class: 'govuk-checkboxes govuk-checkboxes--small') do
+      #     tag.div(class: 'govuk-checkboxes__item') do
+      #       capture do
+      #         concat(form.check_box(:active, class: 'govuk-checkboxes__input', title: building.building_name, checked: @building_params[building.id] == '1'))
+      #         concat(form.label(:active, class: 'govuk-label govuk-checkboxes__label govuk-!-padding-top-0') do
+      #           procurement_building_checkbox_text(building)
+      #         end)
+      #       end
+      #     end
+      #   end
+      # else
+      #   tag.div(class: 'govuk-!-padding-left-7') do
+      #     procurement_building_checkbox_text(building)
+      #   end
+      # end
+
+      tag.div(class: 'govuk-!-padding-left-7') do
+        procurement_building_checkbox_text(building)
+      end
+    end
+
+    def procurement_building_checkbox_text(building)
+      capture do
+        concat(tag.span(building.building_name, class: 'govuk-fieldset__legend'))
+        concat(tag.span(building.address_no_region, class: 'govuk-hint govuk-!-margin-bottom-0'))
+      end
+    end
   end
 end

--- a/app/views/facilities_management/shared/details/edit_partials/_buildings.html.erb
+++ b/app/views/facilities_management/shared/details/edit_partials/_buildings.html.erb
@@ -1,0 +1,82 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <p>
+      <%= t('.page_details_1')%>
+    </p>
+    <p>
+      <%= t('.page_details_2')%>
+    </p>
+  </div>
+  <div class="govuk-grid-column-one-half procurement-add-buildings-container">
+    <h2 class="govuk-heading-m">
+     <%= t('.new_buildings')%>
+    </h2>
+    <p>
+      <%= t('.new_buildings_details')%>
+    </p>
+    <%= link_to t('.add_a_building'), new_facilities_management_rm6232_procurement_edit_building_path(procurement_id: @procurement.id), class: 'govuk-button govuk-button--secondary' %>
+    <%= govuk_details(t('.how_it_works')) do %>
+      <p>
+        <%= t('.how_it_works_1') %>
+      </p>
+      <p>
+        <%= t('.how_it_works_2') %>
+      </p>
+      <p>
+        <%= t('.how_it_works_3') %>
+      </p>
+    <% end %>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-m">
+      <%= t('.my_buildings') %>
+    </h2>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <% if current_user.buildings.any? %>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 55%"><%= t('.building_name_and_address') %></th>
+            <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 30%"><%= t('.status') %></th>
+            <td class="govuk-table__header govuk-!-font-weight-bold" style="width: 15%"></td>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <%#= f.fields_for :procurement_buildings, @buildings, include_id: false do |pb_field|%>
+          <% @buildings.each do |building| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell govuk-!-padding-right-2">
+                <div class="govuk-fieldset <%= 'govuk-form-group--error' if f.object.errors.any? && building.status == 'Ready' %>">
+                  <%= procurement_building_row('', building) %>
+                </div>
+                <%#= pb_field.hidden_field(:building_id, value: pb_field.object.id) %>
+              </td>
+              <td class="govuk-table__cell govuk-!-padding-right-2"><%= govuk_tag(*building.building_status)%></td>
+              <td class="govuk-table__cell govuk-!-padding-right-2"><%= link_to t('.details'), facilities_management_rm6232_procurement_edit_building_path(building.id, procurement_id: @procurement.id), class: "govuk-link govuk-link--no-visited-state", aria: { label: t('.details_link_aria_label', building_name: building.building_name) } %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <%#= f.fields_for :procurement_buildings, @hidden_buildings, include_id: false do |pb_field|%>
+        <%#= pb_field.hidden_field :active, value: @building_params[pb_field.object.id] %>
+        <%#= pb_field.hidden_field :building_id, value: pb_field.object.id %>
+      <%# end %>
+
+      <input type="hidden" name="page" value="<%= params[:page]%>"/>
+      <%= paginate @buildings, views_prefix: 'facilities_management/shared/details', f: f %>
+    <% else %>
+      <hr class="govuk-section-break govuk-section-break--visible">
+        <p class="govuk-hint govuk-!-margin-top-2 govuk-!-margin-bottom-2">
+          <%= t('.no_saved_buildings') %>
+        </p>
+      <hr class="govuk-section-break govuk-section-break--visible">
+    <% end %>
+  </div>
+</div>

--- a/app/views/facilities_management/shared/details/kaminari/_first_page.html.erb
+++ b/app/views/facilities_management/shared/details/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<!--<li class="ccs-first">-->
+  <%#= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+<!--</li>-->

--- a/app/views/facilities_management/shared/details/kaminari/_gap.html.erb
+++ b/app/views/facilities_management/shared/details/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li><%= t('views.pagination.truncate').html_safe %></li>

--- a/app/views/facilities_management/shared/details/kaminari/_last_page.html.erb
+++ b/app/views/facilities_management/shared/details/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<!--<li class="ccs-last">-->
+  <%#= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+<!--</li>-->

--- a/app/views/facilities_management/shared/details/kaminari/_next_page.html.erb
+++ b/app/views/facilities_management/shared/details/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="ccs-last">
+  <%= f.button(t('views.pagination.next').html_safe, class: 'govuk-link button_as_link', name: "paginate-#{current_page + 1}", rel: 'next', remote: remote) unless current_page.last?  %>
+</li>

--- a/app/views/facilities_management/shared/details/kaminari/_page.html.erb
+++ b/app/views/facilities_management/shared/details/kaminari/_page.html.erb
@@ -1,0 +1,18 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<% if page.current? %>
+  <li aria-current="true">
+    <%= page %>
+  </li>
+<% else %>
+  <li>
+    <%= f.button page, class: 'govuk-link button_as_link', name: "paginate-#{page}", remote: remote, rel: page.rel %>
+  </li>
+<% end %>

--- a/app/views/facilities_management/shared/details/kaminari/_paginator.html.erb
+++ b/app/views/facilities_management/shared/details/kaminari/_paginator.html.erb
@@ -1,0 +1,27 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav aria-label="Pagination Navigation">
+    <ul class="govuk-list ccs-pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.display_tag? -%>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end -%>
+      <% end -%>
+      <% unless current_page.out_of_range? %>
+        <%= next_page_tag unless current_page.last? %>
+        <%= last_page_tag unless current_page.last? %>
+      <% end %>
+    </ul>
+  </nav>
+<% end -%>

--- a/app/views/facilities_management/shared/details/kaminari/_prev_page.html.erb
+++ b/app/views/facilities_management/shared/details/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<li class="ccs-first">
+  <%= f.button(t('views.pagination.previous').html_safe, class: 'govuk-link button_as_link', name: "paginate-#{current_page - 1}", rel: 'prev', remote: remote) unless current_page.first? %>
+</li>

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -363,6 +363,7 @@ en:
           save_and_return: Save and return
           title:
             annual_contract_value: Annual contract value
+            buildings: Buildings
             contract_name: Contract name
             contract_period: Contract period
             services: Services
@@ -371,6 +372,22 @@ en:
           annual_contract_value:
             hint_text: Enter your estimate for the annual contract value. Include everything in your calculation.
             label_text: What is your estimate for the annual contract value?
+          buildings:
+            add_a_building: Add a building
+            building_name_and_address: Building name and address
+            details: Details
+            details_link_aria_label: Details for "%{building_name}"
+            how_it_works: How it works
+            how_it_works_1: When creating your buildings, you are not restricted to create just full buildings, for example you may choose to set up just a floor or a specific area within a building. You may also set up an external area, such as a park, as a ‘building’.
+            how_it_works_2: Your service pricing will be broken down to show a cost per service per ‘building’, allowing you to manage your contract effectively. You should therefore create ‘buildings’ dependent on the level of detail you require.
+            how_it_works_3: If you have a site, campus, group of buildings, these should be set up individually and not grouped together into one site.
+            my_buildings: My buildings
+            new_buildings: New buildings
+            new_buildings_details: If you wish to set up a new building so that it can be included in this procurement, click on the 'Add a building' button below.
+            no_saved_buildings: You have no saved buildings. Click on 'Add a building' to start setting up your building(s)
+            page_details_1: Please select all of the buildings you want to include in your procurement. Only 'completed' buildings can be selected. To view a buildings details or finish setting up an incomplete building, please click on 'details' next to the building.
+            page_details_2: Once you have selected all your buildings for this procurement, click on the 'save and continue' button.
+            status: Status
           contract_name:
             hint_text: This will help you to refer to your contracts when talking to suppliers.
             label_text: What do you want to call your contract?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,7 @@ Rails.application.routes.draw do
       get '/', to: 'buyer_account#index'
 
       resources :procurements, only: %i[index show new create] do
-        concerns :procurement_details # , :edit_buildings
+        concerns :procurement_details, :edit_buildings
         get 'supplier_shortlist_spreadsheet'
         put 'update-show', action: 'update_show'
       end

--- a/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/add_a_building/buildings.feature
+++ b/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/add_a_building/buildings.feature
@@ -1,0 +1,191 @@
+@javascript
+Feature: Buildings in entering requirements
+
+  Background:
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have an empty procurement for entering requirements named 'My buildings procurement'
+    When I navigate to the procurement 'My buildings procurement'
+    Then I am on the 'Further service and contract requirements' page
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+
+  @add_address
+  Scenario: Add a Building - no region selection
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Find address'
+    And I select 'Stafford Delivery Office, Newport Road, Stafford' from the address drop down
+    Then the address 'Stafford Delivery Office, Newport Road, Stafford ST16 1AA' is displayed
+    And the region 'Shropshire and Staffordshire' is displayed
+    And I can't change the region
+    Then I click on 'Save and continue'
+    Then I am on the 'Internal and external areas' page
+
+  Scenario: Add a Building - region selection
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | LU6 1GQ  |
+    And I click on 'Find address'
+    And I select '10 Sidings Way, Dunstable' from the address drop down
+    And I select 'Bedfordshire and Hertfordshire' from the region drop down
+    Then the address '10 Sidings Way, Dunstable LU6 1GQ' is displayed
+    And the region 'Bedfordshire and Hertfordshire' is displayed
+    And I can change the region
+    And I click on 'Save and continue'
+    Then I am on the 'Internal and external areas' page
+
+  @add_address
+  Scenario: Add Address manually - no region selection
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Find address'
+    And I click on 'I can’t find my building’s address in the list'
+    And I enter the following details into the form:
+      | Building and street line 1 of 2             | 112 Test street |
+      | Building and street line 2 of 2 (optional)  | Zone 7          |
+      | Town or city                                | Westminister    |
+      | Postcode                                    | ST16 1AA        |
+    And I click on 'Save and continue'
+    Then I am on the 'Add a building' page
+    Then the address '112 Test street, Zone 7, Westminister ST16 1AA' is displayed
+    And the region 'Shropshire and Staffordshire' is displayed  
+    And I can't change the region
+    Then I click on 'Save and continue'
+    Then I am on the 'Internal and external areas' page
+
+  Scenario: Add Address manually - no region selection
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Find address'
+    And I click on 'I can’t find my building’s address in the list'
+    And I enter the following details into the form:
+      | Building and street line 1 of 2 | 1 Windsor Avenue  |
+      | Town or city                    | Aberdeen          |
+      | Postcode                        | NW1 4DF           |
+    And I click on 'Save and continue'
+    Then I am on the 'Add a building' page
+    Then the address '1 Windsor Avenue, Aberdeen NW1 4DF' is displayed
+    And I select 'Aberdeen and Aberdeenshire' from the region drop down
+    And the region 'Aberdeen and Aberdeenshire' is displayed  
+    And I can change the region
+    Then I click on 'Save and continue'
+    Then I am on the 'Internal and external areas' page
+
+  @add_address
+  Scenario: Internal and External Area - external area 0
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Find address'
+    And I select 'Stafford Delivery Office, Newport Road, Stafford' from the address drop down
+    Then I click on 'Save and continue'
+    Then I am on the 'Internal and external areas' page
+    And I enter '300' for the building 'GIA'
+    And I enter '0' for the building 'external area'
+    And I click on 'Save and continue'
+    Then I am on the 'Building type' page
+
+  @add_address
+  Scenario: Internal and External Area - internal area 0
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Find address'
+    And I select 'Stafford Delivery Office, Newport Road, Stafford' from the address drop down
+    Then I click on 'Save and continue'
+    Then I am on the 'Internal and external areas' page
+    And I enter '0' for the building 'GIA'
+    And I enter '300' for the building 'external area'
+    And I click on 'Save and continue'
+    Then I am on the 'Building type' page
+
+  @add_address @pipeline
+  Scenario: Add a building complete journey
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+    And the framework is 'RM6232'
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Find address'
+    And I select 'Stafford Delivery Office, Newport Road, Stafford' from the address drop down
+    Then I click on 'Save and continue'
+    Then I am on the 'Internal and external areas' page
+    And the framework is 'RM6232'
+    And I enter '300' for the building 'GIA'
+    And I enter '600' for the building 'external area'
+    And I click on 'Save and continue'
+    Then I am on the 'Building type' page
+    And the framework is 'RM6232'
+    And I select 'General office - customer facing' for the building type
+    And I click on 'Save and continue'
+    Then I am on the 'Security clearance' page
+    And the framework is 'RM6232'
+    And I select 'Baseline personnel security standard (BPSS)' for the security type
+    And I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'New building'
+    And the framework is 'RM6232'
+    And my building's 'Name' is 'New building'
+    And my building's 'Address' is 'Stafford Delivery Office, Newport Road, Stafford'
+    And my building's 'Region' is 'Shropshire and Staffordshire'
+    And my building's 'Gross internal area' is '300'
+    And my building's 'External area' is '600'
+    And my building's 'Building type' is 'General office - customer facing'
+    And my building's 'Security clearance' is 'Baseline personnel security standard (BPSS)'
+    And my building's status is 'COMPLETED'
+
+  @add_address
+  Scenario: Add a building 1 detail at a time and check completion
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+    And I enter 'Test building' for the building 'name'
+    And I enter 'My new building' for the building 'description'
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Find address'
+    And I select 'Stafford Delivery Office, Newport Road, Stafford' from the address drop down
+    Then I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'Test building'  
+    And my building's 'Name' is 'Test building'
+    And my building's 'Description' is 'My new building'
+    And my building's 'Address' is 'Stafford Delivery Office, Newport Road, Stafford'
+    And my building's status is 'INCOMPLETE'
+    And I change the 'Gross internal area'
+    Then I am on the 'Internal and external areas' page
+    And I enter '123' for the building 'GIA'
+    And I enter '456' for the building 'external area'
+    Then I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'Test building'  
+    And my building's 'Gross internal area' is '123'
+    And my building's 'External area' is '456'
+    And my building's status is 'INCOMPLETE'
+    And I change the 'Building type'
+    Then I am on the 'Building type' page
+    And I open the 'View more building types' details
+    And I select 'Primary school' for the building type
+    Then I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'Test building'
+    And my building's 'Building type' is 'Primary school'
+    And my building's status is 'INCOMPLETE'
+    And I change the 'Security clearance'
+    Then I am on the 'Security clearance' page 
+    And I select 'Developed vetting (DV)' for the security type
+    And I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'Test building'  
+    And my building's 'Security clearance' is 'Developed vetting (DV)'
+    And my building's status is 'COMPLETED'

--- a/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/add_a_building/review_completed_building.feature
+++ b/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/add_a_building/review_completed_building.feature
@@ -1,0 +1,73 @@
+Feature: Review completed buildings in entering requirements
+
+  Background:
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have buildings
+    And I have an empty procurement for entering requirements named 'My buildings procurement'
+    When I navigate to the procurement 'My buildings procurement'
+    Then I am on the 'Further service and contract requirements' page
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+    And I click on the details for 'Test building'
+    Then I am on the buildings summary page for 'Test building'
+
+  Scenario: Check the building data
+    And my building's 'Name' is 'Test building'
+    And my building's 'Description' is 'non-json description'
+    And my building's 'Address' is '17 Sailors road, Floor 2, Southend-On-Sea SS84 6VF'
+    And my building's 'Gross internal area' is '1,002'
+    And my building's 'External area' is '4,596'
+    And my building's 'Building type' is 'General office - customer facing'
+    And my building's 'Security clearance' is 'Baseline personnel security standard (BPSS)'
+    And my building's status is 'COMPLETED'
+
+  Scenario: Change links
+    And I change the 'Name'
+    Then I am on the 'Building details' page
+    And I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'Test building'
+    And I change the 'Description'
+    Then I am on the 'Building details' page
+    And I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'Test building'
+    And I change the 'Address'
+    Then I am on the 'Building details' page
+    And I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'Test building'
+    And I change the 'Gross internal area'
+    Then I am on the 'Internal and external areas' page
+    And I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'Test building'
+    And I change the 'External area'
+    Then I am on the 'Internal and external areas' page
+    And I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'Test building'
+    And I change the 'Building type'
+    Then I am on the 'Building type' page
+    And I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'Test building'
+    And I change the 'Security clearance'
+    Then I am on the 'Security clearance' page
+    And I click on 'Save and return to building details summary'
+    Then I am on the buildings summary page for 'Test building'
+
+  Scenario: Return links
+    And I change the 'Security clearance'
+    Then I am on the 'Security clearance' page
+    And the step is 4
+    And I click on 'Return to building type'
+    Then I am on the 'Building type' page
+    And the step is 3
+    And I click on 'Return to building size'
+    Then I am on the 'Internal and external areas' page
+    And the step is 2
+    And I click on 'Return to building details'
+    Then I am on the 'Building details' page
+    And the step is 1
+    And I click on "I can’t find my building’s address in the list"
+    Then I am on the 'Add building address' page
+    And the step is 1
+    And I click on 'Return to building details'
+    Then I am on the 'Building details' page
+    And I click on 'Return to building details summary'
+    Then I am on the buildings summary page for 'Test building'

--- a/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/add_a_building/add_a_building_validations.feature
+++ b/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/add_a_building/add_a_building_validations.feature
@@ -1,0 +1,81 @@
+Feature: Add a building in requirements - validations
+
+  Background: Navigate to the add a building page
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have buildings
+    And I have an empty procurement for entering requirements named 'My buildings procurement'
+    When I navigate to the procurement 'My buildings procurement'
+    Then I am on the 'Further service and contract requirements' page
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+
+  Scenario Outline: Add a building - empty fields
+    And I click on '<save_button>'
+    Then I should see the following error messages:
+      | Enter a name for your building        |
+      | Enter a valid postcode, like AA1 1AA  |
+
+    Examples:
+      | save_button                                   |
+      | Save and continue                             |
+      | Save and return to building details summary   |
+
+  Scenario: Add a building - building name taken
+    And I enter 'Test building' for the building name
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | This building name is already in use  |
+      | Enter a valid postcode, like AA1 1AA  |
+
+  @javascript
+  Scenario Outline: Add a building - postcode javascript
+    And I enter 'Test building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | <postcode>  |
+    And I click on 'Find address'
+    Then I should see the postcode error message
+  
+    Examples:
+        | postcode  |
+        |           |
+        | test      |
+
+  Scenario: Add a building - postcode backend
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | test  |
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | Enter a valid postcode, like AA1 1AA  |
+
+  Scenario: Add a building - select address
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | You must select an address to save a building |
+
+  @javascript
+  Scenario: Add a building - select region
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | LU6 1GQ  |
+    And I click on 'Find address'
+    And I select '10 Sidings Way, Dunstable' from the address drop down
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | You must select a region for your address |
+
+  Scenario: Add building address - empty fields
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Find address'
+    And I click on 'I can’t find my building’s address in the list'
+    Then I am on the 'Add building address' page
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | Add a building and street name  |
+      | Enter the town or city          |

--- a/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/add_a_building/add_address_manually_validations.feature
+++ b/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/add_a_building/add_address_manually_validations.feature
@@ -1,0 +1,39 @@
+Feature: Add address manually in requirements - validations
+
+  Background:
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have buildings
+    And I have an empty procurement for entering requirements named 'My buildings procurement'
+    When I navigate to the procurement 'My buildings procurement'
+    Then I am on the 'Further service and contract requirements' page
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Find address'
+    And I click on 'I can’t find my building’s address in the list'
+    Then I am on the 'Add building address' page
+
+  Scenario: Add Address manually - nothing entered
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | Add a building and street name        |
+      | Enter the town or city                |
+
+  Scenario Outline: Add Address manually - postcode validation
+    And I enter the following details into the form:
+      | Building and street line 1 of 2 | 112 Test street |
+      | Town or city                    | Westminister    |
+      | Postcode                        | <postocde>      |
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | Enter a valid postcode, like AA1 1AA |
+
+    Examples:
+        | postocde  |
+        |           |
+        | toast     |
+    

--- a/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/add_a_building/building_type_validation.feature
+++ b/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/add_a_building/building_type_validation.feature
@@ -1,0 +1,38 @@
+@javascript @add_address
+Feature: Building type in requirements - validations
+
+  Background: Navigate to Building type page
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have an empty procurement for entering requirements named 'My buildings procurement'
+    When I navigate to the procurement 'My buildings procurement'
+    Then I am on the 'Further service and contract requirements' page
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Find address'
+    And I select 'Stafford Delivery Office, Newport Road, Stafford' from the address drop down
+    And I click on 'Save and continue'
+    Then I am on the 'Internal and external areas' page
+    And I click on 'Skip this step'
+    Then I am on the 'Building type' page
+
+  Scenario Outline: I select nothing
+    And I click on '<save_button>'
+    Then I should see the following error messages:
+      | You must select a building type or describe your own  |
+
+    Examples:
+      | save_button                                   |
+      | Save and continue                             |
+      | Save and return to building details summary   |
+
+  Scenario:
+    And I open the 'View more building types' details
+    And I select 'Other' for the building type
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | You must enter your description of a building type  |

--- a/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/add_a_building/internal_and_external_area_validations.feature
+++ b/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/add_a_building/internal_and_external_area_validations.feature
@@ -1,0 +1,59 @@
+Feature: Internal and External area in requirements - validations
+
+  Background: Navigate to Internal and external areas
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have buildings
+    And I have an empty procurement for entering requirements named 'My buildings procurement'
+    When I navigate to the procurement 'My buildings procurement'
+    Then I am on the 'Further service and contract requirements' page
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+    And I click on the details for 'Test building'
+    Then I am on the 'Test building' page
+    And I change the 'Gross internal area'
+    Then I am on the 'Internal and external areas' page
+
+  Scenario Outline: Areas are empty
+    And I enter '' for the building 'GIA'
+    And I enter '' for the building 'external area'
+    And I click on '<save_button>'
+    Then I should see the following error messages:
+      | Internal area must be a number between 0 and 999,999,999  |
+      | External area must be a number between 0 and 999,999,999  |
+
+    Examples:
+      | save_button                                   |
+      | Save and continue                             |
+      | Save and return to building details summary   |
+
+  Scenario: Areas are not numbers
+    And I enter 'hello' for the building 'GIA'
+    And I enter 'hello' for the building 'external area'
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | Gross Internal Area (GIA) must be a whole number  |
+      | External area must be a whole number              |
+
+  Scenario: Areas are not whole numbers
+    And I enter '45.7' for the building 'GIA'
+    And I enter '89.2' for the building 'external area'
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | Enter a whole number for the size of internal area of this building |
+      | Enter a whole number for the size of external area of this building |
+
+  Scenario: Areas are greater than 999,999,999
+    And I enter '1000000000' for the building 'GIA'
+    And I enter '1000000000' for the building 'external area'
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | Internal area must be a number between 0 and 999,999,999  |
+      | External area must be a number between 0 and 999,999,999  |
+
+  Scenario: Areas are both 0
+    And I enter '0' for the building 'GIA'
+    And I enter '0' for the building 'external area'
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | Internal area must be greater than 0, if the external area is 0 |
+      | External area must be greater than 0, if the internal area is 0 |

--- a/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/add_a_building/security_type_validations.feature
+++ b/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/add_a_building/security_type_validations.feature
@@ -1,0 +1,34 @@
+@javascript @add_address
+Feature: Security type in requirements - validations
+
+  Background: Navigate to Security type page
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have an empty procurement for entering requirements named 'My buildings procurement'
+    When I navigate to the procurement 'My buildings procurement'
+    Then I am on the 'Further service and contract requirements' page
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+    And I click on 'Add a building'
+    Then I am on the 'Add a building' page
+    And I enter 'New building' for the building name
+    And I enter the following details into the form:
+      | Postcode  | ST16 1AA  |
+    And I click on 'Find address'
+    And I select 'Stafford Delivery Office, Newport Road, Stafford' from the address drop down
+    And I click on 'Save and continue'
+    Then I am on the 'Internal and external areas' page
+    And I click on 'Skip this step'
+    Then I am on the 'Building type' page
+    And I click on 'Skip this step'
+    Then I am on the 'Security clearance' page
+
+  Scenario: I select nothing
+    And I click on 'Save and return to building details summary'
+    Then I should see the following error messages:
+      | You must select a security clearance level  |
+
+  Scenario:
+    And I select 'Other' for the security type
+    And I click on 'Save and return to building details summary'
+    Then I should see the following error messages:
+      | You must describe the security clearance level  |

--- a/spec/controllers/facilities_management/rm3830/edit_buildings_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/edit_buildings_controller_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe FacilitiesManagement::RM3830::EditBuildingsController, type: :con
   let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, user: user) }
   let(:user) { controller.current_user }
 
-  render_views
-
   describe 'GET #show' do
     login_fm_buyer_with_details
 

--- a/spec/controllers/facilities_management/rm6232/buildings_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/buildings_controller_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe FacilitiesManagement::RM6232::BuildingsController, type: :control
   let(:building) { create(:facilities_management_building, user: user) }
   let(:user) { controller.current_user }
 
-  render_views
-
   describe 'GET #index' do
     context 'when logging in as a fm buyer with details' do
       login_fm_buyer_with_details

--- a/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
 
       render_views
 
-      pending 'renders the buildings partial' do
+      it 'renders the buildings partial' do
         expect(response).to render_template(partial: '_buildings')
       end
 

--- a/spec/controllers/facilities_management/rm6232/edit_buildings_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/edit_buildings_controller_spec.rb
@@ -1,74 +1,29 @@
 require 'rails_helper'
 
-RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :controller do
+RSpec.describe FacilitiesManagement::RM6232::EditBuildingsController, type: :controller do
   let(:default_params) { { service: 'facilities_management', framework: framework } }
-  let(:framework) { 'RM3830' }
+  let(:framework) { 'RM6232' }
   let(:building) { create(:facilities_management_building, user: user) }
+  let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, user: user) }
   let(:user) { controller.current_user }
-
-  describe 'GET #index' do
-    context 'when logging in as a fm buyer with details' do
-      login_fm_buyer_with_details
-
-      it 'render the index' do
-        get :index
-
-        expect(response).to render_template(:index)
-      end
-    end
-
-    context 'when the framework is not recognised' do
-      login_fm_buyer_with_details
-
-      let(:framework) { 'RM3840' }
-
-      before { get :index }
-
-      it 'renders the unrecognised framework page with the right http status' do
-        expect(response).to render_template('home/unrecognised_framework')
-        expect(response).to have_http_status(:bad_request)
-      end
-
-      it 'sets the framework variables' do
-        expect(assigns(:unrecognised_framework)).to eq 'RM3840'
-        expect(controller.params[:framework]).to eq FacilitiesManagement::Framework.default_framework
-      end
-    end
-
-    context 'when logging in as a buyer without permissions' do
-      login_buyer_without_permissions
-
-      it 'redirects to the not permitted page' do
-        get :index
-
-        expect(response).to redirect_to '/facilities-management/RM3830/not-permitted'
-      end
-    end
-
-    context 'when logging in without buyer details' do
-      login_fm_buyer
-
-      it 'is expected to redirect to edit_facilities_management_buyer_detail_path' do
-        get :index
-
-        expect(response).to redirect_to edit_facilities_management_buyer_detail_path(framework, controller.current_user.buyer_detail)
-      end
-    end
-  end
 
   describe 'GET #show' do
     login_fm_buyer_with_details
 
-    before { get :show, params: { id: building.id } }
+    before { get :show, params: { procurement_id: procurement.id, id: building.id } }
 
     context 'when logging in as the fm buyer that created the building' do
       it 'render the show page' do
         expect(response).to render_template(:show)
       end
 
+      it 'sets the procurement' do
+        expect(assigns(:procurement)).to eq procurement
+      end
+
       it 'has correct backlink text and destination' do
         expect(assigns(:back_text)).to eq 'Return to buildings'
-        expect(assigns(:back_path)).to eq facilities_management_rm3830_buildings_path
+        expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_detail_path(procurement, section: :buildings)
       end
     end
 
@@ -76,7 +31,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
       let(:user) { create(:user) }
 
       it 'redirects to the not permitted page' do
-        expect(response).to redirect_to '/facilities-management/RM3830/not-permitted'
+        expect(response).to redirect_to '/facilities-management/RM6232/not-permitted'
       end
     end
   end
@@ -86,24 +41,28 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
       login_buyer_without_permissions
 
       it 'redirects to the not permitted page' do
-        get :new
+        get :new, params: { procurement_id: procurement.id }
 
-        expect(response).to redirect_to '/facilities-management/RM3830/not-permitted'
+        expect(response).to redirect_to '/facilities-management/RM6232/not-permitted'
       end
     end
 
     context 'when logged in as FM buyer' do
       login_fm_buyer_with_details
 
-      before { get :new }
+      before { get :new, params: { procurement_id: procurement.id } }
 
       it 'render the new page' do
         expect(response).to render_template(:new)
       end
 
+      it 'sets the procurement' do
+        expect(assigns(:procurement)).to eq procurement
+      end
+
       it 'has correct backlink text and destination' do
         expect(assigns(:back_text)).to eq 'Return to buildings'
-        expect(assigns(:back_path)).to eq facilities_management_rm3830_buildings_path
+        expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_detail_path(procurement, section: :buildings)
       end
     end
   end
@@ -111,7 +70,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
   describe 'GET #edit' do
     login_fm_buyer_with_details
 
-    before { get :edit, params: { id: building.id, section: section } }
+    before { get :edit, params: { procurement_id: procurement.id, id: building.id, section: section } }
 
     render_views
 
@@ -119,7 +78,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
       let(:section) { 'contract_name' }
 
       it 'redirects to the show page' do
-        expect(response).to redirect_to facilities_management_rm3830_building_path(building)
+        expect(response).to redirect_to facilities_management_rm6232_procurement_edit_building_path(procurement, building)
       end
     end
 
@@ -134,9 +93,13 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
         expect(response).to render_template('_building_details')
       end
 
+      it 'sets the procurement' do
+        expect(assigns(:procurement)).to eq procurement
+      end
+
       it 'has correct backlink text and destination' do
         expect(assigns(:back_text)).to eq 'Return to building details summary'
-        expect(assigns(:back_path)).to eq facilities_management_rm3830_building_path(building)
+        expect(assigns(:back_path)).to eq facilities_management_rm6232_procurement_edit_building_path(procurement, building)
       end
     end
 
@@ -151,9 +114,13 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
         expect(response).to render_template('_add_address')
       end
 
+      it 'sets the procurement' do
+        expect(assigns(:procurement)).to eq procurement
+      end
+
       it 'has correct backlink text and destination' do
         expect(assigns(:back_text)).to eq 'Return to building details'
-        expect(assigns(:back_path)).to eq edit_facilities_management_rm3830_building_path(building, section: 'building_details')
+        expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building, section: 'building_details')
       end
     end
 
@@ -168,9 +135,13 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
         expect(response).to render_template('_building_area')
       end
 
+      it 'sets the procurement' do
+        expect(assigns(:procurement)).to eq procurement
+      end
+
       it 'has correct backlink text and destination' do
         expect(assigns(:back_text)).to eq 'Return to building details'
-        expect(assigns(:back_path)).to eq edit_facilities_management_rm3830_building_path(building, section: 'building_details')
+        expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building, section: 'building_details')
       end
     end
 
@@ -185,9 +156,13 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
         expect(response).to render_template('_building_type')
       end
 
+      it 'sets the procurement' do
+        expect(assigns(:procurement)).to eq procurement
+      end
+
       it 'has correct backlink text and destination' do
         expect(assigns(:back_text)).to eq 'Return to building size'
-        expect(assigns(:back_path)).to eq edit_facilities_management_rm3830_building_path(building, section: 'building_area')
+        expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building, section: 'building_area')
       end
     end
 
@@ -202,9 +177,13 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
         expect(response).to render_template('_security_type')
       end
 
+      it 'sets the procurement' do
+        expect(assigns(:procurement)).to eq procurement
+      end
+
       it 'has correct backlink text and destination' do
         expect(assigns(:back_text)).to eq 'Return to building type'
-        expect(assigns(:back_path)).to eq edit_facilities_management_rm3830_building_path(building, section: 'building_type')
+        expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building, section: 'building_type')
       end
     end
   end
@@ -218,23 +197,31 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
 
     before do
       allow(controller).to receive(:resolve_region)
-      post :create, params: { facilities_management_building: building_options, **options }
+      post :create, params: { procurement_id: procurement.id, facilities_management_building: building_options, **options }
     end
 
     context 'when the data is valid' do
       let(:new_building) { FacilitiesManagement::Building.order(created_at: :asc).first }
 
       context 'and the user clicked "Save and continue"' do
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
+        end
+
         it 'redirects to the edit area page' do
-          expect(response).to redirect_to edit_facilities_management_rm3830_building_path(new_building.id, section: 'building_area')
+          expect(response).to redirect_to edit_facilities_management_rm6232_procurement_edit_building_path(procurement, new_building.id, section: 'building_area')
         end
       end
 
       context 'and the user clicked "Save and return to building details summary"' do
         let(:options) { { save_and_return: 'Save and return to building details summary' } }
 
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
+        end
+
         it 'redirects to the show page' do
-          expect(response).to redirect_to facilities_management_rm3830_building_path(new_building.id)
+          expect(response).to redirect_to facilities_management_rm6232_procurement_edit_building_path(procurement, new_building.id)
         end
       end
     end
@@ -248,7 +235,11 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
 
       it 'sets the back path and text correctly' do
         expect(assigns(:back_text)).to eq 'Return to buildings'
-        expect(assigns(:back_path)).to eq facilities_management_rm3830_buildings_path
+        expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_detail_path(procurement, section: :buildings)
+      end
+
+      it 'sets the procurement' do
+        expect(assigns(:procurement)).to eq procurement
       end
     end
 
@@ -270,6 +261,10 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
       it 'sets the back path and text correctly' do
         expect(assigns(:back_text)).to eq 'Return to building details'
         expect(assigns(:back_path)).to eq 'javascript:history.back()'
+      end
+
+      it 'sets the procurement' do
+        expect(assigns(:procurement)).to eq procurement
       end
     end
 
@@ -301,7 +296,11 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
 
         it 'sets the back path and text correctly' do
           expect(assigns(:back_text)).to eq 'Return to buildings'
-          expect(assigns(:back_path)).to eq facilities_management_rm3830_buildings_path
+          expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_detail_path(procurement, section: :buildings)
+        end
+
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
         end
       end
 
@@ -320,6 +319,10 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
           expect(assigns(:back_text)).to eq 'Return to building details'
           expect(assigns(:back_path)).to eq 'javascript:history.back()'
         end
+
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
+        end
       end
     end
   end
@@ -332,7 +335,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
 
     before do
       allow(controller).to receive(:resolve_region)
-      put :update, params: { id: building.id, section: section_name, facilities_management_building: update_params, **options }
+      put :update, params: { procurement_id: procurement.id, id: building.id, section: section_name, facilities_management_building: update_params, **options }
     end
 
     context 'when updating the building details' do
@@ -341,8 +344,12 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
       context 'and the data is valid' do
         let(:update_params) { { building_name: 'New building name', address_line_1: 'line 1', address_town: 'town', address_postcode: 'SW1A 1AA', address_region: 'Inner London - West', address_region_code: 'UKI3' } }
 
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
+        end
+
         it 'redirects to the building area edit page' do
-          expect(response).to redirect_to edit_facilities_management_rm3830_building_path(building.id, section: 'building_area')
+          expect(response).to redirect_to edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building.id, section: 'building_area')
         end
 
         it 'updates the building details' do
@@ -362,7 +369,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
           let(:options) { { save_and_return: 'Save and return to building details summary' } }
 
           it 'redirects to the show page' do
-            expect(response).to redirect_to facilities_management_rm3830_building_path(building.id)
+            expect(response).to redirect_to facilities_management_rm6232_procurement_edit_building_path(procurement, building.id)
           end
         end
       end
@@ -393,7 +400,11 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
 
         it 'has correct backlink text and destination' do
           expect(assigns(:back_text)).to eq 'Return to building details summary'
-          expect(assigns(:back_path)).to eq facilities_management_rm3830_building_path(building)
+          expect(assigns(:back_path)).to eq facilities_management_rm6232_procurement_edit_building_path(procurement, building)
+        end
+
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
         end
       end
 
@@ -401,7 +412,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
         let(:update_params) { { building_name: 'New building name', address_line_1: 'line 1', address_town: 'town', address_postcode: 'SW1A 1AA', address_region: 'Inner London - West', address_region_code: 'UKI3', gia: 1234 } }
 
         it 'redirects to the building area edit page' do
-          expect(response).to redirect_to edit_facilities_management_rm3830_building_path(building.id, section: 'building_area')
+          expect(response).to redirect_to edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building.id, section: 'building_area')
         end
 
         it 'does no update the unpermitted attribute' do
@@ -416,8 +427,12 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
       context 'and the data is valid' do
         let(:update_params) { { address_line_1: 'line 1', address_town: 'town', address_postcode: 'SW1A 1AA' } }
 
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
+        end
+
         it 'redirects to the building details edit page' do
-          expect(response).to redirect_to edit_facilities_management_rm3830_building_path(building.id, section: 'building_details')
+          expect(response).to redirect_to edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building.id, section: 'building_details')
         end
 
         it 'updates the building address' do
@@ -438,7 +453,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
           let(:options) { { save_and_return: 'Save and return to building details summary' } }
 
           it 'redirects to the show page' do
-            expect(response).to redirect_to facilities_management_rm3830_building_path(building.id)
+            expect(response).to redirect_to facilities_management_rm6232_procurement_edit_building_path(procurement, building.id)
           end
         end
       end
@@ -468,7 +483,11 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
 
         it 'has correct backlink text and destination' do
           expect(assigns(:back_text)).to eq 'Return to building details'
-          expect(assigns(:back_path)).to eq edit_facilities_management_rm3830_building_path(building, section: 'building_details')
+          expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building, section: 'building_details')
+        end
+
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
         end
       end
 
@@ -476,7 +495,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
         let(:update_params) { { building_name: 'New building name', address_line_1: 'line 1', address_town: 'town', address_postcode: 'SW1A 1AA' } }
 
         it 'redirects to the building details edit page' do
-          expect(response).to redirect_to edit_facilities_management_rm3830_building_path(building.id, section: 'building_details')
+          expect(response).to redirect_to edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building.id, section: 'building_details')
         end
 
         it 'does no update the unpermitted attribute' do
@@ -491,8 +510,12 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
       context 'and the data is valid' do
         let(:update_params) { { gia: 1_234, external_area: 4_321 } }
 
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
+        end
+
         it 'redirects to the building type edit page' do
-          expect(response).to redirect_to edit_facilities_management_rm3830_building_path(building.id, section: 'building_type')
+          expect(response).to redirect_to edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building.id, section: 'building_type')
         end
 
         it 'updates the building areas' do
@@ -508,7 +531,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
           let(:options) { { save_and_return: 'Save and return to building details summary' } }
 
           it 'redirects to the show page' do
-            expect(response).to redirect_to facilities_management_rm3830_building_path(building.id)
+            expect(response).to redirect_to facilities_management_rm6232_procurement_edit_building_path(procurement, building.id)
           end
         end
       end
@@ -533,7 +556,11 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
 
         it 'has correct backlink text and destination' do
           expect(assigns(:back_text)).to eq 'Return to building details'
-          expect(assigns(:back_path)).to eq edit_facilities_management_rm3830_building_path(building.id, section: 'building_details')
+          expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building.id, section: 'building_details')
+        end
+
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
         end
       end
 
@@ -541,7 +568,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
         let(:update_params) { { building_name: 'New building name', gia: 1_234, external_area: 4_321 } }
 
         it 'redirects to the building area edit page' do
-          expect(response).to redirect_to edit_facilities_management_rm3830_building_path(building.id, section: 'building_type')
+          expect(response).to redirect_to edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building.id, section: 'building_type')
         end
 
         it 'does no update the unpermitted attribute' do
@@ -556,8 +583,12 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
       context 'and the data is valid' do
         let(:update_params) { { building_type: 'Call Centre Operations' } }
 
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
+        end
+
         it 'redirects to the security type edit page' do
-          expect(response).to redirect_to edit_facilities_management_rm3830_building_path(building.id, section: 'security_type')
+          expect(response).to redirect_to edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building.id, section: 'security_type')
         end
 
         it 'updates the building type' do
@@ -572,7 +603,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
           let(:options) { { save_and_return: 'Save and return to building details summary' } }
 
           it 'redirects to the show page' do
-            expect(response).to redirect_to facilities_management_rm3830_building_path(building.id)
+            expect(response).to redirect_to facilities_management_rm6232_procurement_edit_building_path(procurement, building.id)
           end
         end
       end
@@ -596,7 +627,11 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
 
         it 'has correct backlink text and destination' do
           expect(assigns(:back_text)).to eq 'Return to building size'
-          expect(assigns(:back_path)).to eq edit_facilities_management_rm3830_building_path(building.id, section: 'building_area')
+          expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building.id, section: 'building_area')
+        end
+
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
         end
       end
 
@@ -604,7 +639,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
         let(:update_params) { { building_name: 'New building name', building_type: 'Call Centre Operations' } }
 
         it 'redirects to the security type edit page' do
-          expect(response).to redirect_to edit_facilities_management_rm3830_building_path(building.id, section: 'security_type')
+          expect(response).to redirect_to edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building.id, section: 'security_type')
         end
 
         it 'does no update the unpermitted attribute' do
@@ -619,8 +654,12 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
       context 'and the data is valid' do
         let(:update_params) { { security_type: 'Counter terrorist check (CTC)' } }
 
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
+        end
+
         it 'redirects to the show page' do
-          expect(response).to redirect_to facilities_management_rm3830_building_path(building)
+          expect(response).to redirect_to facilities_management_rm6232_procurement_edit_building_path(procurement, building)
         end
 
         it 'updates the building type' do
@@ -651,7 +690,11 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
 
         it 'has correct backlink text and destination' do
           expect(assigns(:back_text)).to eq 'Return to building type'
-          expect(assigns(:back_path)).to eq edit_facilities_management_rm3830_building_path(building.id, section: 'building_type')
+          expect(assigns(:back_path)).to eq edit_facilities_management_rm6232_procurement_edit_building_path(procurement, building.id, section: 'building_type')
+        end
+
+        it 'sets the procurement' do
+          expect(assigns(:procurement)).to eq procurement
         end
       end
 
@@ -659,7 +702,7 @@ RSpec.describe FacilitiesManagement::RM3830::BuildingsController, type: :control
         let(:update_params) { { building_name: 'New building name', security_type: 'Counter terrorist check (CTC)' } }
 
         it 'redirects to the show page' do
-          expect(response).to redirect_to facilities_management_rm3830_building_path(building)
+          expect(response).to redirect_to facilities_management_rm6232_procurement_edit_building_path(procurement, building)
         end
 
         it 'does no update the unpermitted attribute' do

--- a/spec/helpers/facilities_management/rm6232/details_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm6232/details_helper_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsHelper, type: :helper do
     context 'when the section is buildings' do
       let(:section) { :buildings }
 
-      pending 'returns Buildings' do
+      it 'returns Buildings' do
         expect(result).to eq('Buildings')
       end
     end


### PR DESCRIPTION
Ticket: [FMFR-1172](https://crowncommercialservice.atlassian.net/browse/FMFR-1172)

As this is a rather complex section of the application, I’ve split it up into parts so that the PRs/commits do not get too large.

This commit concerns the adding of the ‘edit buildings’ section within the procurement for the new FM framework. I’ve done the minimum to get the ‘buildings’ page working in the details section and then added the ‘edit buildings’ section.

Included in this commit are tests for the ‘edit buildings’ section (both specs and feature tests) to make sure it works as expected.