### PR TITLE
FMFR-1238 - Update the start a procurement page

### DIFF
--- a/app/controllers/facilities_management/rm6232/buildings_controller.rb
+++ b/app/controllers/facilities_management/rm6232/buildings_controller.rb
@@ -24,7 +24,7 @@ module FacilitiesManagement
       end
 
       def start_a_procurement_path
-        facilities_management_journey_question_path(slug: 'start-a-procurement')
+        facilities_management_journey_question_path(slug: 'start-a-search')
       end
     end
   end

--- a/app/controllers/facilities_management/rm6232/edit_buildings_controller.rb
+++ b/app/controllers/facilities_management/rm6232/edit_buildings_controller.rb
@@ -24,7 +24,7 @@ module FacilitiesManagement
       end
 
       def start_a_procurement_path
-        facilities_management_journey_question_path(slug: 'start-a-procurement')
+        facilities_management_journey_question_path(slug: 'start-a-search')
       end
 
       def set_procurement

--- a/app/models/facilities_management/journey.rb
+++ b/app/models/facilities_management/journey.rb
@@ -27,7 +27,7 @@ module FacilitiesManagement
 
     FIRST_STEP_CLASS = {
       'RM3830' => FacilitiesManagement::RM3830::Journey::ChooseServices,
-      'RM6232' => FacilitiesManagement::RM6232::Journey::StartAProcurement
+      'RM6232' => FacilitiesManagement::RM6232::Journey::StartASearch
     }.freeze
   end
 end

--- a/app/models/facilities_management/rm6232/journey/start_a_search.rb
+++ b/app/models/facilities_management/rm6232/journey/start_a_search.rb
@@ -1,6 +1,6 @@
 module FacilitiesManagement
   module RM6232
-    class Journey::StartAProcurement
+    class Journey::StartASearch
       include Steppable
 
       attribute :service_codes, Array

--- a/app/models/generic_journey.rb
+++ b/app/models/generic_journey.rb
@@ -91,8 +91,8 @@ class GenericJourney
       'choose-locations' => 'Return to services'
     },
     'RM6232' => {
-      'start-a-procurement' => 'Return to your account',
-      'choose-services' => "Return to 'Start a procurement'",
+      'start-a-search' => 'Return to your account',
+      'choose-services' => "Return to 'Search for suppliers'",
       'choose-locations' => 'Return to services',
       'annual-contract-value' => 'Return to regions'
     }

--- a/app/views/facilities_management/rm6232/buyer_account/index.html.erb
+++ b/app/views/facilities_management/rm6232/buyer_account/index.html.erb
@@ -7,7 +7,7 @@
     </div>
   </div>
   <%= ccs_account_panel_row do %>
-    <%= ccs_account_panel(t('.search_for_suppliers_link'), facilities_management_journey_question_path(slug: 'start-a-procurement')) do %>
+    <%= ccs_account_panel(t('.search_for_suppliers_link'), facilities_management_journey_question_path(slug: 'start-a-search')) do %>
       <%= t('.search_for_suppliers_desc') %>
     <% end %>
     <%= ccs_account_panel(t('.view_your_searches_link'), facilities_management_rm6232_procurements_path) do %>

--- a/app/views/facilities_management/rm6232/journey/start_a_search.html.erb
+++ b/app/views/facilities_management/rm6232/journey/start_a_search.html.erb
@@ -63,7 +63,7 @@
           content: [
             {
               type: :paragraph,
-              text: t('.step_3.content.part_1')
+              text: t('.step_3.content')
             },
             {
               type: :list,
@@ -73,39 +73,17 @@
                 },
                 {
                   text: t('.step_3.list.item_2')
-                }
-              ]
-            },
-            {
-              type: :paragraph,
-              text: t('.step_3.content.part_2')
-            },
-          ]
-        },
-        {
-          title: t('.step_4.title'),
-          content: [
-            {
-              type: :paragraph,
-              text: t('.step_4.content.part_1')
-            },
-            {
-              type: :paragraph,
-              text: t('.step_4.content.part_2')
-            },
-            {
-              type: :list,
-              items: [
-                {
-                  text: t('.step_4.list.item_1')
                 },
                 {
-                  text: t('.step_4.list.item_2')
+                  text: t('.step_3.list.item_3')
+                },
+                {
+                  text: t('.step_3.list.item_4')
                 }
               ]
-            },
+            }
           ]
-        },
+        }
       ]
     ) %>
   </div>
@@ -119,7 +97,7 @@
     <% params[:region_codes]&.split(" ") do |region_code| %>
       <%= hidden_field_tag "region_codes[]", region_code %>
     <% end %>
-    <%= hidden_field_tag :annual_contract_value, params[:annual_contract_value] if params[:annual_contract_value] %>  <div class="govuk-grid-row">
+    <%= hidden_field_tag :annual_contract_value, params[:annual_contract_value] if params[:annual_contract_value] %>
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -250,39 +250,31 @@ en:
           learn_more: Further details (opens in a new tab)
           question: Select the facilities management services that you need
           return_text: Return to your account
-        start_a_procurement:
-          heading: Start a procurement
+        start_a_search:
+          heading: Search for suppliers
           return_text: Return to your account
           step_1:
-            content: 'We will first ask you for some basic service and contract information:'
+            content: 'We will first ask you for some basic service, location and cost information:'
             list:
               item_1: which services you want to have provided
               item_2: where your buildings are located
-              item_3: your current annual cost
-            title: Basic Requirements
+              item_3: your estimated annual cost
+            title: Enter basic requirements
           step_2:
-            content: 'You will be shown:'
+            content: 'You will then be shown, and can save/download:'
             list:
-              item_1: a compliant sub-lot, and a shortlist of potential suppliers
-              item_2: the options available for your next steps if you want to proceed into a procurement
-            title: Results
+              item_1: a compliant Lot
+              item_2: a shortlist of potential suppliers
+            title: View your results
           step_3:
-            content:
-              part_1: 'You will be given the option of completing further building and service requirements either:'
-              part_2: Using this information we will be able to generate documents for you that you can use for your procurement
+            content: 'We will sign post you to the Framework web page, where you can:'
             list:
-              item_1: within this portal with us guiding you through the questions
-              item_2: using a spreadsheet template, which you can download, fill out the information, and upload
-            title: Further service and contract requirements (optional)
-          step_4:
-            content:
-              part_1: On this page you will be able to download a copy of your search results.
-              part_2: 'If you have added further service and contract requirements, you will be able to download:'
-            list:
-              item_1: a deliverables matrix
-              item_2: other spreadsheets
-            title: Final results
-          the_steps_shown: The steps shown below outline the process that you'll follow creating your facilities management procurement.
+              item_1: find further competition guidance
+              item_2: access full contact details for your shortlisted suppliers
+              item_3: download the Terms and Conditions
+              item_4: use Bid Pack templates and instructions to create your further competition
+            title: Get further information
+          the_steps_shown: The steps shown below outline the process that you'll follow to create a supplier shortlist.
       procurements:
         index:
           date_saved: Date saved
@@ -321,7 +313,7 @@ en:
           return_to_your_account: Return to your account
           selected_suppliers: Selected suppliers
           step_1: Step 1 - download your results
-          step_2: Step 2 - how to buy
+          step_2: Step 2 - read about how to buy
           title: What do I do next?
           visit_the_framework_page_html: 'Visit the %{framework_page_link} page for information on how to procure via this framework, including:'
           you_can_download: 'You can download your shortlisted supplier list now, which also contains:'

--- a/features/.cut_pages/facilities_management/rm6232/procurements/results/results_are_correct.feature
+++ b/features/.cut_pages/facilities_management/rm6232/procurements/results/results_are_correct.feature
@@ -4,7 +4,7 @@ Feature: Information appears correctly on results page
     Given I sign in and navigate to my account for 'RM6232'
     Given I have buildings
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
     And I click on 'Continue'
     Then I am on the 'Services' page
     Then I select the following items:

--- a/features/.cut_pages/facilities_management/rm6232/quick_view/results.feature
+++ b/features/.cut_pages/facilities_management/rm6232/quick_view/results.feature
@@ -3,7 +3,7 @@ Feature: Information appears correctly on results page
   Background: Navigate to the results page
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
     And I click on 'Continue'
     Then I am on the 'Services' page
     Then I select the following items:

--- a/features/accessibility/facilities_management/rm6232/quick_view/quick_view_accessibility.feature
+++ b/features/accessibility/facilities_management/rm6232/quick_view/quick_view_accessibility.feature
@@ -4,9 +4,9 @@ Feature: Results accessibility
   Background: Navigate to select services
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
 
-  Scenario: Start a procurement page
+  Scenario: Search for suppliers page
     Then the page should be axe clean
 
   Scenario: Select services page

--- a/features/facilities_management/rm6232/procurements/what_do_i_do_next.feature
+++ b/features/facilities_management/rm6232/procurements/what_do_i_do_next.feature
@@ -13,7 +13,7 @@ Feature: What do I do next
     Then the following content should be displayed on the page:
       | Step 1 - download your results                                            |
       | You can download your shortlisted supplier list now, which also contains: |
-      | Step 2 - how to buy                                                       |
+      | Step 2 - read about how to buy                                            |
       | Visit the Facilities Management and Workplace Services framework page for |
       | information on how to procure via this framework, including:              |
 

--- a/features/facilities_management/rm6232/quick_view/lot_selection.feature
+++ b/features/facilities_management/rm6232/quick_view/lot_selection.feature
@@ -3,7 +3,7 @@ Feature: Service and selection and annual contract cost result in correct sub lo
   Background: Navigate to the services page
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
     And I click on 'Continue'
     Then I am on the 'Services' page
 

--- a/features/facilities_management/rm6232/quick_view/results.feature
+++ b/features/facilities_management/rm6232/quick_view/results.feature
@@ -3,7 +3,7 @@ Feature: Information appears correctly on results page
   Background: Navigate to the results page
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
     And I click on 'Continue'
     Then I am on the 'Services' page
     Then I select the following items:

--- a/features/facilities_management/rm6232/quick_view/select_regions.feature
+++ b/features/facilities_management/rm6232/quick_view/select_regions.feature
@@ -4,7 +4,7 @@ Feature: Select regions
   Background: Navigate to the Regions page
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
     And I click on 'Continue'
     Then I am on the 'Services' page
     And I show all sections

--- a/features/facilities_management/rm6232/quick_view/select_services.feature
+++ b/features/facilities_management/rm6232/quick_view/select_services.feature
@@ -4,7 +4,7 @@ Feature: Select services
   Background: Navigate to the Services page
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
     And I click on 'Continue'
     Then I am on the 'Services' page
     And I show all sections

--- a/features/facilities_management/rm6232/quick_view/service_specification.feature
+++ b/features/facilities_management/rm6232/quick_view/service_specification.feature
@@ -3,7 +3,7 @@ Feature: Service specification
   Scenario: Service specification
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
     And I click on 'Continue'
     Then I am on the 'Services' page
     Given I click on the service specification for '<service_name>'

--- a/features/facilities_management/rm6232/quick_view/validations/annual_contract_value_validations.feature
+++ b/features/facilities_management/rm6232/quick_view/validations/annual_contract_value_validations.feature
@@ -4,7 +4,7 @@ Feature: Annual contract cost validations
   Scenario Outline: validations for the annual contract cost
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
     And I click on 'Continue'
     Then I am on the 'Services' page
     Then I select the following items:

--- a/features/facilities_management/rm6232/quick_view/validations/results_validations.feature
+++ b/features/facilities_management/rm6232/quick_view/validations/results_validations.feature
@@ -4,7 +4,7 @@ Feature: Results validations
   Background: Navigate to the Results page
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
     And I click on 'Continue'
     Then I am on the 'Services' page
     Then I select the following items:

--- a/features/facilities_management/rm6232/quick_view/validations/select_regions_validations.feature
+++ b/features/facilities_management/rm6232/quick_view/validations/select_regions_validations.feature
@@ -4,7 +4,7 @@ Feature: Select region validations
   Scenario: No region selected
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
     And I click on 'Continue'
     Then I am on the 'Services' page
     Then I select the following items:

--- a/features/facilities_management/rm6232/quick_view/validations/select_services_validations.feature
+++ b/features/facilities_management/rm6232/quick_view/validations/select_services_validations.feature
@@ -4,7 +4,7 @@ Feature: Select services validations
   Background: Navigate to the services page
     Given I sign in and navigate to my account for 'RM6232'
     And I click on 'Search for suppliers'
-    Then I am on the 'Start a procurement' page
+    Then I am on the 'Search for suppliers' page
     And I click on 'Continue'
     Then I am on the 'Services' page
 

--- a/spec/models/facilities_management/rm6232/journey/start_a_search_spec.rb
+++ b/spec/models/facilities_management/rm6232/journey/start_a_search_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
-RSpec.describe FacilitiesManagement::RM6232::Journey::StartAProcurement, type: :model do
-  let(:start_a_procurement) { described_class.new }
+RSpec.describe FacilitiesManagement::RM6232::Journey::StartASearch, type: :model do
+  let(:start_a_search) { described_class.new }
 
   describe 'validations' do
     it 'is valid' do
-      expect(start_a_procurement.valid?).to be true
+      expect(start_a_search.valid?).to be true
     end
   end
 
   describe '.next_step_class' do
     it 'returns Journey::ChooseServices' do
-      expect(start_a_procurement.next_step_class).to be FacilitiesManagement::RM6232::Journey::ChooseServices
+      expect(start_a_search.next_step_class).to be FacilitiesManagement::RM6232::Journey::ChooseServices
     end
   end
 
@@ -28,20 +28,20 @@ RSpec.describe FacilitiesManagement::RM6232::Journey::StartAProcurement, type: :
   end
 
   describe '.slug' do
-    it 'returns start-a-procurement' do
-      expect(start_a_procurement.slug).to eq 'start-a-procurement'
+    it 'returns start-a-search' do
+      expect(start_a_search.slug).to eq 'start-a-search'
     end
   end
 
   describe '.template' do
-    it 'returns journey/start_a_procurement' do
-      expect(start_a_procurement.template).to eq 'journey/start_a_procurement'
+    it 'returns journey/start_a_search' do
+      expect(start_a_search.template).to eq 'journey/start_a_search'
     end
   end
 
   describe '.final?' do
     it 'returns false' do
-      expect(start_a_procurement.final?).to be false
+      expect(start_a_search.final?).to be false
     end
   end
 end


### PR DESCRIPTION
Ticket: [FMFR-1238](https://crowncommercialservice.atlassian.net/browse/FMFR-1238)

We are making major changes to the journey by removing everything after the ‘What happens next?’ page.

In this commit I have updated the ‘Start a procurement page’ and have changed it to the ‘Search for suppliers’ page.