### PR TITLE
FMFR-1248 - Add user to admin uploads

### DIFF
--- a/app/controllers/facilities_management/admin/uploads_controller.rb
+++ b/app/controllers/facilities_management/admin/uploads_controller.rb
@@ -15,7 +15,9 @@ module FacilitiesManagement
       end
 
       def create
-        @upload = service::Admin::Upload.new(upload_params)
+        @upload = service::Admin::Upload.new(user: current_user)
+
+        @upload.assign_attributes(upload_params)
 
         if @upload.save(context: :upload)
           @upload.start_upload!
@@ -41,6 +43,18 @@ module FacilitiesManagement
 
       def service
         @service ||= self.class.module_parent.module_parent
+      end
+
+      def upload_params
+        if params[param_key]
+          params.require(param_key).permit(@upload.class::ATTRIBUTES)
+        else
+          {}
+        end
+      end
+
+      def param_key
+        @param_key ||= @upload.model_name.param_key
       end
     end
   end

--- a/app/controllers/facilities_management/rm3830/admin/uploads_controller.rb
+++ b/app/controllers/facilities_management/rm3830/admin/uploads_controller.rb
@@ -7,12 +7,6 @@ module FacilitiesManagement
           spreadsheet_builder.build
           send_data spreadsheet_builder.to_xlsx, filename: 'RM3830 Supplier Framework Data (template).xlsx', type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
         end
-
-        private
-
-        def upload_params
-          params.require(:facilities_management_rm3830_admin_upload).permit(:supplier_data_file) if params[:facilities_management_rm3830_admin_upload].present?
-        end
       end
     end
   end

--- a/app/controllers/facilities_management/rm6232/admin/uploads_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/uploads_controller.rb
@@ -2,11 +2,6 @@ module FacilitiesManagement
   module RM6232
     module Admin
       class UploadsController < FacilitiesManagement::Admin::UploadsController
-        private
-
-        def upload_params
-          params.require(:facilities_management_rm6232_admin_upload).permit(:supplier_details_file, :supplier_services_file, :supplier_regions_file) if params[:facilities_management_rm6232_admin_upload].present?
-        end
       end
     end
   end

--- a/app/models/facilities_management/rm3830/admin/upload.rb
+++ b/app/models/facilities_management/rm3830/admin/upload.rb
@@ -2,6 +2,8 @@ module FacilitiesManagement
   module RM3830
     module Admin
       class Upload < FacilitiesManagement::Admin::Upload
+        belongs_to :user, inverse_of: :rm3830_admin_uploads, optional: true
+
         has_one_attached :supplier_data_file
 
         validates :supplier_data_file, antivirus: { message: :malicious }, size: { less_than: 10.megabytes, message: :too_large }, content_type: { with: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', message: :wrong_content_type }, on: :upload

--- a/app/models/facilities_management/rm6232/admin/upload.rb
+++ b/app/models/facilities_management/rm6232/admin/upload.rb
@@ -2,6 +2,8 @@ module FacilitiesManagement
   module RM6232
     module Admin
       class Upload < FacilitiesManagement::Admin::Upload
+        belongs_to :user, inverse_of: :rm6232_admin_uploads, optional: true
+
         has_one_attached :supplier_details_file
         has_one_attached :supplier_services_file
         has_one_attached :supplier_regions_file

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,16 @@ class User < ApplicationRecord
            class_name: 'FacilitiesManagement::RM3830::Admin::ManagementReport',
            dependent: :nullify
 
+  has_many :rm3830_admin_uploads,
+           inverse_of: :user,
+           class_name: 'FacilitiesManagement::RM3830::Admin::Upload',
+           dependent: :nullify
+
+  has_many :rm6232_admin_uploads,
+           inverse_of: :user,
+           class_name: 'FacilitiesManagement::RM6232::Admin::Upload',
+           dependent: :nullify
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :trackable and :omniauthable
   devise :registerable, :recoverable, :timeoutable

--- a/db/migrate/20220629111720_add_user_to_admin_uploads.rb
+++ b/db/migrate/20220629111720_add_user_to_admin_uploads.rb
@@ -1,0 +1,6 @@
+class AddUserToAdminUploads < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :facilities_management_rm6232_admin_uploads, :user, type: :uuid, foreign_key: true, index: { name: 'index_fm_rm6232_uploads_on_users_id' }
+    add_reference :facilities_management_rm3830_admin_uploads, :user, type: :uuid, foreign_key: true, index: { name: 'index_fm_rm3830_uploads_on_users_id' }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_27_081803) do
+ActiveRecord::Schema.define(version: 2022_06_29_111720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -111,6 +111,8 @@ ActiveRecord::Schema.define(version: 2022_06_27_081803) do
     t.text "import_errors"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "user_id"
+    t.index ["user_id"], name: "index_fm_rm3830_uploads_on_users_id"
   end
 
   create_table "facilities_management_rm3830_frozen_rate_cards", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -371,6 +373,8 @@ ActiveRecord::Schema.define(version: 2022_06_27_081803) do
     t.text "import_errors"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "user_id"
+    t.index ["user_id"], name: "index_fm_rm6232_uploads_on_users_id"
   end
 
   create_table "facilities_management_rm6232_procurement_buildings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -610,6 +614,7 @@ ActiveRecord::Schema.define(version: 2022_06_27_081803) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "facilities_management_buyer_details", "users"
   add_foreign_key "facilities_management_rm3830_admin_management_reports", "users"
+  add_foreign_key "facilities_management_rm3830_admin_uploads", "users"
   add_foreign_key "facilities_management_rm3830_frozen_rate_cards", "facilities_management_rm3830_procurements"
   add_foreign_key "facilities_management_rm3830_frozen_rates", "facilities_management_rm3830_procurements"
   add_foreign_key "facilities_management_rm3830_procurement_building_service_lifts", "facilities_management_rm3830_procurement_building_services"
@@ -623,6 +628,7 @@ ActiveRecord::Schema.define(version: 2022_06_27_081803) do
   add_foreign_key "facilities_management_rm3830_procurements", "users"
   add_foreign_key "facilities_management_rm3830_spreadsheet_imports", "facilities_management_rm3830_procurements"
   add_foreign_key "facilities_management_rm3830_supplier_details", "users"
+  add_foreign_key "facilities_management_rm6232_admin_uploads", "users"
   add_foreign_key "facilities_management_rm6232_procurement_buildings", "facilities_management_buildings", column: "building_id"
   add_foreign_key "facilities_management_rm6232_procurement_buildings", "facilities_management_rm6232_procurements"
   add_foreign_key "facilities_management_rm6232_procurement_call_off_extensions", "facilities_management_rm6232_procurements"


### PR DESCRIPTION
Ticket: [FMFR-1248](https://crowncommercialservice.atlassian.net/browse/FMFR-1248)

Update the admin upload models so that they can have a user attached to them. This is for auditing purposes.