### PR TITLE
FMFR-1173 - Assign services to buildings summary page

### DIFF
--- a/app/controllers/concerns/facilities_management/procurement_details_concern.rb
+++ b/app/controllers/concerns/facilities_management/procurement_details_concern.rb
@@ -11,7 +11,7 @@ module FacilitiesManagement::ProcurementDetailsConcern
     before_action :redirect_if_unrecognised_edit_section, only: :edit
     before_action :set_procurement_edit_data, only: :edit
 
-    helper_method :section, :edit_path, :procurement_show_path
+    helper_method :section, :show_path, :edit_path, :procurement_show_path
   end
 
   def show
@@ -62,12 +62,12 @@ module FacilitiesManagement::ProcurementDetailsConcern
     "/facilities-management/#{params[:framework]}/procurements/#{params[:procurement_id]}"
   end
 
-  def show_path
-    "/facilities-management/#{params[:framework]}/procurements/#{params[:procurement_id]}/details/#{params[:section]}"
+  def show_path(section = params[:section])
+    "/facilities-management/#{params[:framework]}/procurements/#{params[:procurement_id]}/details/#{section}"
   end
 
-  def edit_path
-    "/facilities-management/#{params[:framework]}/procurements/#{params[:procurement_id]}/details/#{params[:section]}/edit"
+  def edit_path(section = params[:section])
+    "/facilities-management/#{params[:framework]}/procurements/#{params[:procurement_id]}/details/#{section}/edit"
   end
 
   def set_procurement_edit_data
@@ -76,7 +76,7 @@ module FacilitiesManagement::ProcurementDetailsConcern
   end
 
   def set_procurement_show_data
-    @active_procurement_buildings = @procurement.procurement_buildings.where(active: true).order_by_building_name.page(params[:page]) if section == :buildings
+    @active_procurement_buildings = @procurement.active_procurement_buildings.order_by_building_name.page(params[:page]) if section == :buildings || section == :buildings_and_services
   end
 
   # Methods relating to paginating the buildings

--- a/app/controllers/facilities_management/rm6232/details_controller.rb
+++ b/app/controllers/facilities_management/rm6232/details_controller.rb
@@ -10,8 +10,7 @@ module FacilitiesManagement
       end
 
       RECOGNISED_DETAILS_EDIT_STEPS = %i[contract_name annual_contract_value tupe contract_period services buildings].freeze
-      RECOGNISED_DETAILS_SHOW_PAGES = %i[contract_period services buildings].freeze
-      # buildings_and_services
+      RECOGNISED_DETAILS_SHOW_PAGES = %i[contract_period services buildings buildings_and_services].freeze
     end
   end
 end

--- a/app/models/concerns/facilities_management/procurement_concern.rb
+++ b/app/models/concerns/facilities_management/procurement_concern.rb
@@ -30,10 +30,20 @@ module FacilitiesManagement
     end
 
     def buildings_status
-      @buildings_status ||= procurement_buildings.where(active: true).any? ? :completed : :not_started
+      @buildings_status ||= active_procurement_buildings.any? ? :completed : :not_started
     end
 
-    # def buildings_and_services_status; end
+    def buildings_and_services_status
+      @buildings_and_services_status ||= if services_status == :not_started || buildings_status == :not_started
+                                           :cannot_start
+                                         else
+                                           buildings_and_services_completed? ? :completed : :incomplete
+                                         end
+    end
+
+    def buildings_and_services_completed?
+      active_procurement_buildings.all?(&:service_selection_complete?)
+    end
 
     def initial_call_off_period
       initial_call_off_period_years.years + initial_call_off_period_months.months

--- a/app/models/facilities_management/rm3830/procurement.rb
+++ b/app/models/facilities_management/rm3830/procurement.rb
@@ -371,18 +371,6 @@ module FacilitiesManagement
         estimated_cost_known.nil? ? :not_started : :completed
       end
 
-      def buildings_and_services_status
-        @buildings_and_services_status ||= if services_status == :not_started || buildings_status == :not_started
-                                             :cannot_start
-                                           else
-                                             buildings_and_services_completed? ? :completed : :incomplete
-                                           end
-      end
-
-      def buildings_and_services_completed?
-        active_procurement_buildings.all?(&:service_selection_complete?)
-      end
-
       def service_requirements_status
         return :cannot_start unless buildings_and_services_status == :completed
         return :not_required unless services_require_questions?

--- a/app/models/facilities_management/rm6232/procurement.rb
+++ b/app/models/facilities_management/rm6232/procurement.rb
@@ -42,6 +42,10 @@ module FacilitiesManagement
         @regions ||= Region.where(code: region_codes)
       end
 
+      def active_procurement_buildings
+        @active_procurement_buildings ||= procurement_buildings.where(active: true)
+      end
+
       aasm do
         state :what_happens_next, initial: true
         state :entering_requirements
@@ -59,16 +63,6 @@ module FacilitiesManagement
 
       def annual_contract_value_status
         annual_contract_value.present? ? :completed : :not_started
-      end
-
-      def buildings_and_services_status
-        # TODO: Add in when appropriate
-        # @buildings_and_services_status ||= if services_status == :not_started || buildings_status == :not_started
-        #                                      :cannot_start
-        #                                    else
-        #                                      buildings_and_services_completed? ? :completed : :incomplete
-        #                                    end
-        :cannot_start
       end
 
       private

--- a/app/models/facilities_management/rm6232/procurement_building.rb
+++ b/app/models/facilities_management/rm6232/procurement_building.rb
@@ -9,6 +9,15 @@ module FacilitiesManagement
 
       delegate :building_name, to: :building
       delegate :address_no_region, to: :building
+
+      def service_selection_complete?
+        false
+        # service_codes.any? && service_code_selection_error_code.nil?
+      end
+
+      def services
+        @services ||= Service.where(code: service_codes).order(:work_package_code, :sort_order).pluck(:name)
+      end
     end
   end
 end

--- a/app/views/facilities_management/shared/details/show_partials/_buildings.html.erb
+++ b/app/views/facilities_management/shared/details/show_partials/_buildings.html.erb
@@ -5,10 +5,10 @@
     </h2>
     <div id="number-of-buildings">
       <p class="govuk-!-font-size-48 govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-        <%= @active_procurement_buildings.count %>
+        <%= @procurement.active_procurement_buildings.count %>
       </p>
       <p class="govuk-!-font-weight-bold">
-        <%= t('.building').pluralize(@active_procurement_buildings.count) %>
+        <%= t('.building').pluralize(@procurement.active_procurement_buildings.count) %>
       </p>
     </div>
     <p class="govuk-caption-m">

--- a/app/views/facilities_management/shared/details/show_partials/_buildings_and_services.html.erb
+++ b/app/views/facilities_management/shared/details/show_partials/_buildings_and_services.html.erb
@@ -1,0 +1,61 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-body">
+       <%= t('.status') %>
+    </span>
+    <span class="govuk-!-padding-left-2">
+      <%= govuk_tag(@procurement.buildings_and_services_status) %>
+    </span>
+  </div>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--m">
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-m">
+      <%= t('.summary_html', buildings_link: link_to(t('.buildings_link_text'), show_path('buildings'), class: 'govuk-link govuk-link--no-visited-state')) %>
+    </span>
+  </div>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--m">
+
+<table class="govuk-table govuk-!-width-full">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 50%"> <%= t('.buildings') %> </td>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col" style="width: 50%"> <%= t('.services') %> </td>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @active_procurement_buildings.each do |procurement_building| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-padding-right-2" style="vertical-align: top;">
+          <%# edit_facilities_management_rm3830_procurement_building_path(procurement_building, step: 'buildings_and_services') %>
+          <%= link_to procurement_building.building_name, '#', class: 'govuk-link--no-visited-state ccs-font-weight-semi-bold' %>
+          <br/>
+          <%= procurement_building.address_no_region %>
+        </td>
+        <% if procurement_building.service_codes.any? %>
+          <td class="govuk-table__cell govuk-!-padding-right-2" style="vertical-align: top;">
+            <%= govuk_details("#{pluralize(procurement_building.services.length, t('.service'))} selected") do %>
+              <ul class="govuk-!-padding-left-3 govuk-!-margin-top-0">
+                <% procurement_building.services.each_with_index do |service_name, index| %>
+                  <li class="<%= 'govuk-!-padding-top-2' unless index == 0%>">
+                    <%= service_name %>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+          </td>
+        <% else %>
+          <td class="govuk-table__cell govuk-!-padding-right-2" style="vertical-align: middle;">
+            <span class="govuk-hint"> <%= t('.no_service_selected') %> </span>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= paginate @active_procurement_buildings, views_prefix: 'shared' %>

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -433,6 +433,7 @@ en:
           return_to_requirements: Return to requirements
           title:
             buildings: Buildings summary
+            buildings_and_services: Assigning services to buildings summary
             contract_period: Contract period summary
             services: Services summary
         show_partials:
@@ -442,6 +443,14 @@ en:
             table_caption: Buildings
             the_buildings_below: The buildings below have been selected for this procurement. If you wish to add or remove buildings please click on the 'change' button.
             you_have_selected: You have selected
+          buildings_and_services:
+            buildings: Building name and address
+            buildings_link_text: Buildings
+            no_service_selected: No service selected
+            service: service
+            services: Assigned services
+            status: Status
+            summary_html: Please click on each of your buildings listed below and select the services you require within each building. The status indicator above will show as 'complete' once services have been selected for all your buildings listed. To add to, or change your list of buildings, please go back to your Requirements summary page, and click on '%{buildings_link}' in section 2.
           contract_period:
             call_off_extension_period: Optional call-off extension period
             call_off_extensions: Optional call-off extensions

--- a/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
@@ -135,15 +135,22 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
 
     context 'when the user wants to assign services to buildings' do
       let(:section_name) { 'buildings-and-services' }
+      let(:building) { create(:facilities_management_building, user: user) }
+      let(:procurement_options) { { procurement_buildings_attributes: { '0': { building_id: building.id, active: true } } } }
 
       render_views
 
-      pending 'renders the contract_periods partial' do
+      it 'renders the buildings_and_services partial' do
         expect(response).to render_template(partial: '_buildings_and_services')
       end
 
       it 'sets the procurement' do
         expect(assigns(:procurement)).to eq procurement
+      end
+
+      it 'sets the active procurement buildings' do
+        expect(assigns(:active_procurement_buildings).count).to eq 1
+        expect(assigns(:active_procurement_buildings).class.to_s).to eq 'FacilitiesManagement::RM6232::ProcurementBuilding::ActiveRecord_AssociationRelation'
       end
     end
   end

--- a/spec/helpers/facilities_management/rm6232/details_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm6232/details_helper_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsHelper, type: :helper do
     context 'when the section is buildings_and_services' do
       let(:section) { :buildings_and_services }
 
-      pending 'returns Assigning services to buildings summary' do
+      it 'returns Assigning services to buildings summary' do
         expect(result).to eq('Assigning services to buildings summary')
       end
     end


### PR DESCRIPTION
Ticket: [FMFR-1173](https://crowncommercialservice.atlassian.net/browse/FMFR-1173)

This is part of the work to add the ‘Assign services to buildings’ section of the application. Like with other parts, I’ve split it up so that the changes do not get too large.

This specific commit adds the summary page for the ‘Assign services to buildings section’ and some specs for that section.

I’ve not added any feature tests yet and will do that when all the parts of this section are complete.