### PR TITLE
FMFR-1173 - Add ability to add services to a building in a procurement

### DIFF
--- a/app/controllers/facilities_management/rm6232/procurement_buildings_controller.rb
+++ b/app/controllers/facilities_management/rm6232/procurement_buildings_controller.rb
@@ -1,0 +1,38 @@
+module FacilitiesManagement
+  module RM6232
+    class ProcurementBuildingsController < FacilitiesManagement::FrameworkController
+      before_action :set_procurement_building_data
+      before_action :authorize_user
+
+      def edit; end
+
+      def update
+        @procurement_building.assign_attributes(procurement_building_params)
+
+        if @procurement_building.save(context: :buildings_and_services)
+          redirect_to facilities_management_rm6232_procurement_detail_path(@procurement, section: 'buildings-and-services')
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def procurement_building_params
+        params.require(:facilities_management_rm6232_procurement_building)
+              .permit(service_codes: [])
+      end
+
+      def set_procurement_building_data
+        @procurement_building = ProcurementBuilding.find(params[:id])
+        @procurement = @procurement_building.procurement
+      end
+
+      protected
+
+      def authorize_user
+        authorize! :manage, @procurement
+      end
+    end
+  end
+end

--- a/app/helpers/facilities_management/rm6232/procurement_buildings_helper.rb
+++ b/app/helpers/facilities_management/rm6232/procurement_buildings_helper.rb
@@ -1,0 +1,5 @@
+module FacilitiesManagement::RM6232
+  module ProcurementBuildingsHelper
+    include FacilitiesManagement::RM6232::ProcurementsHelper
+  end
+end

--- a/app/views/facilities_management/rm6232/procurement_buildings/edit.html.erb
+++ b/app/views/facilities_management/rm6232/procurement_buildings/edit.html.erb
@@ -1,0 +1,63 @@
+<% content_for :page_title, t('.page_title') %>
+<%= render partial: 'shared/error_summary', locals: { errors: @procurement_building.errors } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-m govuk-!-font-size-24">
+      <%= page_subtitle %>
+    </span>
+    <h1 class="govuk-heading-xl">
+      <%= @procurement_building.building_name %>
+    </h1>
+  </div>
+</div>
+
+<%= form_with url: facilities_management_rm6232_procurement_procurement_building_path, model: @procurement_building, method: :put, local: 'false', html: { specialvalidation: true, novalidate: true } do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_group_with_error(f.object, :service_codes) do |displayed_error| %>
+        <fieldset class="govuk-fieldset" aria-describedby="assigning-services-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h2 class="govuk-fieldset__heading">
+              <%= t('.label') %>
+            </h2>
+          </legend>
+          <div id="assigning-services-hint" class="govuk-hint">
+            <%= t('.hint_text_html', services_link: link_to(t('.services_link_text'), facilities_management_rm6232_procurement_detail_path(procurement_id: @procurement.id, section: :services), class: 'govuk-link govuk-link--no-visited-state')) %>
+          </div>
+          <%= displayed_error %>
+          <div class="govuk-checkboxes buildings_and_services">
+            <ul class="govuk-list">
+              <li class="govuk-checkboxes__item ccs-select-all govuk-!-margin-bottom-4">
+                <input class="govuk-checkboxes__input" id="box-all" name="box-all" type="checkbox">
+                <label class="govuk-label govuk-checkboxes__label" for="box-all">
+                  <%= t('.select_all') %>
+                </label>
+              </li>
+              <li class="govuk-!-margin-bottom-4">
+                <p class="govuk-body govuk-!-margin-bottom-0"><%= t('.or') %></p>
+              </li>
+              <%= f.collection_check_boxes(:service_codes, @procurement.services_without_lot_consideration, :code, :name) do |c| %>
+                <li class="govuk-!-margin-bottom-4">
+                  <div class="govuk-checkboxes__item">
+                    <%= c.check_box(class: 'govuk-checkboxes__input procurement-building__input') %>
+                    <%= c.label(class: 'govuk-label govuk-checkboxes__label') %>
+                  </div>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </fieldset>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-top-5">
+    <div class="govuk-grid-column-full">
+      <%= f.submit(t('.save_and_return'), class: 'govuk-button', data: { module: 'govuk-button' }) %>
+      <p>
+        <%= link_to t('.return_to_summary'), facilities_management_rm6232_procurement_detail_path(procurement_id: @procurement.id, section: 'buildings-and-services'), class: 'govuk-link--no-visited-state' %>
+      </p>
+    </div>
+  </div>
+<% end%>

--- a/app/views/facilities_management/shared/details/show_partials/_buildings_and_services.html.erb
+++ b/app/views/facilities_management/shared/details/show_partials/_buildings_and_services.html.erb
@@ -32,8 +32,7 @@
     <% @active_procurement_buildings.each do |procurement_building| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-padding-right-2" style="vertical-align: top;">
-          <%# edit_facilities_management_rm3830_procurement_building_path(procurement_building, step: 'buildings_and_services') %>
-          <%= link_to procurement_building.building_name, '#', class: 'govuk-link--no-visited-state ccs-font-weight-semi-bold' %>
+          <%= link_to procurement_building.building_name, edit_facilities_management_rm6232_procurement_procurement_building_path(id: procurement_building.id), class: 'govuk-link--no-visited-state ccs-font-weight-semi-bold' %>
           <br/>
           <%= procurement_building.address_no_region %>
         </td>

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -131,6 +131,12 @@ en:
               greater_than_or_equal_to: The years for the extension period must be greater than or equal to 0
               not_a_number: The years for the extension period must be a whole number
               not_an_integer: The years for the extension period must be a whole number
+        facilities_management/rm6232/procurement_building:
+          attributes:
+            service_codes:
+              invalid_cafm_helpdesk_billable: You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'
+              invalid_cleaning: "'Mobile cleaning' and 'Routine cleaning' are the same, but differ by delivery method. Please choose one of these services only"
+              too_short: You must select at least one service for this building
         facilities_management/rm6232/supplier/lot_data:
           attributes:
             region_codes:
@@ -261,6 +267,16 @@ en:
               item_2: other spreadsheets
             title: Final results
           the_steps_shown: The steps shown below outline the process that you'll follow creating your facilities management procurement.
+      procurement_buildings:
+        edit:
+          hint_text_html: To add to, or change your list of services to select from, please go back to your Requirements summary page, and click on '%{services_link}' in section 2.
+          label: Which of your services are required within this building?
+          or: Or
+          page_title: Assigning services to a building
+          return_to_summary: Return to assigning services to buildings summary page
+          save_and_return: Save and return
+          select_all: Select all
+          services_link_text: Services
       procurements:
         index:
           advanced_procurement_activities: Advanced procurement activities

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,8 +179,11 @@ Rails.application.routes.draw do
 
       resources :procurements, only: %i[index show new create] do
         concerns :procurement_details, :edit_buildings
+
         get 'supplier_shortlist_spreadsheet'
         put 'update-show', action: 'update_show'
+
+        resources :procurement_buildings, path: 'procurement-buildings', only: %i[edit update]
       end
 
       namespace :admin, path: 'admin', defaults: { service: 'facilities_management/admin' } do

--- a/features/accessibility/facilities_management/rm6232/procurements/entering_requirements/services_and_building/assigning_services_to_buildings_accessibility.feature
+++ b/features/accessibility/facilities_management/rm6232/procurements/entering_requirements/services_and_building/assigning_services_to_buildings_accessibility.feature
@@ -1,0 +1,42 @@
+@accessibility @javascript
+Feature: Assigning services to buildings accessibility
+
+  Background: I navigate to the assigning services to buildings summary page
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have buildings
+    And I have an empty procurement with buildings named 'S & B procurement' with the following servcies:
+      | E.1   |
+      | N.5   |
+      | I.1   |
+      | L.3   |
+      | R.1   |
+    When I navigate to the procurement 'S & B procurement'
+    Then I am on the 'Further service and contract requirements' page
+    And I click on 'Assigning services to buildings'
+    Then I am on the 'Assigning services to buildings summary' page
+
+  Scenario: Assigning services to buildings summary page
+    Then the page should be axe clean
+
+  Scenario: Select services page
+    Given I click on 'Test building' 
+    Then I am on the 'Test building' page
+    Then the page should be axe clean
+
+  Scenario: Completed service selection
+    Given I click on 'Test building' 
+    Then I am on the 'Test building' page
+    And I am on the page with secondary heading 'Which of your services are required within this building?'
+    When I select the following services for the building:
+      | Mechanical and Electrical Engineering Maintenance |
+      | Routine cleaning                                  |
+      | Helpdesk Services                                 |
+    And I click on 'Save and return'
+    Then I am on the 'Assigning services to buildings summary' page
+    Given I click on 'Test London building' 
+    Then I am on the 'Test London building' page
+    And I am on the page with secondary heading 'Which of your services are required within this building?'
+    When I select the service 'Flag flying service' for the building
+    And I click on 'Save and return'
+    Then I am on the 'Assigning services to buildings summary' page
+    Then the page should be axe clean

--- a/features/accessibility/facilities_management/rm6232/procurements/entering_requirements/services_and_building/buildings_accessibility.feature
+++ b/features/accessibility/facilities_management/rm6232/procurements/entering_requirements/services_and_building/buildings_accessibility.feature
@@ -1,0 +1,31 @@
+@accessibility @javascript
+Feature: Buildings accessibility
+
+  Background: Navigate to the requirements page
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have an empty procurement for entering requirements named 'My buildings procurement'
+    When I navigate to the procurement 'My buildings procurement'
+    Then I am on the 'Further service and contract requirements' page
+
+  Scenario: Buildings page without pagination
+    Given I have buildings
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+    Then the page should be axe clean
+
+  Scenario:  Buildings page with pagination
+    Given I have 200 buildings
+    And I click on 'Buildings'
+    And I am on the 'Buildings' page
+    Then the page should be axe clean
+
+  Scenario: Buildings summary page
+    Given I have buildings
+    And I click on 'Buildings'
+    Then I am on the 'Buildings' page
+    And I find and select the following buildings:
+      | Test building         |
+      | Test London building  |
+    And I click on 'Save and return'
+    Then I am on the 'Buildings summary' page
+    Then the page should be axe clean

--- a/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/assigning_services_to_buildings.feature
+++ b/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/assigning_services_to_buildings.feature
@@ -1,0 +1,112 @@
+Feature: Assigning services to buildings
+
+  Background: I navigate to the assigning services to buildings summary page
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have buildings
+    And I have an empty procurement with buildings named 'S & B procurement' with the following servcies:
+      | E.1   |
+      | E.21  |
+      | N.5   |
+      | I.1   |
+      | L.3   |
+      | R.1   |
+    When I navigate to the procurement 'S & B procurement'
+    Then I am on the 'Further service and contract requirements' page
+    And 'Assigning services to buildings' should have the status 'INCOMPLETE' in 'Services and buildings'
+    And I click on 'Assigning services to buildings'
+    Then I am on the 'Assigning services to buildings summary' page
+
+  @pipeline
+  Scenario: Select services for the buildings
+    And the assigning services to buildings status should be 'INCOMPLETE'
+    And the building named 'Test building' should have no services selected
+    And the building named 'Test London building' should have no services selected
+    Given I click on 'Test building' 
+    Then I am on the 'Test building' page
+    And I am on the page with secondary heading 'Which of your services are required within this building?'
+    When I select the following services for the building:
+      | Mechanical and Electrical Engineering Maintenance |
+      | Routine cleaning                                  |
+      | Helpdesk Services                                 |
+    And I click on 'Save and return'
+    Then I am on the 'Assigning services to buildings summary' page
+    And the assigning services to buildings status should be 'INCOMPLETE'
+    And the building named 'Test building' should say 3 services selected
+    Then I open the selected services for 'Test building'
+    And the following services have been selected for 'Test building':
+      | Mechanical and Electrical Engineering Maintenance |
+      | Routine cleaning                                  |
+      | Helpdesk Services                                 |
+    Given I click on 'Test London building' 
+    Then I am on the 'Test London building' page
+    And I am on the page with secondary heading 'Which of your services are required within this building?'
+    When I select the service 'Flag flying service' for the building
+    And I click on 'Save and return'
+    Then I am on the 'Assigning services to buildings summary' page
+    And the assigning services to buildings status should be 'COMPLETED'
+    And the building named 'Test London building' should say 1 service selected
+    Then I open the selected services for 'Test London building'
+    And the following services have been selected for 'Test London building':
+      | Flag flying service |
+    Then I click on 'Return to requirements'
+    And I am on the 'Further service and contract requirements' page
+    And 'Assigning services to buildings' should have the status 'COMPLETED' in 'Services and buildings'
+
+  @javascript
+  Scenario: Select all services
+    Given I click on 'Test building'
+    Then I am on the 'Test building' page
+    And I am on the page with secondary heading 'Which of your services are required within this building?'
+    Given I select all services for the building
+    And I click on 'Save and return'
+    And the building named 'Test building' should say 6 services selected
+    Then I open the selected services for 'Test building'
+    And the following services have been selected for 'Test building':
+      | Mechanical and Electrical Engineering Maintenance |
+      | Specialist maintenance Services                   |
+      | Routine cleaning                                  |
+      | Control of access - Staff and Visitors            |
+      | Flag flying service                               |
+      | Helpdesk Services                                 |
+    Given I click on 'Test building'
+    Then I am on the 'Test building' page
+    And I am on the page with secondary heading 'Which of your services are required within this building?'
+    Then select all should be 'checked'
+    When I deselect the service 'Flag flying service' for the building
+    Then select all should be 'unchecked'
+    When I select the service 'Flag flying service' for the building
+    Then select all should be 'checked'
+
+  Scenario: Only services without requirements are selected
+    Given I click on 'Test building' 
+    Then I am on the 'Test building' page
+    And I am on the page with secondary heading 'Which of your services are required within this building?'
+    When I select the service 'Specialist maintenance Services' for the building
+    And I click on 'Save and return'
+    Then I am on the 'Assigning services to buildings summary' page
+    And the assigning services to buildings status should be 'INCOMPLETE'
+    And the building named 'Test building' should say 1 service selected
+    Then I open the selected services for 'Test building'
+    And the following services have been selected for 'Test building':
+      | Specialist maintenance Services |
+    Given I click on 'Test London building' 
+    Then I am on the 'Test London building' page
+    And I am on the page with secondary heading 'Which of your services are required within this building?'
+    When I select the service 'Specialist maintenance Services' for the building
+    And I click on 'Save and return'
+    Then I am on the 'Assigning services to buildings summary' page
+    And the assigning services to buildings status should be 'COMPLETED'
+    And the building named 'Test London building' should say 1 service selected
+    Then I open the selected services for 'Test London building'
+    And the following services have been selected for 'Test London building':
+      | Specialist maintenance Services|
+    Then I click on 'Return to requirements'
+    And I am on the 'Further service and contract requirements' page
+    And 'Assigning services to buildings' should have the status 'COMPLETED' in 'Services and buildings'
+
+  Scenario: Return links work
+    Given I click on 'Test building'
+    Then I am on the 'Test building' page
+    And I am on the page with secondary heading 'Which of your services are required within this building?'
+    When I click on 'Return to assigning services to buildings summary page'
+    Then I am on the 'Assigning services to buildings summary' page

--- a/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/assigning_services_to_buildings_validations.feature
+++ b/features/facilities_management/rm6232/procurements/entering_requirements/services_and_buildings/validations/assigning_services_to_buildings_validations.feature
@@ -1,0 +1,67 @@
+@pipeline
+Feature: Assigning services to buildings validations
+
+  Background: Background name
+    Given I sign in and navigate to my account for 'RM6232'
+    And I have buildings
+    And I have an empty procurement with buildings named 'S & B procurement' with the following servcies:
+      | I.1 |
+      | I.4 |
+      | Q.3 |
+      | R.1 |
+      | S.1 |
+    When I navigate to the procurement 'S & B procurement'
+    Then I am on the 'Further service and contract requirements' page
+    And I click on 'Assigning services to buildings'
+    Then I am on the 'Assigning services to buildings summary' page
+    And I click on 'Test building'
+    Then I am on the page with secondary heading 'Which of your services are required within this building?'
+
+  Scenario: No services selected
+    When I click on 'Save and return'
+    Then I should see the following error messages:
+      | You must select at least one service for this building  |
+
+  Scenario: Both cleanings selected
+    When I select the following services for the building:
+      | Routine cleaning          |
+      | Mobile cleaning Services  |
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | 'Mobile cleaning' and 'Routine cleaning' are the same, but differ by delivery method. Please choose one of these services only  |
+
+  Scenario Outline: Only one of the extra services is selected
+    Given I select the service '<service>' for the building
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | <error_messages>  |
+
+  Examples:
+    | service                       | error_messages                                                                                                      |
+    | CAFM system                   | You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works' |
+    | Helpdesk Services             | You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works' |
+    | Management of Billable Works  | You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works' |
+
+  Scenario Outline: Only two of the extra services are selected
+    Given I select the following services for the building:
+      | <service_1> |
+      | <service_2> |
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | <error_messages>  |
+  
+   Examples:
+    | service_1                     | service_2                     | error_messages                                                                                                      |
+    | CAFM system                   | Helpdesk Services             | You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works' |
+    | Helpdesk Services             | Management of Billable Works  | You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works' |
+    | Management of Billable Works  | CAFM system                   | You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works' |
+  
+  Scenario: Only CAFM system, Helpdesk services and Management of billable works
+    Given I select the following services for the building:
+      | CAFM system                   |
+      | Helpdesk Services             |
+      | Management of Billable Works  |
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works' |
+

--- a/features/step_definitions/facilities_management/buyer_detail_steps.rb
+++ b/features/step_definitions/facilities_management/buyer_detail_steps.rb
@@ -18,3 +18,7 @@ Then('the following buyer details have been entered:') do |buyer_details_table|
     end
   end
 end
+
+Then('I change my contact detail address') do
+  buyer_detail_page.change_address.click
+end

--- a/features/step_definitions/facilities_management/entering_requirements_steps.rb
+++ b/features/step_definitions/facilities_management/entering_requirements_steps.rb
@@ -190,3 +190,138 @@ end
 Then('I should see the following seleceted services in the summary:') do |services_summary|
   expect(entering_requirements_page.all('table > tbody > tr > td').map(&:text)).to match services_summary.raw.flatten
 end
+
+Given('I have incomplete buildings') do
+  create(:facilities_management_building, building_name: 'Test incomplete building', user: @user, address_region: nil, address_region_code: nil)
+  create(:facilities_management_building_london, building_name: 'Test incomplete London building', user: @user, address_region: nil, address_region_code: nil)
+end
+
+And('I find and select the building with the name {string}') do |building_name|
+  continue = true
+
+  while continue
+    if entering_requirements_page.text.include? building_name
+      entering_requirements_page.find('label', text: building_name).click
+      continue = false
+    elsif entering_requirements_page.has_css?('.ccs-pagination') && first('.ccs-pagination')
+      entering_requirements_page.next_pagination.click
+    else
+      raise("Cannot find Building with name #{building_name}")
+    end
+  end
+end
+
+Then('I click on the details for {string}') do |building_name|
+  entering_requirements_page.find("a[aria-label='Details for \"#{building_name}\"']").click
+end
+
+Then('I find and select the following buildings:') do |building_names|
+  building_names.raw.flatten.each do |building_name|
+    step "I find and select the building with the name '#{building_name}'"
+  end
+end
+
+Then('there are no buildings to select') do
+  expect(entering_requirements_page.no_buildings_text).to have_content("You have no saved buildings. Click on 'Add a building' to start setting up your building(s)")
+end
+
+Then('the summary should say {int} buildings selected') do |number_of_selected_buildings|
+  expect(entering_requirements_page.number_of_selected_buildings).to have_content("#{number_of_selected_buildings} buildings")
+end
+
+Then('the summary should say {int} building selected') do |number_of_selected_buildings|
+  expect(entering_requirements_page.number_of_selected_buildings).to have_content("#{number_of_selected_buildings} building")
+end
+
+Then('the following buildings can be selected:') do |building_names|
+  building_names.raw.flatten.each do |building_name|
+    expect(entering_requirements_page).to have_selector('label', text: building_name)
+  end
+end
+
+Then('the following buildings cannot be selected:') do |building_names|
+  building_names.raw.flatten.each do |building_name|
+    expect(entering_requirements_page).not_to have_selector('label', text: building_name)
+  end
+end
+
+Then('the following buildings are selected:') do |building_names|
+  expect(entering_requirements_page.checked_buildings.map { |element| element.find(:xpath, './../label/span[1]').text }).to match(building_names.raw.flatten)
+end
+
+Then('no buildings are selected') do
+  expect(entering_requirements_page.checked_buildings).to be_empty
+end
+
+Then('I deselect building {string}') do |building_name|
+  entering_requirements_page.find('label', text: building_name).click
+end
+
+Then('I should see the following seleceted buildings in the summary:') do |buildings_summary|
+  expect(page.all('table > tbody > tr > th').map(&:text)).to match buildings_summary.raw.flatten
+end
+
+Given('I have {int} buildings') do |number_of_buildings|
+  number_of_buildings.times do |building_number|
+    create(:facilities_management_building, building_name: "Test building #{format('%03d', building_number + 1)}", user: @user)
+  end
+end
+
+Then('I select all services for the building') do
+  if @javascript
+    entering_requirements_page.select_all_services_checkbox.check
+  else
+    entering_requirements_page.all_checkboxes.each(&:check)
+  end
+end
+
+Then('I select the service {string} for the building') do |service|
+  entering_requirements_page.check(service)
+end
+
+Then('I deselect the service {string} for the building') do |service|
+  entering_requirements_page.uncheck(service)
+end
+
+Then('I select the following services for the building:') do |services|
+  services.raw.flatten.each do |service|
+    entering_requirements_page.check(service)
+  end
+end
+
+Then('the assigning services to buildings status should be {string}') do |status|
+  expect(entering_requirements_page.assigning_services_to_buildings_status.text).to eq status.downcase
+end
+
+Then('the building named {string} should have no services selected') do |building_name|
+  expect(building_status(building_name)).to have_content('No service selected')
+end
+
+Then('the building named {string} should say {int} services selected') do |building_name, number_of_selected_services|
+  expect(building_status(building_name).find('summary')).to have_content("#{number_of_selected_services} services selected")
+end
+
+Then('the building named {string} should say {int} service selected') do |building_name, number_of_selected_services|
+  expect(building_status(building_name).find('summary')).to have_content("#{number_of_selected_services} service selected")
+end
+
+Then('I open the selected services for {string}') do |building_name|
+  building_status(building_name).find('summary').click
+end
+
+Then('the following services have been selected for {string}:') do |building_name, selected_services_table|
+  expect(building_status(building_name).all('ul > li').map(&:text)).to match selected_services_table.raw.flatten
+end
+
+Then('select all should be {string}') do |status|
+  case status
+  when 'checked'
+    expect(entering_requirements_page.select_all_services_checkbox).to be_checked
+  when 'unchecked'
+    expect(entering_requirements_page.select_all_services_checkbox).not_to be_checked
+  end
+end
+
+def building_status(building_name)
+  entering_requirements_page.find(:xpath, "//td[* = '#{building_name}']/following-sibling::td")
+end

--- a/features/step_definitions/facilities_management/procurement_steps.rb
+++ b/features/step_definitions/facilities_management/procurement_steps.rb
@@ -15,6 +15,14 @@ Given('I have an empty procurement for entering requirements named {string} with
   create(FRMAEOWRK_AND_STATE_TO_FACTORY[@framework][:empty_entering_requirements], user: @user, contract_name: contract_name, service_codes: service_codes_table.raw.flatten)
 end
 
+Given('I have an empty procurement with buildings named {string} with the following servcies:') do |contract_name, service_codes_table|
+  procurement = create(FRMAEOWRK_AND_STATE_TO_FACTORY[@framework][:empty_entering_requirements], user: @user, contract_name: contract_name, service_codes: service_codes_table.raw.flatten)
+
+  @user.buildings.each do |building|
+    procurement.procurement_buildings.create(building: building, active: true)
+  end
+end
+
 FRMAEOWRK_AND_STATE_TO_FACTORY = {
   'RM3830' => {
     initial: :facilities_management_rm3830_procurement,

--- a/features/step_definitions/facilities_management/quick_view_steps.rb
+++ b/features/step_definitions/facilities_management/quick_view_steps.rb
@@ -1,0 +1,40 @@
+Then('I select all for {string}') do |item_group|
+  page.find("[data-sectionname='#{item_group}']").find('input[name="section-checkbox_select_all"]').check
+end
+
+When('I deselect the following items:') do |items|
+  items.raw.flatten.each do |item|
+    page.uncheck(item)
+  end
+end
+
+When('I remove the following items from the basket:') do |items|
+  items.raw.flatten.each do |item|
+    quick_view_results_page.basket.selection(text: item).first.find(:xpath, '../div/span/a').click
+  end
+end
+
+Then('the following items should appear in the basket:') do |items|
+  expect(quick_view_results_page.basket.selection.map(&:text)).to match(items.raw.flatten)
+end
+
+Then('the basket should say {string}') do |basket_text|
+  expect(quick_view_results_page.basket.selection_count).to have_content(basket_text)
+end
+
+Then('the remove all link should not be visible') do
+  expect(quick_view_results_page.basket.remove_all).not_to be_visible
+end
+
+Then('the remove all link should be visible') do
+  expect(quick_view_results_page.basket.remove_all).to be_visible
+end
+
+Then('select all {string} be checked for {string}') do |status, section|
+  case status
+  when 'should'
+    expect(page.find("[data-sectionname='#{section}']").find('input[name="section-checkbox_select_all"]')).to be_checked
+  when 'should not'
+    expect(page.find("[data-sectionname='#{section}']").find('input[name="section-checkbox_select_all"]')).not_to be_checked
+  end
+end

--- a/features/step_definitions/facilities_management/rm3830/contract_detail_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/contract_detail_steps.rb
@@ -170,7 +170,3 @@ end
 Then('I change my contact detail postcode') do
   contract_detail_page.change_postcode.click
 end
-
-Then('I change my contact detail address') do
-  contract_detail_page.change_address.click
-end

--- a/features/step_definitions/facilities_management/rm3830/entering_requirements_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/entering_requirements_steps.rb
@@ -15,144 +15,13 @@ And('I enter {string} for estimated annual cost') do |estimated_annual_cost|
   entering_requirements_page.estimated_cost_known.set(estimated_annual_cost)
 end
 
-And('I find and select the building with the name {string}') do |building_name|
-  continue = true
-
-  while continue
-    if entering_requirements_page.text.include? building_name
-      entering_requirements_page.find('label', text: building_name).click
-      continue = false
-    elsif entering_requirements_page.has_css?('.ccs-pagination') && first('.ccs-pagination')
-      entering_requirements_page.next_pagination.click
-    else
-      raise("Cannot find Building with name #{building_name}")
-    end
-  end
-end
-
-Then('I click on the details for {string}') do |building_name|
-  entering_requirements_page.find("a[aria-label='Details for \"#{building_name}\"']").click
-end
-
-Then('I find and select the following buildings:') do |building_names|
-  building_names.raw.flatten.each do |building_name|
-    step "I find and select the building with the name '#{building_name}'"
-  end
-end
-
-Then('there are no buildings to select') do
-  expect(entering_requirements_page.no_buildings_text).to have_content("You have no saved buildings. Click on 'Add a building' to start setting up your building(s)")
-end
-
-Then('the summary should say {int} buildings selected') do |number_of_selected_buildings|
-  expect(entering_requirements_page.number_of_selected_buildings).to have_content("#{number_of_selected_buildings} buildings")
-end
-
-Then('the summary should say {int} building selected') do |number_of_selected_buildings|
-  expect(entering_requirements_page.number_of_selected_buildings).to have_content("#{number_of_selected_buildings} building")
-end
-
-Given('I have incomplete buildings') do
-  create(:facilities_management_building, building_name: 'Test incomplete building', user: @user, address_region: nil, address_region_code: nil)
-  create(:facilities_management_building_london, building_name: 'Test incomplete London building', user: @user, address_region: nil, address_region_code: nil)
-end
-
-Then('the following buildings can be selected:') do |building_names|
-  building_names.raw.flatten.each do |building_name|
-    expect(entering_requirements_page).to have_selector('label', text: building_name)
-  end
-end
-
-Then('the following buildings cannot be selected:') do |building_names|
-  building_names.raw.flatten.each do |building_name|
-    expect(entering_requirements_page).not_to have_selector('label', text: building_name)
-  end
-end
-
-Then('the following buildings are selected:') do |building_names|
-  expect(entering_requirements_page.checked_buildings.map { |element| element.find(:xpath, './../label/span[1]').text }).to match(building_names.raw.flatten)
-end
-
-Then('no buildings are selected') do
-  expect(entering_requirements_page.checked_buildings).to be_empty
-end
-
-Then('I deselect building {string}') do |building_name|
-  entering_requirements_page.find('label', text: building_name).click
-end
-
-Then('I should see the following seleceted buildings in the summary:') do |buildings_summary|
-  expect(page.all('table > tbody > tr > th').map(&:text)).to match buildings_summary.raw.flatten
-end
-
-Given('I have {int} buildings') do |number_of_buildings|
-  number_of_buildings.times do |building_number|
-    create(:facilities_management_building, building_name: "Test building #{format('%03d', building_number + 1)}", user: @user)
-  end
-end
-
-Then('I select all services for the building') do
-  if @javascript
-    entering_requirements_page.select_all_services_checkbox.check
-  else
-    entering_requirements_page.all_checkboxes.each(&:check)
-  end
-end
-
-Then('I select the service {string} for the building') do |service|
-  entering_requirements_page.check(service)
-end
-
-Then('I deselect the service {string} for the building') do |service|
-  entering_requirements_page.uncheck(service)
-end
-
 Then('I select the service code {string} for the building') do |service|
   entering_requirements_page.check("facilities_management_rm3830_procurement_building_service_codes_#{service.downcase.gsub('.', '_')}")
-end
-
-Then('I select the following services for the building:') do |services|
-  services.raw.flatten.each do |service|
-    entering_requirements_page.check(service)
-  end
 end
 
 Then('I select the following service codes for the building:') do |services|
   services.raw.flatten.each do |service|
     entering_requirements_page.check("facilities_management_rm3830_procurement_building_service_codes_#{service.downcase.gsub('.', '_')}")
-  end
-end
-
-Then('the assigning services to buildings status should be {string}') do |status|
-  expect(entering_requirements_page.assigning_services_to_buildings_status.text).to eq status.downcase
-end
-
-Then('the building named {string} should have no services selected') do |building_name|
-  expect(building_status(building_name)).to have_content('No service selected')
-end
-
-Then('the building named {string} should say {int} services selected') do |building_name, number_of_selected_services|
-  expect(building_status(building_name).find('summary')).to have_content("#{number_of_selected_services} services selected")
-end
-
-Then('the building named {string} should say {int} service selected') do |building_name, number_of_selected_services|
-  expect(building_status(building_name).find('summary')).to have_content("#{number_of_selected_services} service selected")
-end
-
-Then('I open the selected services for {string}') do |building_name|
-  building_status(building_name).find('summary').click
-end
-
-Then('the following services have been selected for {string}:') do |building_name, selected_services_table|
-  expect(building_status(building_name).all('ul > li').map(&:text)).to match selected_services_table.raw.flatten
-end
-
-Then('select all should be {string}') do |status|
-  case status
-  when 'checked'
-    expect(entering_requirements_page.select_all_services_checkbox).to be_checked
-  when 'unchecked'
-    expect(entering_requirements_page.select_all_services_checkbox).not_to be_checked
   end
 end
 
@@ -201,10 +70,6 @@ end
 
 Then('I select {string} for the missing region') do |region|
   entering_requirements_page.region_drop_down.find(:option, region).select_option
-end
-
-def building_status(building_name)
-  entering_requirements_page.find(:xpath, "//td[* = '#{building_name}']/following-sibling::td")
 end
 
 def create_completed_procurement(contract_name, **options)

--- a/features/step_definitions/facilities_management/rm3830/procurement_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/procurement_steps.rb
@@ -1,11 +1,3 @@
-Given('I have an empty procurement with buildings named {string} with the following servcies:') do |contract_name, service_codes_table|
-  procurement = create(:facilities_management_rm3830_procurement_entering_requirements, user: @user, contract_name: contract_name, service_codes: service_codes_table.raw.flatten)
-
-  @user.buildings.each do |building|
-    procurement.procurement_buildings.create(building: building, active: true)
-  end
-end
-
 Given('I have an empty procurement with buildings named {string} with the following servcies assigned:') do |contract_name, service_codes_table|
   service_codes = service_codes_table.raw.flatten
 

--- a/features/step_definitions/facilities_management/rm3830/quick_view_results_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/quick_view_results_steps.rb
@@ -1,25 +1,5 @@
-Then('I select all for {string}') do |item_group|
-  page.find("[data-sectionname='#{item_group}']").find('input[name="section-checkbox_select_all"]').check
-end
-
-When('I deselect the following items:') do |items|
-  items.raw.flatten.each do |item|
-    page.uncheck(item)
-  end
-end
-
 Then('I deselect all for {string}') do |item_group|
   page.find("[data-sectionname='#{item_group}']").find('input[name="section-checkbox_select_all"]').uncheck
-end
-
-When('I remove the following items from the basket:') do |items|
-  items.raw.flatten.each do |item|
-    quick_view_results_page.basket.selection(text: item).first.find(:xpath, '../div/span/a').click
-  end
-end
-
-Then('the following items should appear in the basket:') do |items|
-  expect(quick_view_results_page.basket.selection.map(&:text)).to match(items.raw.flatten)
 end
 
 Then('I select the service code {string}') do |service|
@@ -29,27 +9,6 @@ end
 Then('I select the following service codes:') do |services|
   services.raw.flatten.each do |service|
     page.check("facilities_management_rm3830_procurement_service_codes_#{service.upcase.gsub('.', '-')}")
-  end
-end
-
-Then('the basket should say {string}') do |basket_text|
-  expect(quick_view_results_page.basket.selection_count).to have_content(basket_text)
-end
-
-Then('the remove all link should not be visible') do
-  expect(quick_view_results_page.basket.remove_all).not_to be_visible
-end
-
-Then('the remove all link should be visible') do
-  expect(quick_view_results_page.basket.remove_all).to be_visible
-end
-
-Then('select all {string} be checked for {string}') do |status, section|
-  case status
-  when 'should'
-    expect(page.find("[data-sectionname='#{section}']").find('input[name="section-checkbox_select_all"]')).to be_checked
-  when 'should not'
-    expect(page.find("[data-sectionname='#{section}']").find('input[name="section-checkbox_select_all"]')).not_to be_checked
   end
 end
 

--- a/features/support/pages/buyer_detail.rb
+++ b/features/support/pages/buyer_detail.rb
@@ -14,5 +14,6 @@ module Pages
     end
 
     element :postcode_error_message, '#error_facilities_management_buyer_detail_organisation_address_postcode > span'
+    element :change_address, '#change-input-2'
   end
 end

--- a/features/support/pages/rm6232/entering_requirements.rb
+++ b/features/support/pages/rm6232/entering_requirements.rb
@@ -115,11 +115,11 @@ module Pages::RM6232
     element :no_buildings_text, '#procurement_buildings-form-group > div:nth-child(2) > div > p'
     elements :checked_buildings, 'input[checked="checked"]'
 
-    # element :building_status, '.govuk-body > span > strong'
-    # element :assigning_services_to_buildings_status, '.govuk-body > span > strong'
+    element :building_status, '.govuk-body > span > strong'
+    element :assigning_services_to_buildings_status, '#main-content > div:nth-child(3) > div > span.govuk-\!-padding-left-2 > strong'
 
-    # element :select_all_services_checkbox, '#box-all'
-    # elements :all_checkboxes, 'input[type=checkbox]'
+    element :select_all_services_checkbox, '#box-all'
+    elements :all_checkboxes, 'input[type=checkbox]'
 
     # element :next_pagination, 'li.ccs-last > button'
     # element :previous_pagination, 'li.ccs-first > button'

--- a/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/details_controller_spec.rb
@@ -633,7 +633,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
       context 'and the data is valid' do
         let(:update_params) { { service_codes: %w[F.1 F.2] } }
 
-        it 'redirects to the procurement show page' do
+        it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_rm6232_procurement_detail_path(procurement, 'services')
         end
 
@@ -659,7 +659,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
       context 'and an unpermitted parameters are passed in' do
         let(:update_params) { { contract_name: 'Hello there' } }
 
-        it 'redirects to the procurement show page' do
+        it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_rm6232_procurement_detail_path(procurement, 'services')
         end
 
@@ -679,7 +679,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
       context 'and the data is valid' do
         let(:update_params) { { procurement_buildings_attributes: { '0': { active: '1', building_id: building_1.id }, '1': { active: '0', building_id: building_2.id }, '2': { active: '1', building_id: new_building.id } } } }
 
-        it 'redirects to the procurement show page' do
+        it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_rm6232_procurement_detail_path(procurement, 'buildings')
         end
 
@@ -725,7 +725,7 @@ RSpec.describe FacilitiesManagement::RM6232::DetailsController, type: :controlle
       context 'and an unpermitted parameters are passed in' do
         let(:update_params) { { contract_name: 'Hello there' } }
 
-        it 'redirects to the procurement show page' do
+        it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_rm6232_procurement_detail_path(procurement, 'buildings')
         end
 

--- a/spec/controllers/facilities_management/rm6232/procurement_buildings_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/procurement_buildings_controller_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::ProcurementBuildingsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management', framework: 'RM6232' } }
+  let(:procurement_building) { create(:facilities_management_rm6232_procurement_building_no_services, procurement: procurement) }
+  let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, user: user) }
+  let(:user) { controller.current_user }
+
+  login_fm_buyer_with_details
+
+  context 'without buyer details' do
+    login_fm_buyer
+
+    it 'will redirect to buyer details' do
+      get :edit, params: { procurement_id: procurement.id, id: procurement_building.id }
+
+      expect(response).to redirect_to edit_facilities_management_buyer_detail_path(id: controller.current_user.buyer_detail.id)
+    end
+  end
+
+  describe 'GET edit' do
+    before { get :edit, params: { procurement_id: procurement.id, id: procurement_building.id } }
+
+    it 'renders the edit page' do
+      expect(response).to render_template(:edit)
+    end
+
+    it 'sets the procurement and procurement building' do
+      expect(assigns(:procurement)).to eq procurement
+      expect(assigns(:procurement_building)).to eq procurement_building
+    end
+
+    context 'when the user does not own the procurement' do
+      let(:user) { create(:user) }
+
+      it 'redirects to the not permitted path' do
+        expect(response).to redirect_to facilities_management_rm6232_not_permitted_path
+      end
+    end
+  end
+
+  describe 'PUT update' do
+    before { put :update, params: { procurement_id: procurement.id, id: procurement_building.id, facilities_management_rm6232_procurement_building: update_params } }
+
+    context 'and the data is valid' do
+      let(:update_params) { { service_codes: %w[F.1 F.2] } }
+
+      it 'redirects to the details show page' do
+        expect(response).to redirect_to facilities_management_rm6232_procurement_detail_path(procurement, 'buildings-and-services')
+      end
+
+      it 'updates service_codes' do
+        expect { procurement_building.reload }.to change(procurement_building, :service_codes)
+
+        expect(procurement_building.service_codes).to eq %w[F.1 F.2]
+      end
+    end
+
+    context 'and the data is not valid' do
+      let(:update_params) { { service_codes: [''] } }
+
+      it 'renders the edit page' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'does not update service_codes' do
+        expect { procurement_building.reload }.not_to change(procurement_building, :service_codes)
+      end
+    end
+
+    context 'and an unpermitted parameters are passed in' do
+      let(:update_params) { { service_codes: %w[F.1 F.2], active: false } }
+
+      it 'redirects to the details show page' do
+        expect(response).to redirect_to facilities_management_rm6232_procurement_detail_path(procurement, 'buildings-and-services')
+      end
+
+      it 'does no update the unpermitted attribute' do
+        expect { procurement_building.reload }.not_to change(procurement_building, :active)
+      end
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/journey/choose_services_spec.rb
+++ b/spec/models/facilities_management/rm6232/journey/choose_services_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FacilitiesManagement::RM6232::Journey::ChooseServices, type: :mod
     end
 
     # rubocop:disable RSpec/NestedGroups
-    context 'when validateing that not all services are mandatory' do
+    context 'when validating that not all services are mandatory' do
       context 'when the only code is Q.3' do
         let(:service_codes) { %w[Q.3] }
 

--- a/spec/models/facilities_management/rm6232/procurement_building_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_building_spec.rb
@@ -1,0 +1,203 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::ProcurementBuilding, type: :model do
+  subject(:procurement_building) { build(:facilities_management_rm6232_procurement_building_no_services, procurement: procurement, service_codes: service_codes) }
+
+  let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements) }
+  let(:service_codes) { [] }
+
+  describe 'validations' do
+    context 'when there are no service codes' do
+      it 'is not valid and has the correct error message' do
+        expect(procurement_building.valid?(:buildings_and_services)).to be false
+        expect(procurement_building.errors[:service_codes].first).to eq 'You must select at least one service for this building'
+      end
+    end
+
+    context 'when the service codes are blank' do
+      let(:service_codes) { [''] }
+
+      it 'is not valid and has the correct error message' do
+        expect(procurement_building.valid?(:buildings_and_services)).to be false
+        expect(procurement_building.errors[:service_codes].first).to eq 'You must select at least one service for this building'
+      end
+    end
+
+    context 'when validating that both cleaning services are not present' do
+      let(:service_codes) { %w[I.1 I.4] }
+
+      context 'when the services are only the two cleaning services' do
+        it 'is not valid and has the correct error message' do
+          expect(procurement_building.valid?(:buildings_and_services)).to be false
+          expect(procurement_building.errors[:service_codes].first).to eq "'Mobile cleaning' and 'Routine cleaning' are the same, but differ by delivery method. Please choose one of these services only"
+        end
+      end
+
+      context 'when the services are only the two cleaning services plus another service' do
+        before { procurement_building.service_codes << 'E.1' }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement_building.valid?(:buildings_and_services)).to be false
+          expect(procurement_building.errors[:service_codes].first).to eq "'Mobile cleaning' and 'Routine cleaning' are the same, but differ by delivery method. Please choose one of these services only"
+        end
+      end
+    end
+
+    # rubocop:disable RSpec/NestedGroups
+    context 'when validating that not all services are mandatory' do
+      context 'when the only code is Q.3' do
+        let(:service_codes) { %w[Q.3] }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement_building.valid?(:buildings_and_services)).to be false
+          expect(procurement_building.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { procurement_building.service_codes << 'H.1' }
+
+          it 'will be valid' do
+            expect(procurement_building.valid?(:buildings_and_services)).to be true
+          end
+        end
+      end
+
+      context 'when the only code is R.1' do
+        let(:service_codes) { %w[R.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement_building.valid?(:buildings_and_services)).to be false
+          expect(procurement_building.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { procurement_building.service_codes << 'J.1' }
+
+          it 'will be valid' do
+            expect(procurement_building.valid?(:buildings_and_services)).to be true
+          end
+        end
+      end
+
+      context 'when the only code is S.1' do
+        let(:service_codes) { %w[S.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement_building.valid?(:buildings_and_services)).to be false
+          expect(procurement_building.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { procurement_building.service_codes << 'K.1' }
+
+          it 'will be valid' do
+            expect(procurement_building.valid?(:buildings_and_services)).to be true
+          end
+        end
+      end
+
+      context 'when the only codes are Q.3 and R.1' do
+        let(:service_codes) { %w[Q.3 R.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement_building.valid?(:buildings_and_services)).to be false
+          expect(procurement_building.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { procurement_building.service_codes << 'L.1' }
+
+          it 'will be valid' do
+            expect(procurement_building.valid?(:buildings_and_services)).to be true
+          end
+        end
+      end
+
+      context 'when the only codes are Q.3 and S.1' do
+        let(:service_codes) { %w[Q.3 S.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement_building.valid?(:buildings_and_services)).to be false
+          expect(procurement_building.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { procurement_building.service_codes << 'M.1' }
+
+          it 'will be valid' do
+            expect(procurement_building.valid?(:buildings_and_services)).to be true
+          end
+        end
+      end
+
+      context 'when the only codes are S.1 and R.1' do
+        let(:service_codes) { %w[S.1 R.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement_building.valid?(:buildings_and_services)).to be false
+          expect(procurement_building.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { procurement_building.service_codes << 'J.2' }
+
+          it 'will be valid' do
+            expect(procurement_building.valid?(:buildings_and_services)).to be true
+          end
+        end
+      end
+
+      context 'when the only codes are Q.3, S.1 and R.1' do
+        let(:service_codes) { %w[Q.3 S.1 R.1] }
+
+        it 'is not valid and has the correct error message' do
+          expect(procurement_building.valid?(:buildings_and_services)).to be false
+          expect(procurement_building.errors[:service_codes].first).to eq "You must select another service to include 'CAFM system', 'Helpdesk services' and/or 'Management of billable works'"
+        end
+
+        context 'when another service is included as well' do
+          before { procurement_building.service_codes << 'K.2' }
+
+          it 'will be valid' do
+            expect(procurement_building.valid?(:buildings_and_services)).to be true
+          end
+        end
+      end
+    end
+    # rubocop:enable RSpec/NestedGroups
+
+    context 'when the service selection is valid' do
+      let(:service_codes) { %w[E.1 I.1 S.1] }
+
+      it 'will be valid' do
+        expect(procurement_building.valid?(:buildings_and_services)).to be true
+      end
+    end
+  end
+
+  describe '.service_selection_complete?' do
+    context 'when there are no service codes' do
+      let(:service_codes) { [] }
+
+      it 'returns false' do
+        expect(procurement_building.service_selection_complete?).to eq false
+      end
+    end
+
+    context 'when the selection is invalid' do
+      let(:service_codes) { %w[Q.3 R.1 S.1] }
+
+      it 'returns false' do
+        expect(procurement_building.service_selection_complete?).to eq false
+      end
+    end
+
+    context 'when the slection is valid' do
+      let(:service_codes) { %w[Q.3 R.1 S.1 E.1] }
+
+      it 'returns true' do
+        expect(procurement_building.service_selection_complete?).to eq true
+      end
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/procurement_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_spec.rb
@@ -618,7 +618,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
     context 'when both buildings have a valid selection' do
       let(:service_codes) { %w[Q.3 R.1 S.1 E.1] }
 
-      pending 'returns true' do
+      it 'returns true' do
         expect(procurement.buildings_and_services_completed?).to eq true
       end
     end
@@ -663,7 +663,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
           procurement_building2.update(service_codes: ['F.1', 'G.4', 'R.1'])
         end
 
-        pending 'shown with the COMPLETED status label' do
+        it 'shown with the COMPLETED status label' do
           expect(status).to eq(:completed)
         end
       end

--- a/spec/models/facilities_management/rm6232/procurement_validations_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_validations_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
       end
 
       # rubocop:disable RSpec/NestedGroups
-      context 'when validateing that not all services are mandatory' do
+      context 'when validating that not all services are mandatory' do
         context 'when the only code is Q.3' do
           let(:service_codes) { %w[Q.3] }
 


### PR DESCRIPTION
Add the ability to add services to a building in a procurement. This includes the validation of the service selection which should match the validation in the previous framework.

I also added the method to check the service selection so that part is complete. In the next PR I will add the code to make sure all the statuses are complete before continuing from the further service requirements page.

As well as adding some more specs, I also added some feature tests and some accessibility tests for the ‘Assigning services to buildings’ section. I also moved some of the step definitions about to make sure any that are shared between frameworks are in a neutral file.