### PR TITLE
FMFR-1172 - Add summary page for buildings

### DIFF
--- a/app/controllers/concerns/facilities_management/procurement_details_concern.rb
+++ b/app/controllers/concerns/facilities_management/procurement_details_concern.rb
@@ -7,8 +7,9 @@ module FacilitiesManagement::ProcurementDetailsConcern
     before_action :authorize_user
     before_action :redirect_if_unrecognised_section, only: :show
     before_action :redirect_to_edit_from_show, only: :show
+    before_action :set_procurement_show_data, only: :show
     before_action :redirect_if_unrecognised_edit_section, only: :edit
-    before_action :set_procurement_data, only: :edit
+    before_action :set_procurement_edit_data, only: :edit
 
     helper_method :section, :edit_path, :procurement_show_path
   end
@@ -69,9 +70,13 @@ module FacilitiesManagement::ProcurementDetailsConcern
     "/facilities-management/#{params[:framework]}/procurements/#{params[:procurement_id]}/details/#{params[:section]}/edit"
   end
 
-  def set_procurement_data
+  def set_procurement_edit_data
     @procurement.build_call_off_extensions if section == :contract_period
     set_buildings if section == :buildings
+  end
+
+  def set_procurement_show_data
+    @active_procurement_buildings = @procurement.procurement_buildings.where(active: true).order_by_building_name.page(params[:page]) if section == :buildings
   end
 
   # Methods relating to paginating the buildings

--- a/app/models/facilities_management/rm6232/procurement_building.rb
+++ b/app/models/facilities_management/rm6232/procurement_building.rb
@@ -6,6 +6,9 @@ module FacilitiesManagement
 
       belongs_to :procurement, foreign_key: :facilities_management_rm6232_procurement_id, inverse_of: :procurement_buildings
       belongs_to :building, class_name: 'FacilitiesManagement::Building'
+
+      delegate :building_name, to: :building
+      delegate :address_no_region, to: :building
     end
   end
 end

--- a/app/views/facilities_management/shared/details/show_partials/_buildings.html.erb
+++ b/app/views/facilities_management/shared/details/show_partials/_buildings.html.erb
@@ -1,0 +1,44 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+      <%= t('.you_have_selected') %>
+    </h2>
+    <div id="number-of-buildings">
+      <p class="govuk-!-font-size-48 govuk-!-font-weight-bold govuk-!-margin-bottom-0">
+        <%= @active_procurement_buildings.count %>
+      </p>
+      <p class="govuk-!-font-weight-bold">
+        <%= t('.building').pluralize(@active_procurement_buildings.count) %>
+      </p>
+    </div>
+    <p class="govuk-caption-m">
+      <%= t('.the_buildings_below') %>
+    </p>
+
+    <%= link_to t('.change'), edit_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-2' %>
+    
+    <hr class="govuk-section-break govuk-section-break--m">
+    
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header govuk-!-font-weight-bold"><%= t('.table_caption') %></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @active_procurement_buildings.each do |procurement_building| %>
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header govuk-table__cell govuk-border-bottom_none govuk-!-padding-bottom-0"><%= procurement_building.building_name %></th>
+          </tr>
+          <tr>
+            <td class="govuk-table__cell govuk-!-padding-top-0"><%= procurement_building.address_no_region %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <hr class="govuk-section-break govuk-section-break--m">
+
+    <%= paginate @active_procurement_buildings, views_prefix: 'shared' %>
+  </div>
+</div>

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -432,9 +432,16 @@ en:
         show:
           return_to_requirements: Return to requirements
           title:
+            buildings: Buildings summary
             contract_period: Contract period summary
             services: Services summary
         show_partials:
+          buildings:
+            building: building
+            change: Change
+            table_caption: Buildings
+            the_buildings_below: The buildings below have been selected for this procurement. If you wish to add or remove buildings please click on the 'change' button.
+            you_have_selected: You have selected
           contract_period:
             call_off_extension_period: Optional call-off extension period
             call_off_extensions: Optional call-off extensions

--- a/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/buildings.feature
+++ b/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/buildings.feature
@@ -6,133 +6,132 @@ Feature: Buildings
     When I navigate to the procurement 'My buildings procurement'
     Then I am on the 'Further service and contract requirements' page
 
-  # TODO: Add when summary page has been developed
-  # @pipeline
-  # Scenario: Building selection saves
-  #   Given I have buildings
-  #   And I click on 'Buildings'
-  #   Then I am on the 'Buildings' page
-  #   And I find and select the following buildings:
-  #     | Test building         |
-  #     | Test London building  |
-  #   And I click on 'Save and return'
-  #   Then I am on the 'Buildings summary' page
-  #   And the summary should say 2 buildings selected
-  #   And I should see the following seleceted buildings in the summary:
-  #     | Test building         |
-  #     | Test London building  |
-  #   And I click on 'Return to requirements'
-  #   Then I am on the 'Further service and contract requirements' page
-  #   And 'Buildings' should have the status 'COMPLETED' in 'Services and buildings'
-  #   When I click on 'Buildings'
-  #   Then I am on the 'Buildings summary' page
+  @pipeline
+  Scenario: Building selection saves
+    Given I have buildings
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+    And I find and select the following buildings:
+      | Test building         |
+      | Test London building  |
+    And I click on 'Save and return'
+    Then I am on the 'Buildings summary' page
+    And the summary should say 2 buildings selected
+    And I should see the following seleceted buildings in the summary:
+      | Test building         |
+      | Test London building  |
+    And I click on 'Return to requirements'
+    Then I am on the 'Further service and contract requirements' page
+    And 'Buildings' should have the status 'COMPLETED' in 'Services and buildings'
+    When I click on 'Buildings'
+    Then I am on the 'Buildings summary' page
 
-  # Scenario: Incomplete buildings cannot be selected
-  #   Given I have buildings
-  #   And I have incomplete buildings
-  #   And I click on 'Buildings'
-  #   And I am on the 'Buildings' page
-  #   Then the following buildings cannot be selected:
-  #     | Test incomplete building        |
-  #     | Test incomplete London building |
-  #   And the following buildings can be selected:
-  #     | Test building         |
-  #     | Test London building  |
+  Scenario: Incomplete buildings cannot be selected
+    Given I have buildings
+    And I have incomplete buildings
+    And I click on 'Buildings'
+    And I am on the 'Buildings' page
+    Then the following buildings cannot be selected:
+      | Test incomplete building        |
+      | Test incomplete London building |
+    And the following buildings can be selected:
+      | Test building         |
+      | Test London building  |
 
-  # @pipeline
-  # Scenario: Selections and deselections carry over between pages - no saved buildings
-  #   Given I have 200 buildings
-  #   And I click on 'Buildings'
-  #   And I am on the 'Buildings' page
-  #   And I find and select the following buildings:
-  #     | Test building 015 |
-  #     | Test building 067 |
-  #     | Test building 080 |
-  #   And I click on 'Next'
-  #   And I am on the 'Buildings' page
-  #   And I find and select the following buildings:
-  #     | Test building 147 |
-  #     | Test building 200 |
-  #   And I click on 'Previous'
-  #   And I am on the 'Buildings' page
-  #   Then the following buildings are selected:
-  #     | Test building 015 |
-  #     | Test building 067 |
-  #     | Test building 080 |
-  #   And I deselect building 'Test building 067'
-  #   And I click on 'Next'
-  #   And I am on the 'Buildings' page
-  #   Then the following buildings are selected:
-  #     | Test building 147 |
-  #     | Test building 200 |
-  #   And I find and select the building with the name 'Test building 101'
-  #   And I deselect building 'Test building 147'
-  #   And I click on 'Previous'
-  #   And I am on the 'Buildings' page
-  #   Then the following buildings are selected:
-  #     | Test building 015 |
-  #     | Test building 080 |
-  #   And I click on 'Next'
-  #   And I am on the 'Buildings' page
-  #   Then the following buildings are selected:
-  #     | Test building 101 |
-  #     | Test building 200 |
-  #   And I click on 'Save and return'
-  #   Then I am on the 'Buildings summary' page
-  #   And the summary should say 4 buildings selected
-  #   And I should see the following seleceted buildings in the summary:
-  #     | Test building 015 |
-  #     | Test building 080 |
-  #     | Test building 101 |
-  #     | Test building 200 |
+  @pipeline
+  Scenario: Selections and deselections carry over between pages - no saved buildings
+    Given I have 200 buildings
+    And I click on 'Buildings'
+    And I am on the 'Buildings' page
+    And I find and select the following buildings:
+      | Test building 015 |
+      | Test building 067 |
+      | Test building 080 |
+    And I click on 'Next'
+    And I am on the 'Buildings' page
+    And I find and select the following buildings:
+      | Test building 147 |
+      | Test building 200 |
+    And I click on 'Previous'
+    And I am on the 'Buildings' page
+    Then the following buildings are selected:
+      | Test building 015 |
+      | Test building 067 |
+      | Test building 080 |
+    And I deselect building 'Test building 067'
+    And I click on 'Next'
+    And I am on the 'Buildings' page
+    Then the following buildings are selected:
+      | Test building 147 |
+      | Test building 200 |
+    And I find and select the building with the name 'Test building 101'
+    And I deselect building 'Test building 147'
+    And I click on 'Previous'
+    And I am on the 'Buildings' page
+    Then the following buildings are selected:
+      | Test building 015 |
+      | Test building 080 |
+    And I click on 'Next'
+    And I am on the 'Buildings' page
+    Then the following buildings are selected:
+      | Test building 101 |
+      | Test building 200 |
+    And I click on 'Save and return'
+    Then I am on the 'Buildings summary' page
+    And the summary should say 4 buildings selected
+    And I should see the following seleceted buildings in the summary:
+      | Test building 015 |
+      | Test building 080 |
+      | Test building 101 |
+      | Test building 200 |
 
-  # Scenario: Selections and deselections carry over between pages - with saved buildings
-  #   Given I have 200 buildings
-  #   And I click on 'Buildings'
-  #   And I am on the 'Buildings' page
-  #   And I find and select the building with the name 'Test building 001'
-  #   And I click on 'Next'
-  #   And I am on the 'Buildings' page
-  #   And I find and select the building with the name 'Test building 101'
-  #   And I click on 'Save and return'
-  #   Then I am on the 'Buildings summary' page
-  #   And the summary should say 2 buildings selected
-  #   And I should see the following seleceted buildings in the summary:
-  #     | Test building 001 |
-  #     | Test building 101 |
-  #   Then I click on 'Change'
-  #   And I am on the 'Buildings' page
-  #   Then the following buildings are selected:
-  #     | Test building 001 |
-  #   And I find and select the building with the name 'Test building 023'
-  #   And I deselect building 'Test building 001'
-  #   And I click on 'Next'
-  #   And I am on the 'Buildings' page
-  #   Then the following buildings are selected:
-  #     | Test building 101 |
-  #   And I deselect building 'Test building 101'
-  #   And I click on 'Previous'
-  #   And I am on the 'Buildings' page
-  #   Then the following buildings are selected:
-  #     | Test building 023 |
-  #   And I click on 'Next'
-  #   And I am on the 'Buildings' page
-  #   And no buildings are selected
-  #   Then I click on 'Save and return'
-  #   Then I am on the 'Buildings summary' page
-  #   And the summary should say 1 building selected
-  #   And I should see the following seleceted buildings in the summary:
-  #     | Test building 023 |
+  Scenario: Selections and deselections carry over between pages - with saved buildings
+    Given I have 200 buildings
+    And I click on 'Buildings'
+    And I am on the 'Buildings' page
+    And I find and select the building with the name 'Test building 001'
+    And I click on 'Next'
+    And I am on the 'Buildings' page
+    And I find and select the building with the name 'Test building 101'
+    And I click on 'Save and return'
+    Then I am on the 'Buildings summary' page
+    And the summary should say 2 buildings selected
+    And I should see the following seleceted buildings in the summary:
+      | Test building 001 |
+      | Test building 101 |
+    Then I click on 'Change'
+    And I am on the 'Buildings' page
+    Then the following buildings are selected:
+      | Test building 001 |
+    And I find and select the building with the name 'Test building 023'
+    And I deselect building 'Test building 001'
+    And I click on 'Next'
+    And I am on the 'Buildings' page
+    Then the following buildings are selected:
+      | Test building 101 |
+    And I deselect building 'Test building 101'
+    And I click on 'Previous'
+    And I am on the 'Buildings' page
+    Then the following buildings are selected:
+      | Test building 023 |
+    And I click on 'Next'
+    And I am on the 'Buildings' page
+    And no buildings are selected
+    Then I click on 'Save and return'
+    Then I am on the 'Buildings summary' page
+    And the summary should say 1 building selected
+    And I should see the following seleceted buildings in the summary:
+      | Test building 023 |
 
-  # Scenario: Text when there are no buildings
-  #   And I click on 'Buildings'
-  #   Then I am on the 'Buildings' page
-  #   And there are no buildings to select
-  #   Given I click on the 'Return to requirements' back link
-  #   Then I am on the 'Further service and contract requirements' page
-  #   And 'Buildings' should have the status 'NOT STARTED' in 'Services and buildings'
-  #   And I click on 'Buildings'
-  #   Then I am on the 'Buildings' page
-  #   Given I click on the 'Return to requirements' return link
-  #   Then I am on the 'Further service and contract requirements' page
-  #   And 'Buildings' should have the status 'NOT STARTED' in 'Services and buildings'
+  Scenario: Text when there are no buildings
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+    And there are no buildings to select
+    Given I click on 'Return to requirements'
+    Then I am on the 'Further service and contract requirements' page
+    And 'Buildings' should have the status 'NOT STARTED' in 'Services and buildings'
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+    Given I click on the 'Return to requirements' return link
+    Then I am on the 'Further service and contract requirements' page
+    And 'Buildings' should have the status 'NOT STARTED' in 'Services and buildings'

--- a/features/support/pages/rm6232/entering_requirements.rb
+++ b/features/support/pages/rm6232/entering_requirements.rb
@@ -112,7 +112,7 @@ module Pages::RM6232
     element :number_of_selected_servcies, '#number-of-services'
     element :number_of_selected_buildings, '#number-of-buildings'
 
-    element :no_buildings_text, 'form > div.procurement > div:nth-child(5)'
+    element :no_buildings_text, '#procurement_buildings-form-group > div:nth-child(2) > div > p'
     elements :checked_buildings, 'input[checked="checked"]'
 
     # element :building_status, '.govuk-body > span > strong'

--- a/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
@@ -125,6 +125,11 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
         it 'sets the procurement' do
           expect(assigns(:procurement)).to eq procurement
         end
+
+        it 'sets the active procurement buildings' do
+          expect(assigns(:active_procurement_buildings).count).to eq 1
+          expect(assigns(:active_procurement_buildings).class.to_s).to eq 'FacilitiesManagement::RM6232::ProcurementBuilding::ActiveRecord_AssociationRelation'
+        end
       end
     end
 

--- a/spec/helpers/facilities_management/rm6232/details_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm6232/details_helper_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsHelper, type: :helper do
     context 'when the section is buildings' do
       let(:section) { :buildings }
 
-      pending 'returns Buildings summary' do
+      it 'returns Buildings summary' do
         expect(result).to eq('Buildings summary')
       end
     end


### PR DESCRIPTION
Ticket: [FMFR-1172](https://crowncommercialservice.atlassian.net/browse/FMFR-1172)

Added the summary page for buildings so that we can see the selected buildings by the user.

I was also able to update the feature tests for both the show and edit pages for ‘buildings’ to show how they worked.