### PR TITLE
FMFR-1249 - Add logging of the changes by the admin

### DIFF
--- a/app/controllers/facilities_management/admin/supplier_details_controller.rb
+++ b/app/controllers/facilities_management/admin/supplier_details_controller.rb
@@ -14,6 +14,7 @@ module FacilitiesManagement
         @supplier.assign_attributes(supplier_params)
 
         if @supplier.save(context: @page)
+          FacilitiesManagement::RM6232::Admin::SupplierData::Edit.log_change(current_user, @supplier) if @framework == 'RM6232'
           redirect_to facilities_management_admin_supplier_detail_path
         else
           render :edit

--- a/app/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller.rb
@@ -14,6 +14,7 @@ module FacilitiesManagement
           @lot_data.assign_attributes(lot_data_params)
 
           if @lot_data.save(context: @lot_data_type.to_sym)
+            FacilitiesManagement::RM6232::Admin::SupplierData::Edit.log_change(current_user, @lot_data)
             redirect_to facilities_management_rm6232_admin_supplier_lot_datum_path(id: @supplier.id)
           else
             set_data

--- a/app/models/facilities_management/rm6232/admin/supplier_data.rb
+++ b/app/models/facilities_management/rm6232/admin/supplier_data.rb
@@ -1,0 +1,14 @@
+module FacilitiesManagement
+  module RM6232
+    module Admin
+      class SupplierData < ApplicationRecord
+        belongs_to :upload, inverse_of: :supplier_data, foreign_key: :facilities_management_rm6232_admin_upload_id, optional: true
+        has_many :edits, inverse_of: :supplier_data, class_name: 'FacilitiesManagement::RM6232::Admin::SupplierData::Edit', dependent: :destroy, foreign_key: :facilities_management_rm6232_admin_supplier_data_id
+
+        def self.latest_data
+          order(created_at: :desc).first
+        end
+      end
+    end
+  end
+end

--- a/app/models/facilities_management/rm6232/admin/supplier_data/edit.rb
+++ b/app/models/facilities_management/rm6232/admin/supplier_data/edit.rb
@@ -1,0 +1,18 @@
+module FacilitiesManagement
+  module RM6232
+    module Admin
+      class SupplierData::Edit < ApplicationRecord
+        self.table_name = 'facilities_management_rm6232_admin_supplier_data_edits'
+
+        belongs_to :supplier_data, inverse_of: :edits, foreign_key: :facilities_management_rm6232_admin_supplier_data_id
+        belongs_to :user, inverse_of: :rm6232_supplier_data_edits
+
+        def self.log_change(user, model)
+          return if model.saved_changes.blank?
+
+          create!(user: user, supplier_data: SupplierData.latest_data, **%i[supplier_id change_type data].zip(model.changed_data).to_h)
+        end
+      end
+    end
+  end
+end

--- a/app/models/facilities_management/rm6232/admin/suppliers_admin.rb
+++ b/app/models/facilities_management/rm6232/admin/suppliers_admin.rb
@@ -23,6 +23,14 @@ module FacilitiesManagement
             [:red, 'INACTIVE']
           end
         end
+
+        def changed_data
+          [
+            id,
+            :details,
+            saved_changes.except(:updated_at).map { |attribute, value| { attribute: attribute, value: value.last } }
+          ]
+        end
       end
     end
   end

--- a/app/models/facilities_management/rm6232/admin/upload.rb
+++ b/app/models/facilities_management/rm6232/admin/upload.rb
@@ -4,6 +4,8 @@ module FacilitiesManagement
       class Upload < FacilitiesManagement::Admin::Upload
         belongs_to :user, inverse_of: :rm6232_admin_uploads, optional: true
 
+        has_one :supplier_data, inverse_of: :upload, class_name: 'FacilitiesManagement::RM6232::Admin::SupplierData', dependent: :destroy, foreign_key: :facilities_management_rm6232_admin_upload_id
+
         has_one_attached :supplier_details_file
         has_one_attached :supplier_services_file
         has_one_attached :supplier_regions_file

--- a/app/models/facilities_management/rm6232/supplier/lot_data.rb
+++ b/app/models/facilities_management/rm6232/supplier/lot_data.rb
@@ -14,6 +14,23 @@ module FacilitiesManagement
       def regions
         Region.where(code: region_codes)
       end
+
+      def changed_data
+        model_changes = saved_changes.except(:updated_at).first
+        data_before = model_changes.last.first
+        data_after = model_changes.last.last
+
+        [
+          supplier.id,
+          :lot_data,
+          {
+            attribute: model_changes.first,
+            lot_code: lot_code,
+            added: data_after - data_before,
+            removed: data_before - data_after
+          }
+        ]
+      end
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,11 @@ class User < ApplicationRecord
            class_name: 'FacilitiesManagement::RM6232::Admin::Upload',
            dependent: :nullify
 
+  has_many :rm6232_supplier_data_edits,
+           inverse_of: :user,
+           class_name: 'FacilitiesManagement::RM6232::Admin::SupplierData::Edit',
+           dependent: :nullify
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :trackable and :omniauthable
   devise :registerable, :recoverable, :timeoutable

--- a/app/services/facilities_management/rm6232/admin/files_importer.rb
+++ b/app/services/facilities_management/rm6232/admin/files_importer.rb
@@ -8,15 +8,7 @@ module FacilitiesManagement::RM6232
       private
 
       def other_data
-        {}
-      end
-
-      def file_source
-        if @upload
-          @upload.supplier_data_file.filename.to_s
-        else
-          file_sources(:supplier_data_file)
-        end
+        { upload: @upload }
       end
 
       FILE_SOURCES = {

--- a/app/services/facilities_management/rm6232/admin/files_importer/data_uploader.rb
+++ b/app/services/facilities_management/rm6232/admin/files_importer/data_uploader.rb
@@ -1,11 +1,13 @@
 module FacilitiesManagement::RM6232
   module Admin
     class FilesImporter::DataUploader < FacilitiesManagement::FilesImporter::DataUploader
-      def self.upload!(supplier_data)
+      def self.upload!(supplier_data, upload:)
         super(Supplier) do
           Supplier.destroy_all
 
           supplier_data.each { |supplier| create_supplier!(supplier) }
+
+          SupplierData.create!(upload: upload, data: supplier_data)
         end
       end
 

--- a/db/migrate/20220629115809_add_rm6232_rate_card.rb
+++ b/db/migrate/20220629115809_add_rm6232_rate_card.rb
@@ -1,0 +1,10 @@
+class AddRM6232RateCard < ActiveRecord::Migration[6.0]
+  def change
+    create_table :facilities_management_rm6232_admin_supplier_data, id: :uuid do |t|
+      t.references :facilities_management_rm6232_admin_upload, foreign_key: true, type: :uuid, index: { name: 'index_fm_rm6232_supplier_data_on_fm_rm6232_admin_upload_id ' }
+      t.json :data
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220629123952_add_rm6232_supplier_data_edit.rb
+++ b/db/migrate/20220629123952_add_rm6232_supplier_data_edit.rb
@@ -1,0 +1,14 @@
+class AddRM6232SupplierDataEdit < ActiveRecord::Migration[6.0]
+  def change
+    create_table :facilities_management_rm6232_admin_supplier_data_edits, id: :uuid do |t|
+      t.references :facilities_management_rm6232_admin_supplier_data, foreign_key: true, type: :uuid, null: false, index: { name: 'index_fm_rm6232_admin_sd_edits_on_fm_rm6232_admin_sd_id ' }
+      t.references :user, type: :uuid, foreign_key: true, index: { name: 'index_fm_rm6232_admin_sd_edits_on_user_id' }
+
+      t.uuid :supplier_id
+      t.string :change_type, limit: 255
+      t.json :data
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_29_111720) do
+ActiveRecord::Schema.define(version: 2022_06_29_123952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -365,6 +365,26 @@ ActiveRecord::Schema.define(version: 2022_06_29_111720) do
     t.text "service_usage", array: true
   end
 
+  create_table "facilities_management_rm6232_admin_supplier_data", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "facilities_management_rm6232_admin_upload_id"
+    t.json "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["facilities_management_rm6232_admin_upload_id"], name: "index_fm_rm6232_supplier_data_on_fm_rm6232_admin_upload_id "
+  end
+
+  create_table "facilities_management_rm6232_admin_supplier_data_edits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "facilities_management_rm6232_admin_supplier_data_id", null: false
+    t.uuid "user_id"
+    t.uuid "supplier_id"
+    t.string "change_type", limit: 255
+    t.json "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["facilities_management_rm6232_admin_supplier_data_id"], name: "index_fm_rm6232_admin_sd_edits_on_fm_rm6232_admin_sd_id "
+    t.index ["user_id"], name: "index_fm_rm6232_admin_sd_edits_on_user_id"
+  end
+
   create_table "facilities_management_rm6232_admin_uploads", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "aasm_state", limit: 30
     t.string "supplier_details_file", limit: 255
@@ -628,6 +648,9 @@ ActiveRecord::Schema.define(version: 2022_06_29_111720) do
   add_foreign_key "facilities_management_rm3830_procurements", "users"
   add_foreign_key "facilities_management_rm3830_spreadsheet_imports", "facilities_management_rm3830_procurements"
   add_foreign_key "facilities_management_rm3830_supplier_details", "users"
+  add_foreign_key "facilities_management_rm6232_admin_supplier_data", "facilities_management_rm6232_admin_uploads"
+  add_foreign_key "facilities_management_rm6232_admin_supplier_data_edits", "facilities_management_rm6232_admin_supplier_data", column: "facilities_management_rm6232_admin_supplier_data_id"
+  add_foreign_key "facilities_management_rm6232_admin_supplier_data_edits", "users"
   add_foreign_key "facilities_management_rm6232_admin_uploads", "users"
   add_foreign_key "facilities_management_rm6232_procurement_buildings", "facilities_management_buildings", column: "building_id"
   add_foreign_key "facilities_management_rm6232_procurement_buildings", "facilities_management_rm6232_procurements"

--- a/spec/controllers/facilities_management/admin/supplier_details_controller_rm6232_spec.rb
+++ b/spec/controllers/facilities_management/admin/supplier_details_controller_rm6232_spec.rb
@@ -145,7 +145,11 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController, type: :co
   describe 'PUT update' do
     login_fm_admin
 
-    before { put :update, params: { id: supplier.id, page: page, facilities_management_rm6232_admin_suppliers_admin: supplier_params } }
+    before do
+      allow(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to receive(:log_change)
+      allow(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to receive(:log_change).with(controller.current_user, supplier)
+      put :update, params: { id: supplier.id, page: page, facilities_management_rm6232_admin_suppliers_admin: supplier_params }
+    end
 
     context 'when updating on the supplier name page' do
       let(:page) { :supplier_name }
@@ -164,6 +168,10 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController, type: :co
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+        end
+
+        it 'adds a log to the database' do
+          expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
         end
       end
     end
@@ -186,6 +194,10 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController, type: :co
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
         end
+
+        it 'adds a log to the database' do
+          expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
+        end
       end
     end
 
@@ -207,6 +219,10 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController, type: :co
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
         end
+
+        it 'adds a log to the database' do
+          expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
+        end
       end
     end
 
@@ -227,6 +243,10 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController, type: :co
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+        end
+
+        it 'adds a log to the database' do
+          expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
         end
       end
     end

--- a/spec/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller_spec.rb
@@ -98,7 +98,11 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierLotDataController, t
     let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier) }
     let(:attributes) { {} }
 
-    before { put :update, params: { supplier_lot_datum_id: lot_data.id, lot_data_type: lot_data_type, facilities_management_rm6232_supplier_lot_data: attributes } }
+    before do
+      allow(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to receive(:log_change)
+      allow(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to receive(:log_change).with(controller.current_user, lot_data)
+      put :update, params: { supplier_lot_datum_id: lot_data.id, lot_data_type: lot_data_type, facilities_management_rm6232_supplier_lot_data: attributes }
+    end
 
     context 'when the lot data type is region codes' do
       let(:lot_data_type) { 'region_codes' }
@@ -118,6 +122,10 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierLotDataController, t
 
         it 'does not set the region data' do
           expect(assigns(:regions)).to be_nil
+        end
+
+        it 'adds a log to the database' do
+          expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, lot_data)
         end
       end
 
@@ -162,6 +170,10 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierLotDataController, t
 
       it 'does not set the work_packages data' do
         expect(assigns(:work_packages)).to be_nil
+      end
+
+      it 'adds a log to the database' do
+        expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, lot_data)
       end
     end
 

--- a/spec/models/facilities_management/rm6232/admin/supplier_data/edit_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/supplier_data/edit_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData::Edit, type: :model do
+  describe '.log_change' do
+    let(:supplier) { create(:facilities_management_rm6232_admin_suppliers_admin) }
+    let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, facilities_management_rm6232_supplier_id: supplier.id) }
+    let(:user) { create(:user) }
+    let(:result) { described_class.log_change(user, model) }
+
+    before { model.update(**atrributes) }
+
+    context 'when the model is supplier admin' do
+      let(:model) { supplier }
+      let(:atrributes) { { active: status } }
+
+      context 'and there are changes' do
+        let(:status) { false }
+        let(:data) do
+          [
+            {
+              attribute: 'active',
+              value: false
+            }
+          ]
+        end
+
+        it 'logs the changes' do
+          expect { result }.to change(described_class, :count).by(1)
+          expect(result.attributes.slice('supplier_id', 'change_type', 'data').deep_symbolize_keys).to eq(
+            {
+              supplier_id: supplier.id,
+              change_type: 'details',
+              data: data
+            }
+          )
+        end
+      end
+
+      context 'and there are no changes' do
+        let(:status) { true }
+
+        it 'returns nil' do
+          expect(result).to be_nil
+        end
+      end
+    end
+
+    context 'when the model is supplier lot data' do
+      let(:model) { lot_data }
+      let(:atrributes) { { service_codes: service_codes } }
+
+      context 'and there are changes' do
+        let(:service_codes) { %w[E.16 H.6 P.11 F.4] }
+        let(:data) do
+          {
+            attribute: 'service_codes',
+            lot_code: '1a',
+            added: %w[F.4],
+            removed: []
+          }
+        end
+
+        it 'logs the changes' do
+          expect { result }.to change(described_class, :count).by(1)
+          expect(result.attributes.slice('supplier_id', 'change_type', 'data').deep_symbolize_keys).to eq(
+            {
+              supplier_id: supplier.id,
+              change_type: 'lot_data',
+              data: data
+            }
+          )
+        end
+      end
+
+      context 'and there are no changes' do
+        let(:service_codes) { %w[E.16 H.6 P.11] }
+
+        it 'returns nil' do
+          expect(result).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/admin/supplier_data_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/supplier_data_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData, type: :model do
+  describe 'latest_data' do
+    let(:latest_data) { described_class.create }
+
+    before do
+      4.times { described_class.create(created_at: Time.zone.now - 1.day) }
+      latest_data
+    end
+
+    it 'is the latest set of data' do
+      expect(described_class.latest_data).to eq latest_data
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/admin/suppliers_admin_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/suppliers_admin_spec.rb
@@ -592,4 +592,84 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SuppliersAdmin, type: :model
       end
     end
   end
+
+  describe '.changed_data' do
+    let(:result) { supplier.changed_data }
+
+    before { supplier.update(**attributes) }
+
+    context 'when changing the supplier status' do
+      let(:attributes) { { active: false } }
+      let(:data) do
+        [
+          {
+            attribute: 'active',
+            value: false
+          }
+        ]
+      end
+
+      it 'returns the correct data' do
+        expect(result).to eq([supplier.id, :details, data])
+      end
+    end
+
+    context 'when changing the supplier name' do
+      let(:attributes) { { supplier_name: 'Vandaham Corp' } }
+      let(:data) do
+        [
+          {
+            attribute: 'supplier_name',
+            value: 'Vandaham Corp'
+          }
+        ]
+      end
+
+      it 'returns the correct data' do
+        expect(result).to eq([supplier.id, :details, data])
+      end
+    end
+
+    context 'when changing the duns and CRN number' do
+      let(:new_duns) { Faker::Company.unique.duns_number.gsub('-', '') }
+      let(:attributes) { { duns: new_duns, registration_number: '0654321' } }
+      let(:data) do
+        [
+          {
+            attribute: 'duns',
+            value: new_duns
+          },
+          {
+            attribute: 'registration_number',
+            value: '0654321'
+          }
+        ]
+      end
+
+      it 'returns the correct data' do
+        expect(result).to eq([supplier.id, :details, data])
+      end
+    end
+
+    context 'when changing the address' do
+      let(:attributes) { { address_line_1: "Jakolo's Inn", address_line_2: supplier.address_line_2, address_town: 'Alba cavanich', address_county: supplier.address_county, address_postcode: supplier.address_postcode } }
+
+      let(:data) do
+        [
+          {
+            attribute: 'address_line_1',
+            value: "Jakolo's Inn"
+          },
+          {
+            attribute: 'address_town',
+            value: 'Alba cavanich'
+          }
+        ]
+      end
+
+      it 'returns the correct data' do
+        expect(result).to eq([supplier.id, :details, data])
+      end
+    end
+  end
 end

--- a/spec/models/facilities_management/rm6232/supplier/lot_data_spec.rb
+++ b/spec/models/facilities_management/rm6232/supplier/lot_data_spec.rb
@@ -83,4 +83,116 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData, type: :model do
       end
     end
   end
+
+  describe '.changed_data' do
+    let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier) }
+    let(:supplier) { lot_data.supplier }
+    let(:result) { lot_data.changed_data }
+
+    before { lot_data.update(**attributes) }
+
+    context 'when changing the services' do
+      let(:attributes) { { service_codes: service_codes } }
+
+      context 'and a service is added' do
+        let(:service_codes) { %w[E.16 H.6 P.11 F.4] }
+        let(:data) do
+          {
+            attribute: 'service_codes',
+            lot_code: '1a',
+            added: %w[F.4],
+            removed: []
+          }
+        end
+
+        it 'returns the correct data' do
+          expect(result).to eq([supplier.id, :lot_data, data])
+        end
+      end
+
+      context 'and a service is removed' do
+        let(:service_codes) { %w[E.16 P.11] }
+        let(:data) do
+          {
+            attribute: 'service_codes',
+            lot_code: '1a',
+            added: [],
+            removed: %w[H.6]
+          }
+        end
+
+        it 'returns the correct data' do
+          expect(result).to eq([supplier.id, :lot_data, data])
+        end
+      end
+
+      context 'and one service is added and one removed' do
+        let(:service_codes) { %w[E.16 P.11 F.4] }
+        let(:data) do
+          {
+            attribute: 'service_codes',
+            lot_code: '1a',
+            added: %w[F.4],
+            removed: %w[H.6]
+          }
+        end
+
+        it 'returns the correct data' do
+          expect(result).to eq([supplier.id, :lot_data, data])
+        end
+      end
+    end
+
+    context 'when changing the regions' do
+      let(:attributes) { { region_codes: region_codes } }
+
+      context 'and a region is added' do
+        let(:region_codes) { %w[UKC1 UKD1 UKE1 UKF1] }
+        let(:data) do
+          {
+            attribute: 'region_codes',
+            lot_code: '1a',
+            added: %w[UKF1],
+            removed: []
+          }
+        end
+
+        it 'returns the correct data' do
+          expect(result).to eq([supplier.id, :lot_data, data])
+        end
+      end
+
+      context 'and a region is removed' do
+        let(:region_codes) { %w[UKC1 UKE1] }
+        let(:data) do
+          {
+            attribute: 'region_codes',
+            lot_code: '1a',
+            added: [],
+            removed: %w[UKD1]
+          }
+        end
+
+        it 'returns the correct data' do
+          expect(result).to eq([supplier.id, :lot_data, data])
+        end
+      end
+
+      context 'and one region is added and one removed' do
+        let(:region_codes) { %w[UKC1 UKE1 UKF1] }
+        let(:data) do
+          {
+            attribute: 'region_codes',
+            lot_code: '1a',
+            added: %w[UKF1],
+            removed: %w[UKD1]
+          }
+        end
+
+        it 'returns the correct data' do
+          expect(result).to eq([supplier.id, :lot_data, data])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: [FMFR-1249](https://crowncommercialservice.atlassian.net/browse/FMFR-1249)

There is a requirement from the admin team that all changes that are made to the supplier data are logged. In this commit I have added the models which will store these changes along with who made them.

The first model is the `Admin::SupplierData`. This has a JSON of the full supplier data before it is imported into the database after a user uploads the data. We then have the `Admin::SupplierData::Edit` model which contains all the changes made since the most recent `Admin::SupplierData` was created.

As always I have added specs to make sure everything is working as expected. In a future commit I will add a section to view who made the changes.