### PR TITLE
FMFR-1241 - Update annual contract value pages

### DIFF
--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -6,10 +6,10 @@ en:
         facilities_management/rm6232/journey/annual_contract_value:
           attributes:
             annual_contract_value:
-              greater_than: The annual contract value must be a whole number greater than 0
-              less_than: The annual contract value must be less than 1,000,000,000,000 (1 trillion)
-              not_a_number: The annual contract value must be a whole number greater than 0
-              not_an_integer: The annual contract value must be a whole number greater than 0
+              greater_than: The annual contract cost must be a whole number greater than 0
+              less_than: The annual contract cost must be less than 1,000,000,000,000 (1 trillion)
+              not_a_number: The annual contract cost must be a whole number greater than 0
+              not_an_integer: The annual contract cost must be a whole number greater than 0
         facilities_management/rm6232/journey/choose_locations:
           attributes:
             region_codes:
@@ -63,10 +63,10 @@ en:
         facilities_management/rm6232/procurement:
           attributes:
             annual_contract_value:
-              greater_than: The annual contract value must be a whole number greater than 0
-              less_than: The annual contract value must be less than 1,000,000,000,000 (1 trillion)
-              not_a_number: The annual contract value must be a whole number greater than 0
-              not_an_integer: The annual contract value must be a whole number greater than 0
+              greater_than: The annual contract cost must be a whole number greater than 0
+              less_than: The annual contract cost must be less than 1,000,000,000,000 (1 trillion)
+              not_a_number: The annual contract cost must be a whole number greater than 0
+              not_an_integer: The annual contract cost must be a whole number greater than 0
             base:
               buildings_and_services_incomplete: "‘Assigning services to buildings’ must be ‘COMPLETED’"
               buildings_incomplete: "‘Buildings’ must be ‘COMPLETED’"
@@ -229,10 +229,10 @@ en:
           youneedtoknow: 'You need to know:'
       journey:
         annual_contract_value:
-          heading: Annual contract value
-          question: What is your estimate for the annual contract value?
+          heading: Annual contract cost
+          question: What is your estimate for the annual contract cost?
           return_text: Return to your account
-          subtitle: Enter your estimate for the annual contract value. Include everything in your calculation.
+          subtitle: Enter your estimated annual cost of the call off contract (including any potential billable works that you may put through the contract).
         choose_locations:
           heading: Regions
           more_information:
@@ -297,10 +297,10 @@ en:
           change: Change
           contract_name_hint: Enter a name or reference to save this search. You will then be able to download your shortlist.
           contract_name_label: Save your search
-          estimated_annual_contract_value: Estimated annual contract value
+          estimated_annual_contract_value: Estimated annual contract cost
           heading: Results
           regions: Regions
-          return_to_contract_cost: Return to annual contract value
+          return_to_contract_cost: Return to annual contract cost
           return_to_dashboard: Return to your account
           save_and_continue: Save and continue
           save_and_return: Save and return to procurements dashboard

--- a/features/.cut_pages/accessibility/facilities_management/rm6232/procurements/entering_requirements/contract_details/annual_contract_value_accessibility.feature
+++ b/features/.cut_pages/accessibility/facilities_management/rm6232/procurements/entering_requirements/contract_details/annual_contract_value_accessibility.feature
@@ -1,11 +1,11 @@
 @accessibility @javascript
-Feature: Annual contract value accessibility
+Feature: Annual contract cost accessibility
 
-  Scenario: Annual contract value page
+  Scenario: Annual contract cost page
     Given I sign in and navigate to my account for 'RM6232'
     And I have an empty procurement for entering requirements named 'My empty procurement'
     When I navigate to the procurement 'My empty procurement'
     Then I am on the 'Further service and contract requirements' page
-    And I click on 'Annual contract value'
-    And I am on the 'Annual contract value' page
+    And I click on 'Annual contract cost'
+    And I am on the 'Annual contract cost' page
     Then the page should be axe clean

--- a/features/.cut_pages/facilities_management/rm6232/procurements/entering_requirements/contract_details/annual_contract_value.feature
+++ b/features/.cut_pages/facilities_management/rm6232/procurements/entering_requirements/contract_details/annual_contract_value.feature
@@ -1,25 +1,25 @@
-Feature: Annual contract value
+Feature: Annual contract cost
 
-  Background: Navigate to the annual contract value page
+  Background: Navigate to the annual contract cost page
     Given I sign in and navigate to my account for 'RM6232'
     And I have an empty procurement for entering requirements named 'My empty procurement'
     When I navigate to the procurement 'My empty procurement'
     Then I am on the 'Further service and contract requirements' page
-    And I click on 'Annual contract value'
-    And I am on the 'Annual contract value' page
+    And I click on 'Annual contract cost'
+    And I am on the 'Annual contract cost' page
 
   Scenario: The value is saved
-    And I enter '123456' for annual contract value
+    And I enter '123456' for annual contract cost
     And I click on 'Save and return'
     Then I am on the 'Further service and contract requirements' page
-    And 'Annual contract value' should have the status 'COMPLETED' in 'Contract details'
+    And 'Annual contract cost' should have the status 'COMPLETED' in 'Contract details'
 
   Scenario: The return links work
     Given I click on the 'Return to requirements' return link
     Then I am on the 'Further service and contract requirements' page
-    And 'Annual contract value' should have the status 'COMPLETED' in 'Contract details'
-    Then I click on 'Annual contract value'
-    And I am on the 'Annual contract value' page
+    And 'Annual contract cost' should have the status 'COMPLETED' in 'Contract details'
+    Then I click on 'Annual contract cost'
+    And I am on the 'Annual contract cost' page
     Given I click on 'Return to requirements'
     Then I am on the 'Further service and contract requirements' page
-    And 'Annual contract value' should have the status 'COMPLETED' in 'Contract details'
+    And 'Annual contract cost' should have the status 'COMPLETED' in 'Contract details'

--- a/features/.cut_pages/facilities_management/rm6232/procurements/entering_requirements/contract_details/validations/annual_contract_value_validations.feature
+++ b/features/.cut_pages/facilities_management/rm6232/procurements/entering_requirements/contract_details/validations/annual_contract_value_validations.feature
@@ -1,22 +1,22 @@
 @pipeline
-Feature: Annual contract value validations
+Feature: Annual contract cost validations
 
   Scenario Outline: Validations on the input
     Given I sign in and navigate to my account for 'RM6232'
     And I have an empty procurement for entering requirements named 'My empty procurement'
     When I navigate to the procurement 'My empty procurement'
     Then I am on the 'Further service and contract requirements' page
-    And I click on 'Annual contract value'
-    And I am on the 'Annual contract value' page
-    And I enter '<annual_contract_value>' for annual contract value
+    And I click on 'Annual contract cost'
+    And I am on the 'Annual contract cost' page
+    And I enter '<annual_contract_value>' for annual contract cost
     And I click on 'Save and return'
     Then I should see the following error messages:
       | <error_message> |
 
     Examples:
-      | annual_contract_value | error_message                                                               |
-      |                       | The annual contract value must be a whole number greater than 0             |
-      | text                  | The annual contract value must be a whole number greater than 0             |
-      | 0                     | The annual contract value must be a whole number greater than 0             |
-      | 1000000000000         | The annual contract value must be less than 1,000,000,000,000 (1 trillion)  |
-      | 56.9                  | The annual contract value must be a whole number greater than 0             |
+      | annual_contract_value | error_message                                                             |
+      |                       | The annual contract cost must be a whole number greater than 0            |
+      | text                  | The annual contract cost must be a whole number greater than 0            |
+      | 0                     | The annual contract cost must be a whole number greater than 0            |
+      | 1000000000000         | The annual contract cost must be less than 1,000,000,000,000 (1 trillion) |
+      | 56.9                  | The annual contract cost must be a whole number greater than 0            |

--- a/features/.cut_pages/facilities_management/rm6232/procurements/results/results_are_correct.feature
+++ b/features/.cut_pages/facilities_management/rm6232/procurements/results/results_are_correct.feature
@@ -17,8 +17,8 @@ Feature: Information appears correctly on results page
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '123456' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '123456' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '2a'
@@ -74,12 +74,12 @@ Feature: Information appears correctly on results page
     And 'Buildings' should have the status 'COMPLETED' in 'Services and buildings'
 
   Scenario Outline: I select total services
-    And I click on 'Annual contract value'
-    And I am on the 'Annual contract value' page
-    And I enter '<annual_contract_value>' for annual contract value
+    And I click on 'Annual contract cost'
+    And I am on the 'Annual contract cost' page
+    And I enter '<annual_contract_value>' for annual contract cost
     And I click on 'Save and return'
     Then I am on the 'Further service and contract requirements' page
-    And 'Annual contract value' should have the status 'COMPLETED' in 'Contract details'
+    And 'Annual contract cost' should have the status 'COMPLETED' in 'Contract details'
     And I click on 'Assigning services to buildings'
     Then I am on the 'Assigning services to buildings summary' page
     Given I click on 'Test building' 
@@ -131,12 +131,12 @@ Feature: Information appears correctly on results page
 
   @pipeline
   Scenario Outline: I select hard services
-    And I click on 'Annual contract value'
-    And I am on the 'Annual contract value' page
-    And I enter '<annual_contract_value>' for annual contract value
+    And I click on 'Annual contract cost'
+    And I am on the 'Annual contract cost' page
+    And I enter '<annual_contract_value>' for annual contract cost
     And I click on 'Save and return'
     Then I am on the 'Further service and contract requirements' page
-    And 'Annual contract value' should have the status 'COMPLETED' in 'Contract details'
+    And 'Annual contract cost' should have the status 'COMPLETED' in 'Contract details'
     And I click on 'Assigning services to buildings'
     Then I am on the 'Assigning services to buildings summary' page
     Given I click on 'Test building' 
@@ -182,12 +182,12 @@ Feature: Information appears correctly on results page
       | 50000000              | c           | 13                  |
 
   Scenario Outline: I select soft services
-    And I click on 'Annual contract value'
-    And I am on the 'Annual contract value' page
-    And I enter '<annual_contract_value>' for annual contract value
+    And I click on 'Annual contract cost'
+    And I am on the 'Annual contract cost' page
+    And I enter '<annual_contract_value>' for annual contract cost
     And I click on 'Save and return'
     Then I am on the 'Further service and contract requirements' page
-    And 'Annual contract value' should have the status 'COMPLETED' in 'Contract details'
+    And 'Annual contract cost' should have the status 'COMPLETED' in 'Contract details'
     And I click on 'Assigning services to buildings'
     Then I am on the 'Assigning services to buildings summary' page
     Given I click on 'Test building' 

--- a/features/.cut_pages/facilities_management/rm6232/quick_view/results.feature
+++ b/features/.cut_pages/facilities_management/rm6232/quick_view/results.feature
@@ -16,8 +16,8 @@ Feature: Information appears correctly on results page
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '123456' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '123456' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '2a'
@@ -28,7 +28,7 @@ Feature: Information appears correctly on results page
     And I should see the following 'regions' in the selection summary:
       | Tees Valley and Durham  |
       | Essex                   |
-    And I should see the following 'annual contract value' in the selection summary:
+    And I should see the following 'annual contract cost' in the selection summary:
       | £123,456  |
 
   @pipeline 
@@ -40,7 +40,7 @@ Feature: Information appears correctly on results page
     Then I am on the 'Further service and contract requirements' page
     And the procurement name is shown to be 'Mechonis field contract'
     And 'Contract name' should have the status 'COMPLETED' in 'Contract details'
-    And 'Annual contract value' should have the status 'COMPLETED' in 'Contract details'
+    And 'Annual contract cost' should have the status 'COMPLETED' in 'Contract details'
     And 'Services' should have the status 'Completed' in 'Services and buildings'
     And I click on 'Services'
     Then I am on the 'Services summary' page

--- a/features/accessibility/facilities_management/rm6232/quick_view/quick_view_accessibility.feature
+++ b/features/accessibility/facilities_management/rm6232/quick_view/quick_view_accessibility.feature
@@ -28,7 +28,7 @@ Feature: Results accessibility
     And I show all sections
     Then the page should be axe clean
 
-  Scenario: Annual contract value page
+  Scenario: Annual contract cost page
     And I click on 'Continue'
     Then I am on the 'Services' page
     And I show all sections
@@ -43,7 +43,7 @@ Feature: Results accessibility
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
+    Then I am on the 'Annual contract cost' page
     Then the page should be axe clean
 
   Scenario: Restuls page
@@ -61,8 +61,8 @@ Feature: Results accessibility
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '123456' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '123456' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     Then the page should be axe clean

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_details/supplier_name.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_details/supplier_name.feature
@@ -18,7 +18,7 @@ Feature: Supplier name
 
   @pipline
   Scenario Outline: Change supplier name changes in results
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | E.2  | UKE2  | 123456 |
       | O.1  | UKE4  |        |
     And I 'should' see the supplier '<supplier_name>' in the results
@@ -32,7 +32,7 @@ Feature: Supplier name
     And I enter 'New supplier' into the 'Supplier name' field
     And I click on 'Save and return'
     Then I am on the 'Supplier details' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | E.2  | UKE2  | 123456 |
       | O.1  | UKE4  |        |
     Then I 'should not' see the supplier '<supplier_name>' in the results 

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_details/supplier_status.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_details/supplier_status.feature
@@ -19,7 +19,7 @@ Feature: Supplier status
 
   @pipline
   Scenario Outline: Change supplier status removes it from the results
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | F.2  | UKH3  | 654321 |
       | L.1  | UKK1  |        |
     And I 'should' see the supplier '<supplier_name>' in the results
@@ -33,7 +33,7 @@ Feature: Supplier status
     And I select 'INACTIVE' for the supplier status
     And I click on 'Save and return'
     Then I am on the 'Supplier details' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | F.2  | UKH3  | 654321 |
       | L.1  | UKK1  |        |
     Then I 'should not' see the supplier '<supplier_name>' in the results 

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/quick_view/region_selection_adding.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/quick_view/region_selection_adding.feature
@@ -4,7 +4,7 @@ Feature: Adding regions for suppliers on the admin tool and seeing the effect on
     Given I sign in as an admin and navigate to the 'RM6232' dashboard
 
   Scenario Outline: Total services - region selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | E.16  | UKC1  | <contract_value>  |
       | M.3   | UKG1  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -20,7 +20,7 @@ Feature: Adding regions for suppliers on the admin tool and seeing the effect on
       | Herefordshire, Worcestershire and Warwickshire  |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | E.16  | UKC1  | <contract_value>  |
       | M.3   | UKG1  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -33,7 +33,7 @@ Feature: Adding regions for suppliers on the admin tool and seeing the effect on
       | 11000000        | 1c          | Swift, Friesen and Predovic   |
 
   Scenario Outline: Hard services - region selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | E.6 | UKD1  | <contract_value>  |
       | F.2 | UKE2  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -49,7 +49,7 @@ Feature: Adding regions for suppliers on the admin tool and seeing the effect on
       | North Yorkshire |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | E.6 | UKE2  | <contract_value>  |
       | F.2 | UKE2  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -63,7 +63,7 @@ Feature: Adding regions for suppliers on the admin tool and seeing the effect on
 
   @pipeline
   Scenario Outline: Soft services - region selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | G.6 | UKG2  | <contract_value>  |
       | J.1 | UKD6  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -79,7 +79,7 @@ Feature: Adding regions for suppliers on the admin tool and seeing the effect on
       | Cheshire  |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | G.6 | UKG2  | <contract_value>  |
       | J.1 | UKD6  |                   |
     Then I should be in sub-lot '<lot_number>'

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/quick_view/region_selection_removing.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/quick_view/region_selection_removing.feature
@@ -4,7 +4,7 @@ Feature: Removing regions for suppliers on the admin tool and seeing the effect 
     Given I sign in as an admin and navigate to the 'RM6232' dashboard
 
   Scenario Outline: Total services - region selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | F.1  | UKH1  | <contract_value>  |
       | K.1  | UKH2  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -20,7 +20,7 @@ Feature: Removing regions for suppliers on the admin tool and seeing the effect 
       | Bedfordshire and Hertfordshire  |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | F.1  | UKH1  | <contract_value>  |
       | K.1  | UKH2  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -35,7 +35,7 @@ Feature: Removing regions for suppliers on the admin tool and seeing the effect 
 
   @pipeline
   Scenario Outline: Hard services - region selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | F.2  | UKL18  | <contract_value>  |
       | N.10 | UKL24  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -51,7 +51,7 @@ Feature: Removing regions for suppliers on the admin tool and seeing the effect 
       | Powys  |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | F.2  | UKL18  | <contract_value>  |
       | N.10 | UKL24  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -64,7 +64,7 @@ Feature: Removing regions for suppliers on the admin tool and seeing the effect 
       | 11000000        | 2c          | Breitenberg-Mante         |
 
   Scenario Outline: Soft services - region selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | H.1  | UKH3  | <contract_value>  |
       | I.5  | UKK4  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -80,7 +80,7 @@ Feature: Removing regions for suppliers on the admin tool and seeing the effect 
       | Devon  |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | H.1  | UKH3  | <contract_value>  |
       | I.5  | UKK4  |                   |
     Then I should be in sub-lot '<lot_number>'

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/quick_view/service_selection_adding.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/quick_view/service_selection_adding.feature
@@ -5,7 +5,7 @@ Feature: Adding services for suppliers on the admin tool and seeing the effect o
 
   @pipeline
   Scenario Outline: Total services - service selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | E.2  | UKE2  | <contract_value> |
       | O.1  | UKE4  |                  |
     Then I should be in sub-lot '<lot_number>'
@@ -21,7 +21,7 @@ Feature: Adding services for suppliers on the admin tool and seeing the effect o
       | End-User Accommodation Services  |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | E.2  | UKE2  | <contract_value>  |
       | O.1  | UKE4  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -34,7 +34,7 @@ Feature: Adding services for suppliers on the admin tool and seeing the effect o
       | 11000000        | 1c          | Schultz-Wilkinson             |
 
   Scenario Outline: Hard services - service selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | E.6  | UKD1  | <contract_value>  |
       | E.9  | UKI3  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -50,7 +50,7 @@ Feature: Adding services for suppliers on the admin tool and seeing the effect o
       | Planned / Group re-lamping service  |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | E.6  | UKD1  | <contract_value>  |
       | E.9  | UKI3  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -63,7 +63,7 @@ Feature: Adding services for suppliers on the admin tool and seeing the effect o
       | 11000000        | 2c          | Berge-Koepp             |
 
   Scenario Outline: Soft services - service selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | I.2  | UKD1  | <contract_value> |
       | G.3  | UKI3  |                  |
     Then I should be in sub-lot '<lot_number>'
@@ -79,7 +79,7 @@ Feature: Adding services for suppliers on the admin tool and seeing the effect o
       | Tree Surgery (Arboriculture)  |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | I.2  | UKD1  | <contract_value>  |
       | G.3  | UKI3  |                   |
     Then I should be in sub-lot '<lot_number>'

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/quick_view/service_selection_removing.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/quick_view/service_selection_removing.feature
@@ -4,7 +4,7 @@ Feature: Removing services for suppliers on the admin tool and seeing the effect
     Given I sign in as an admin and navigate to the 'RM6232' dashboard
 
   Scenario Outline: Total services - service selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | F.1  | UKH1  | <contract_value>  |
       | K.2  | UKH2  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -20,7 +20,7 @@ Feature: Removing services for suppliers on the admin tool and seeing the effect
       | Taxi booking Service  |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | F.1  | UKH1  | <contract_value>  |
       | K.2  | UKH2  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -34,7 +34,7 @@ Feature: Removing services for suppliers on the admin tool and seeing the effect
 
   @pipeline
   Scenario Outline: Hard services - service selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | F.2   | UKL18 | <contract_value>  |
       | N.10  | UKL24 |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -50,7 +50,7 @@ Feature: Removing services for suppliers on the admin tool and seeing the effect
       | Housing and residential accommodation management  |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | F.2  | UKL18  | <contract_value>  |
       | N.10  | UKL24  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -63,7 +63,7 @@ Feature: Removing services for suppliers on the admin tool and seeing the effect
       | 11000000        | 2c          | Berge-Koepp                 |
 
   Scenario Outline: Soft services - service selection
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | H.2  | UKH3  | <contract_value>  |
       | I.9  | UKK4  |                   |
     Then I should be in sub-lot '<lot_number>'
@@ -79,7 +79,7 @@ Feature: Removing services for suppliers on the admin tool and seeing the effect
       | Cleaning of communications and equipment rooms  |
     And I click on 'Save and return'
     Then I am on the 'View lot data' page
-    Given I go to a quick view with the following services, regions and annual contract value:
+    Given I go to a quick view with the following services, regions and annual contract cost:
       | H.2  | UKH3  | <contract_value>  |
       | I.9  | UKK4  |                   |
     Then I should be in sub-lot '<lot_number>'

--- a/features/facilities_management/rm6232/quick_view/lot_selection.feature
+++ b/features/facilities_management/rm6232/quick_view/lot_selection.feature
@@ -1,4 +1,4 @@
-Feature: Service and selection and annual contract value result in correct sub lot
+Feature: Service and selection and annual contract cost result in correct sub lot
 
   Background: Navigate to the services page
     Given I sign in and navigate to my account for 'RM6232'
@@ -19,8 +19,8 @@ Feature: Service and selection and annual contract value result in correct sub l
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '<estimated_annual_cost>' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '<estimated_annual_cost>' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '<sublot>'
@@ -43,8 +43,8 @@ Feature: Service and selection and annual contract value result in correct sub l
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '<estimated_annual_cost>' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '<estimated_annual_cost>' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '<sublot>'
@@ -67,8 +67,8 @@ Feature: Service and selection and annual contract value result in correct sub l
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '<estimated_annual_cost>' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '<estimated_annual_cost>' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '<sublot>'
@@ -91,8 +91,8 @@ Feature: Service and selection and annual contract value result in correct sub l
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '<estimated_annual_cost>' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '<estimated_annual_cost>' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '<sublot>'
@@ -116,8 +116,8 @@ Feature: Service and selection and annual contract value result in correct sub l
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '<estimated_annual_cost>' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '<estimated_annual_cost>' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '<sublot>'
@@ -140,8 +140,8 @@ Feature: Service and selection and annual contract value result in correct sub l
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '<estimated_annual_cost>' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '<estimated_annual_cost>' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '<sublot>'
@@ -165,8 +165,8 @@ Feature: Service and selection and annual contract value result in correct sub l
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '<estimated_annual_cost>' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '<estimated_annual_cost>' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '<sublot>'
@@ -188,8 +188,8 @@ Feature: Service and selection and annual contract value result in correct sub l
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '<estimated_annual_cost>' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '<estimated_annual_cost>' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '<sublot>'
@@ -212,8 +212,8 @@ Feature: Service and selection and annual contract value result in correct sub l
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '<estimated_annual_cost>' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '<estimated_annual_cost>' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '<sublot>'
@@ -239,8 +239,8 @@ Feature: Service and selection and annual contract value result in correct sub l
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '<estimated_annual_cost>' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '<estimated_annual_cost>' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '<sublot>'

--- a/features/facilities_management/rm6232/quick_view/results.feature
+++ b/features/facilities_management/rm6232/quick_view/results.feature
@@ -16,8 +16,8 @@ Feature: Information appears correctly on results page
       | Tees Valley and Durham  |
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '123456' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '123456' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '2a'
@@ -28,7 +28,7 @@ Feature: Information appears correctly on results page
     And I should see the following 'regions' in the selection summary:
       | Tees Valley and Durham  |
       | Essex                   |
-    And I should see the following 'annual contract value' in the selection summary:
+    And I should see the following 'annual contract cost' in the selection summary:
       | £123,456  |
 
   @pipline
@@ -41,7 +41,7 @@ Feature: Information appears correctly on results page
     And I click on 'Continue'
     Then I am on the 'Regions' page
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
+    Then I am on the 'Annual contract cost' page
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '1a'
@@ -58,7 +58,7 @@ Feature: Information appears correctly on results page
       | Tees Valley and Durham  |
     And I select 'Gloucestershire, Wiltshire and Bristol/Bath area'
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
+    Then I am on the 'Annual contract cost' page
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '2a'
@@ -67,14 +67,14 @@ Feature: Information appears correctly on results page
       | Gloucestershire, Wiltshire and Bristol/Bath area  |
 
   @pipline
-  Scenario: I can change the annual contract value from the results page
-    Given I change the 'annual contract value' from the selection summary
-    Then I am on the 'Annual contract value' page
-    And I enter '123456789' for the annual contract value
+  Scenario: I can change the annual contract cost from the results page
+    Given I change the 'annual contract cost' from the selection summary
+    Then I am on the 'Annual contract cost' page
+    And I enter '123456789' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
     And I should be in sub-lot '2c'
-    And I should see the following 'annual contract value' in the selection summary:
+    And I should see the following 'annual contract cost' in the selection summary:
       | £123,456,789  |
 
   Scenario: Save and return goes to the dashboard

--- a/features/facilities_management/rm6232/quick_view/select_regions.feature
+++ b/features/facilities_management/rm6232/quick_view/select_regions.feature
@@ -98,7 +98,7 @@ Feature: Select regions
       | Inner London - East         |
       | East Lothian and Midlothian |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
+    Then I am on the 'Annual contract cost' page
     And I click on the 'Return to regions' back link
     Then I am on the 'Regions' page
     And the following items should appear in the basket:

--- a/features/facilities_management/rm6232/quick_view/validations/annual_contract_value_validations.feature
+++ b/features/facilities_management/rm6232/quick_view/validations/annual_contract_value_validations.feature
@@ -1,7 +1,7 @@
 @pipeline
-Feature: Annual contract value validations
+Feature: Annual contract cost validations
   
-  Scenario Outline: validations for the annual contract value
+  Scenario Outline: validations for the annual contract cost
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
     Then I am on the 'Start a procurement' page
@@ -14,16 +14,16 @@ Feature: Annual contract value validations
     Then I select the following items:
       | Tees Valley and Durham  |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '<value>' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '<value>' for the annual contract cost
     And I click on 'Continue'
     Then I should see the following error messages:
       | <error_message> |
 
     Examples:
-      | value         | error_message                                                               |
-      |               | The annual contract value must be a whole number greater than 0             |
-      | 0             | The annual contract value must be a whole number greater than 0             |
-      | 1000000000000 | The annual contract value must be less than 1,000,000,000,000 (1 trillion)  |
-      | 67.4          | The annual contract value must be a whole number greater than 0             |
-      | Big int       | The annual contract value must be a whole number greater than 0             |
+      | value         | error_message                                                             |
+      |               | The annual contract cost must be a whole number greater than 0            |
+      | 0             | The annual contract cost must be a whole number greater than 0            |
+      | 1000000000000 | The annual contract cost must be less than 1,000,000,000,000 (1 trillion) |
+      | 67.4          | The annual contract cost must be a whole number greater than 0            |
+      | Big int       | The annual contract cost must be a whole number greater than 0            |

--- a/features/facilities_management/rm6232/quick_view/validations/results_validations.feature
+++ b/features/facilities_management/rm6232/quick_view/validations/results_validations.feature
@@ -14,8 +14,8 @@ Feature: Results validations
     Then I select the following items:
       | Essex                   |
     And I click on 'Continue'
-    Then I am on the 'Annual contract value' page
-    And I enter '123456' for the annual contract value
+    Then I am on the 'Annual contract cost' page
+    And I enter '123456' for the annual contract cost
     And I click on 'Continue'
     Then I am on the 'Results' page
 

--- a/features/step_definitions/facilities_management/rm6232/admin_steps.rb
+++ b/features/step_definitions/facilities_management/rm6232/admin_steps.rb
@@ -77,7 +77,7 @@ Then('I select {string} for the supplier status') do |option|
   end
 end
 
-Given('I go to a quick view with the following services, regions and annual contract value:') do |quick_view_data|
+Given('I go to a quick view with the following services, regions and annual contract cost:') do |quick_view_data|
   service_codes = quick_view_data.transpose.raw[0].reject(&:blank?)
   region_codes = quick_view_data.transpose.raw[1].reject(&:blank?)
   annual_cost = quick_view_data.transpose.raw[2].first

--- a/features/step_definitions/facilities_management/rm6232/entering_requirements_steps.rb
+++ b/features/step_definitions/facilities_management/rm6232/entering_requirements_steps.rb
@@ -1,3 +1,3 @@
-Then('I enter {string} for annual contract value') do |annual_contract_value|
+Then('I enter {string} for annual contract cost') do |annual_contract_value|
   entering_requirements_page.annual_contract_value.set(annual_contract_value)
 end

--- a/features/step_definitions/facilities_management/rm6232/quick_view_steps.rb
+++ b/features/step_definitions/facilities_management/rm6232/quick_view_steps.rb
@@ -1,4 +1,4 @@
-Then('I enter {string} for the annual contract value') do |value|
+Then('I enter {string} for the annual contract cost') do |value|
   quick_view_page.annual_contract_value.set(value)
 end
 
@@ -12,7 +12,7 @@ Then('I should see the following {string} in the selection summary:') do |option
     quick_view_page.selection_summary.send(option.to_sym).selection.zip(selection_summary_table.raw.flatten).each do |element, expected_value|
       expect(element).to have_content(expected_value)
     end
-  when 'annual contract value'
+  when 'annual contract cost'
     expect(quick_view_page.selection_summary.send(option.to_sym).selection).to have_content(selection_summary_table.raw.flatten.first)
   end
 end

--- a/features/support/pages/rm6232/quick_view.rb
+++ b/features/support/pages/rm6232/quick_view.rb
@@ -15,7 +15,7 @@ module Pages::RM6232
       section :services, SummarySection, 'div.ccs-summary-box:nth-of-type(1)'
       section :regions, SummarySection, 'div.ccs-summary-box:nth-of-type(2)'
 
-      section :'annual contract value', 'div.ccs-summary-box:nth-of-type(3)' do
+      section :'annual contract cost', 'div.ccs-summary-box:nth-of-type(3)' do
         element :selection, '.ccs-summary-box__content'
         element :change, 'a'
       end

--- a/spec/controllers/facilities_management/rm6232/procurement_details_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/procurement_details_controller_spec.rb
@@ -190,7 +190,7 @@
 #       end
 #     end
 
-#     context 'when the user wants to edit the annual contract value' do
+#     context 'when the user wants to edit the annual contract cost' do
 #       let(:section_name) { 'annual-contract-value' }
 
 #       render_views
@@ -394,7 +394,7 @@
 #       end
 #     end
 
-#     context 'when updating the annual contract value' do
+#     context 'when updating the annual contract cost' do
 #       let(:section_name) { 'annual-contract-value' }
 
 #       context 'and the data is valid' do
@@ -404,7 +404,7 @@
 #           expect(response).to redirect_to facilities_management_rm6232_procurement_path(procurement)
 #         end
 
-#         it 'updates the annual contract value' do
+#         it 'updates the annual contract cost' do
 #           expect { procurement.reload }.to change(procurement, :annual_contract_value)
 
 #           expect(procurement.annual_contract_value).to eq(567_890)
@@ -418,7 +418,7 @@
 #           expect(response).to render_template(:edit)
 #         end
 
-#         it 'does not update the annual contract value' do
+#         it 'does not update the annual contract cost' do
 #           expect { procurement.reload }.not_to change(procurement, :annual_contract_value)
 #         end
 #       end

--- a/spec/controllers/facilities_management/rm6232/procurements_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/procurements_controller_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementsController, type: :cont
 
     it 'sets the back path and text correctly' do
       expect(assigns(:back_path)).to eq '/facilities-management/RM6232/annual-contract-value?annual_contract_value=123456&region_codes%5B%5D=UKC1&service_codes%5B%5D=E.1'
-      expect(assigns(:back_text)).to eq 'Return to annual contract value'
+      expect(assigns(:back_text)).to eq 'Return to annual contract cost'
     end
 
     it 'sets the suppliers' do
@@ -190,7 +190,7 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementsController, type: :cont
 
       it 'sets the back path and text correctly' do
         expect(assigns(:back_path)).to eq '/facilities-management/RM6232/annual-contract-value?annual_contract_value=123456&region_codes%5B%5D=UKC1&service_codes%5B%5D=E.1'
-        expect(assigns(:back_text)).to eq 'Return to annual contract value'
+        expect(assigns(:back_text)).to eq 'Return to annual contract cost'
       end
 
       it 'sets the suppliers' do

--- a/spec/helpers/facilities_management/rm6232/procurements_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm6232/procurements_helper_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementsHelper, type: :helper d
         end
       end
 
-      context 'when the annual contract value is nil' do
+      context 'when the annual contract cost is nil' do
         let(:annual_contract_value) { nil }
 
-        it 'returns the correct URL without the annual contract value' do
+        it 'returns the correct URL without the annual contract cost' do
           expect(result).to eq '/facilities-management/RM6232/choose-services?region_codes%5B%5D=UKI3&region_codes%5B%5D=UKI4&service_codes%5B%5D=E.1&service_codes%5B%5D=F.1&service_codes%5B%5D=G.1'
         end
       end

--- a/spec/models/facilities_management/rm6232/journey/annual_contract_value_spec.rb
+++ b/spec/models/facilities_management/rm6232/journey/annual_contract_value_spec.rb
@@ -5,52 +5,52 @@ RSpec.describe FacilitiesManagement::RM6232::Journey::AnnualContractValue, type:
   let(:estimated_annual_contract_value) { 123_456 }
 
   describe 'validations' do
-    context 'when no annual contract value is present' do
+    context 'when no annual contract cost is present' do
       let(:estimated_annual_contract_value) { nil }
 
       it 'is not valid and has the correct error message' do
         expect(annual_contract_value.valid?).to be false
-        expect(annual_contract_value.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+        expect(annual_contract_value.errors[:annual_contract_value].first).to eq 'The annual contract cost must be a whole number greater than 0'
       end
     end
 
-    context 'when the annual contract value is not a number' do
+    context 'when the annual contract cost is not a number' do
       let(:estimated_annual_contract_value) { 'Morag' }
 
       it 'is not valid and has the correct error message' do
         expect(annual_contract_value.valid?).to be false
-        expect(annual_contract_value.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+        expect(annual_contract_value.errors[:annual_contract_value].first).to eq 'The annual contract cost must be a whole number greater than 0'
       end
     end
 
-    context 'when the annual contract value is not an integer' do
+    context 'when the annual contract cost is not an integer' do
       let(:estimated_annual_contract_value) { 1_000_000.67 }
 
       it 'is not valid and has the correct error message' do
         expect(annual_contract_value.valid?).to be false
-        expect(annual_contract_value.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+        expect(annual_contract_value.errors[:annual_contract_value].first).to eq 'The annual contract cost must be a whole number greater than 0'
       end
     end
 
-    context 'when the annual contract value is less than 1' do
+    context 'when the annual contract cost is less than 1' do
       let(:estimated_annual_contract_value) { 0 }
 
       it 'is not valid and has the correct error message' do
         expect(annual_contract_value.valid?).to be false
-        expect(annual_contract_value.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+        expect(annual_contract_value.errors[:annual_contract_value].first).to eq 'The annual contract cost must be a whole number greater than 0'
       end
     end
 
-    context 'when the annual contract value is more than 999,999,999,999' do
+    context 'when the annual contract cost is more than 999,999,999,999' do
       let(:estimated_annual_contract_value) { 1_000_000_000_000 }
 
       it 'is not valid and has the correct error message' do
         expect(annual_contract_value.valid?).to be false
-        expect(annual_contract_value.errors[:annual_contract_value].first).to eq 'The annual contract value must be less than 1,000,000,000,000 (1 trillion)'
+        expect(annual_contract_value.errors[:annual_contract_value].first).to eq 'The annual contract cost must be less than 1,000,000,000,000 (1 trillion)'
       end
     end
 
-    context 'when annual contract value is present' do
+    context 'when annual contract cost is present' do
       it 'is valid' do
         expect(annual_contract_value.valid?).to be true
       end

--- a/spec/models/facilities_management/rm6232/procurement_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_spec.rb
@@ -588,7 +588,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
 
     let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, annual_contract_value: annual_contract_value) }
 
-    context 'when the annual contract value section has not been completed' do
+    context 'when the annual contract cost section has not been completed' do
       let(:annual_contract_value) { nil }
 
       it 'has a status of not_started' do
@@ -596,7 +596,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
       end
     end
 
-    context 'when the annual contract value section has been completed' do
+    context 'when the annual contract cost section has been completed' do
       let(:annual_contract_value) { 123_456 }
 
       it 'has a status of completed' do

--- a/spec/models/facilities_management/rm6232/procurement_validations_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_validations_spec.rb
@@ -68,52 +68,52 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
     describe 'annual_contract_value' do
       let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, annual_contract_value: annual_contract_value) }
 
-      context 'when no annual contract value is present' do
+      context 'when no annual contract cost is present' do
         let(:annual_contract_value) { nil }
 
         it 'is not valid and has the correct error message' do
           expect(procurement.valid?(:annual_contract_value)).to be false
-          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract cost must be a whole number greater than 0'
         end
       end
 
-      context 'when the annual contract value is not a number' do
+      context 'when the annual contract cost is not a number' do
         let(:annual_contract_value) { 'Camuvari' }
 
         it 'is not valid and has the correct error message' do
           expect(procurement.valid?(:annual_contract_value)).to be false
-          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract cost must be a whole number greater than 0'
         end
       end
 
-      context 'when the annual contract value is not an integer' do
+      context 'when the annual contract cost is not an integer' do
         let(:annual_contract_value) { 1_000_000.67 }
 
         it 'is not valid and has the correct error message' do
           expect(procurement.valid?(:annual_contract_value)).to be false
-          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract cost must be a whole number greater than 0'
         end
       end
 
-      context 'when the annual contract value is less than 1' do
+      context 'when the annual contract cost is less than 1' do
         let(:annual_contract_value) { 0 }
 
         it 'is not valid and has the correct error message' do
           expect(procurement.valid?(:annual_contract_value)).to be false
-          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract value must be a whole number greater than 0'
+          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract cost must be a whole number greater than 0'
         end
       end
 
-      context 'when the annual contract value is more than 999,999,999,999' do
+      context 'when the annual contract cost is more than 999,999,999,999' do
         let(:annual_contract_value) { 1_000_000_000_000 }
 
         it 'is not valid and has the correct error message' do
           expect(procurement.valid?(:annual_contract_value)).to be false
-          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract value must be less than 1,000,000,000,000 (1 trillion)'
+          expect(procurement.errors[:annual_contract_value].first).to eq 'The annual contract cost must be less than 1,000,000,000,000 (1 trillion)'
         end
       end
 
-      context 'when annual contract value is present' do
+      context 'when annual contract cost is present' do
         let(:annual_contract_value) { 123_456 }
 
         it 'is valid' do


### PR DESCRIPTION
Ticket: [FMFR-1241](https://crowncommercialservice.atlassian.net/browse/FMFR-1241)

We are making major changes to the journey by removing everything after the ‘What happens next?’ page.

In this commit I have updated some of the copy on the ‘Annual contract value’ page, changing it to ‘Annual contract cost’ (hence the high number of changes).