### PR TITLE
FMFR-1249 - Add views for the audit logs

### DIFF
--- a/app/controllers/facilities_management/rm6232/admin/change_logs_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/change_logs_controller.rb
@@ -1,0 +1,37 @@
+module FacilitiesManagement
+  module RM6232
+    module Admin
+      class ChangeLogsController < FacilitiesManagement::Admin::FrameworkController
+        before_action :redirect_if_unrecognised_change_type, :set_change_log, only: :show
+
+        helper_method :change_type
+
+        def index
+          @audit_logs = Kaminari.paginate_array(SupplierData.audit_logs).page(params[:page])
+        end
+
+        def show; end
+
+        private
+
+        def change_type
+          @change_type ||= params[:change_type].to_sym
+        end
+
+        def set_change_log
+          @change_log = if change_type == :upload
+                          SupplierData.find(params[:change_log_id])
+                        else
+                          SupplierData::Edit.find(params[:change_log_id])
+                        end
+        end
+
+        def redirect_if_unrecognised_change_type
+          redirect_to facilities_management_rm6232_admin_change_logs_path unless RECOGNISED_CHANGE_TYPES.include? change_type
+        end
+
+        RECOGNISED_CHANGE_TYPES = %i[upload details lot_data].freeze
+      end
+    end
+  end
+end

--- a/app/helpers/facilities_management/rm6232/admin/change_logs_helper.rb
+++ b/app/helpers/facilities_management/rm6232/admin/change_logs_helper.rb
@@ -1,0 +1,24 @@
+module FacilitiesManagement::RM6232::Admin::ChangeLogsHelper
+  def show_page_title
+    @show_page_title ||= t("facilities_management.rm6232.admin.change_logs.show.heading.#{@change_log.true_change_type}")
+  end
+
+  def item_names(codes)
+    case @change_log.data['attribute']
+    when 'region_codes'
+      FacilitiesManagement::Region.where(code: codes).map { |region| "#{region.name} (#{region.code})" }
+    when 'service_codes'
+      FacilitiesManagement::RM6232::Service.where(code: codes).order(:work_package_code, :sort_order).map { |service| "#{service.code} #{service.name}" }
+    end
+  end
+
+  def get_attribute_value(attribute, value)
+    return value unless attribute == 'active'
+
+    govuk_tag_with_text(*if value || value.nil?
+                           [:blue, 'ACTIVE']
+                         else
+                           [:red, 'INACTIVE']
+                         end)
+  end
+end

--- a/app/models/facilities_management/rm6232/admin/supplier_data.rb
+++ b/app/models/facilities_management/rm6232/admin/supplier_data.rb
@@ -8,6 +8,39 @@ module FacilitiesManagement
         def self.latest_data
           order(created_at: :desc).first
         end
+
+        def self.audit_logs
+          order(created_at: :desc).map do |supplier_data|
+            [
+              supplier_data.edits.order(created_at: :desc).map do |edit|
+                {
+                  id: edit.id,
+                  short_id: edit.short_id,
+                  created_at: edit.created_at,
+                  user_email: edit.user.email,
+                  change_type: edit.change_type,
+                  true_change_type: edit.true_change_type
+                }
+              end,
+              {
+                id: supplier_data.id,
+                short_id: supplier_data.short_id,
+                created_at: supplier_data.created_at,
+                user_email: supplier_data.upload&.user&.email,
+                change_type: 'upload',
+                true_change_type: 'upload'
+              }
+            ]
+          end.flatten
+        end
+
+        def true_change_type
+          'upload'
+        end
+
+        def short_id
+          "##{id[..7]}"
+        end
       end
     end
   end

--- a/app/models/facilities_management/rm6232/admin/supplier_data/edit.rb
+++ b/app/models/facilities_management/rm6232/admin/supplier_data/edit.rb
@@ -12,6 +12,42 @@ module FacilitiesManagement
 
           create!(user: user, supplier_data: SupplierData.latest_data, **%i[supplier_id change_type data].zip(model.changed_data).to_h)
         end
+
+        def true_change_type
+          return change_type unless change_type == 'lot_data'
+
+          data['attribute']
+        end
+
+        def short_id
+          "##{id[..7]}"
+        end
+
+        # TODO: See if we can rmove this
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def current_supplier_data
+          @current_supplier_data ||= begin
+            supplier = supplier_data.data.find { |supplier_item| supplier_item['id'] == supplier_id }.dup
+
+            supplier_data.edits.where(supplier_id: supplier_id).where('created_at <= ?', created_at).order(created_at: :asc).each do |edit|
+              if edit.change_type == 'lot_data'
+                supplier_lot_data = supplier['lot_data'].find { |lot_data| lot_data['lot_code'] == edit.data['lot_code'] }
+
+                edit.data['removed'].each { |code| supplier_lot_data[edit.data['attribute']].delete(code) }
+                edit.data['added'].each { |code| supplier_lot_data[edit.data['attribute']] << code }
+              else
+                edit.data.each { |detail| supplier[detail['attribute']] = detail['value'] }
+              end
+            end
+
+            supplier
+          end
+        end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+        def previous_supplier_data
+          supplier_data.edits.where(supplier_id: supplier_id).where('created_at < ?', created_at).order(created_at: :desc).first&.current_supplier_data || supplier_data.data.find { |supplier_item| supplier_item['id'] == supplier_id }
+        end
       end
     end
   end

--- a/app/views/facilities_management/rm6232/admin/change_logs/_change_log_details.html.erb
+++ b/app/views/facilities_management/rm6232/admin/change_logs/_change_log_details.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p>
+      <%= t('.a_change_was_made_to_html', supplier_name: @change_log.current_supplier_data['supplier_name'], created_at: format_date_time(@change_log.created_at)) %>
+    </p>
+    <p>
+      <%= t('.change_made_by_html', email: @change_log.user.email) %>
+    </p>
+    <% if @change_log.change_type == 'lot_data' %>
+      <p>
+        <%= t('.changed_lot_html', lot_code: @change_log.data['lot_code']) %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/facilities_management/rm6232/admin/change_logs/_details.html.erb
+++ b/app/views/facilities_management/rm6232/admin/change_logs/_details.html.erb
@@ -1,0 +1,27 @@
+<%= render partial: 'change_log_details' %>
+
+<hr class="govuk-section-break govuk-!-margin-3">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m"><%= t('.below_are_the_changes') %></caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header"><%= t('.attribute') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.prev_value') %></th>
+          <th scope="col" class="govuk-table__header"><%= t('.new_value') %></th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @change_log.data.each do |item| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= t(".attribute_name.#{item['attribute']}") %></th>
+            <td class="govuk-table__cell"><%= get_attribute_value(item['attribute'], @change_log.previous_supplier_data[item['attribute']]) %></td>
+            <td class="govuk-table__cell"><%= get_attribute_value(item['attribute'], item['value']) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/facilities_management/rm6232/admin/change_logs/_lot_data.html.erb
+++ b/app/views/facilities_management/rm6232/admin/change_logs/_lot_data.html.erb
@@ -1,0 +1,35 @@
+<%= render partial: 'change_log_details' %>
+
+<% if @change_log.data['added'].any? %>
+  <hr class="govuk-section-break govuk-!-margin-3">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m">
+        <%= t(".items_added.#{@change_log.data['attribute']}") %>
+      </h2>
+      <ul id="added-items" class="govuk-list govuk-list--bullet">
+        <% item_names(@change_log.data['added']).each do |item_name| %>
+          <li><%= item_name %></li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>
+
+<% if @change_log.data['removed'].any? %>
+  <hr class="govuk-section-break govuk-!-margin-3">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m">
+        <%= t(".items_removed.#{@change_log.data['attribute']}") %>
+      </h2>
+      <ul id="removed-items" class="govuk-list govuk-list--bullet">
+        <% item_names(@change_log.data['removed']).each do |item_name| %>
+          <li><%= item_name %></li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/facilities_management/rm6232/admin/change_logs/_upload.html.erb
+++ b/app/views/facilities_management/rm6232/admin/change_logs/_upload.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p>
+      <%= t('.an_upload_was_done_html', created_at: format_date_time(@change_log.created_at)) %>
+    </p>
+    <% if @change_log.upload %>
+      <p>
+        <%= t('.this_upload_was_done_by_html', email: @change_log.upload.user.email) %>
+      </p>
+      <p>
+        <%= t('.you_can_view_upload_html', link_url: link_to(t('.upload'), @change_log.upload, class: 'govuk-link--no-visited-state')) %>
+      </p>
+    <% else %>
+      <p>
+        <%= t('.this_upload_was_done_via_deployment') %>
+      </p>
+      <p>
+        <%= t('.to_get_data') %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/facilities_management/rm6232/admin/change_logs/index.html.erb
+++ b/app/views/facilities_management/rm6232/admin/change_logs/index.html.erb
@@ -1,0 +1,48 @@
+<%= content_for :page_title, t('.heading') %>
+<%= admin_breadcrumbs({ text: t('.heading') })%>
+
+<h1 class="govuk-heading-xl">
+  <%= t('.heading') %>
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      <%= t('.below_is_table') %>
+    </p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col" width="15%"><%= t('.change_log_item') %></th>
+          <th class="govuk-table__header" scope="col" width="20%"><%= t('.date_of_change') %></th>
+          <td class="govuk-table__header" scope="col" width="40%"><%= t('.user') %></td>
+          <td class="govuk-table__header" scope="col" width="25%"><%= t('.change') %></td>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @audit_logs.each do |audit_log| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell govuk-!-padding-right-2">
+              <%= link_to audit_log[:short_id], facilities_management_rm6232_admin_change_log_show_path(audit_log[:id], audit_log[:change_type]), class: 'govuk-link govuk-link--no-visited-state' %>
+            </td>
+            <td class="govuk-table__cell govuk-!-padding-right-2">
+              <%= format_date_time audit_log[:created_at] %>
+            </td>
+            <td class="govuk-table__cell govuk-!-padding-right-2">
+              <%= audit_log[:user_email] || t('.during_a_deployment') %>
+            </td>
+            <td class="govuk-table__cell govuk-!-padding-right-2">
+              <%= t(".change_made.#{audit_log[:true_change_type]}") %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <%= paginate @audit_logs, views_prefix: 'shared' %>
+  </div>
+</div>

--- a/app/views/facilities_management/rm6232/admin/change_logs/show.html.erb
+++ b/app/views/facilities_management/rm6232/admin/change_logs/show.html.erb
@@ -1,0 +1,18 @@
+<%= content_for :page_title, show_page_title %>
+<%= admin_breadcrumbs(
+  { text: t('facilities_management.rm6232.admin.change_logs.index.heading'), link: facilities_management_rm6232_admin_change_logs_path },
+  { text: show_page_title }
+)%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <span class="govuk-caption-l">
+      <%= t('.log_item', short_id: @change_log.short_id) %>
+    </span>
+    <h1 class="govuk-heading-xl">
+      <%= show_page_title %>
+    </h1>
+  </div>
+</div>
+
+<%= render partial: change_type.to_s %>

--- a/app/views/facilities_management/rm6232/admin/home/index.html.erb
+++ b/app/views/facilities_management/rm6232/admin/home/index.html.erb
@@ -15,5 +15,9 @@
     <%= ccs_account_panel(t('.supplier_data'), facilities_management_rm6232_admin_supplier_data_path) do %>
       <%= t('.manage_supplier_data') %>
     <% end %>
+
+    <%= ccs_account_panel(t('.audit_logs'), facilities_management_rm6232_admin_change_logs_path) do %>
+      <%= t('.view_logs') %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/facilities_management/rm6232/admin/uploads/show.html.erb
+++ b/app/views/facilities_management/rm6232/admin/uploads/show.html.erb
@@ -27,6 +27,14 @@
           <%= format_date_time @upload.created_at %>
         </dd>
       </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t('.uploaded_by') %>
+        </dt>
+        <dd id="uploaded-by-email" class="govuk-summary-list__value">
+          <%= @upload.user.email %>
+        </dd>
+      </div>
     </dl>
   </div>
 </div>

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -172,11 +172,67 @@ en:
   facilities_management:
     rm6232:
       admin:
+        change_logs:
+          change_log_details:
+            a_change_was_made_to_html: A change was made to the supplier <strong id="updated-supplier">%{supplier_name}</strong> on <strong>%{created_at}</strong>.
+            change_made_by_html: This change was made by <strong id="updated-by-email">%{email}</strong>.
+            changed_lot_html: The change was made in <strong id="updated-lot">Lot %{lot_code}</strong>.
+          details:
+            attribute: Attribute
+            attribute_name:
+              active: Status
+              address_county: County
+              address_line_1: Building and street
+              address_line_2: Building and street (line 2)
+              address_postcode: Postcode
+              address_town: Town or city
+              duns: DUNS number
+              registration_number: Company registration number
+              supplier_name: Supplier name
+            below_are_the_changes: 'Below are the changes that were made to the supplier''s details:'
+            new_value: New value
+            prev_value: Previous value
+          index:
+            below_is_table: Below is a table which records a log of all the changes made to the supplier data. You can view the specific changes that were made by clicking on a log item.
+            change: Change
+            change_log_item: Log item
+            change_made:
+              details: Details
+              region_codes: Regions
+              service_codes: Services
+              upload: Data uploaded
+            date_of_change: Date of change
+            during_a_deployment: During a deployment
+            heading: Supplier data change log
+            user: User
+          lot_data:
+            items_added:
+              region_codes: 'The following regions were added to the supplier:'
+              service_codes: 'The following services were added to the supplier:'
+            items_removed:
+              region_codes: 'The following regions were removed from the supplier:'
+              service_codes: 'The following services were removed from the supplier:'
+          show:
+            heading:
+              details: Changes to supplier details
+              region_codes: Changes to supplier regions
+              service_codes: Changes to supplier services
+              upload: Supplier data upload
+            log_item: Log item %{short_id}
+          upload:
+            an_upload_was_done_html: An upload was created on <strong>%{created_at}</strong>.
+            this_upload_was_done_by_html: This upload was created by <strong id="updated-by-email">%{email}</strong>.
+            this_upload_was_done_via_deployment: This upload was created via a deployment to the application.
+            to_get_data: You can get the data that was used by speaking to a developer.
+            upload: upload
+            you_can_view_upload_html: You can view the %{link_url} in the 'Manage supplier data' section of the portal.
         home:
           index:
+            audit_logs: Supplier data change log
             header: RM6232 administration dashboard
             manage_supplier_data: Manage the supplier's details and their lot data
             supplier_data: Supplier data
+            view_logs: View logs of all changes made to the supplier data by the admin team
         sessions:
           new:
             admin_sign_in_header: Sign in to the RM6232 administration dashboard
@@ -307,6 +363,7 @@ en:
             name: File name
             return: Return to 'Manage supplier data'
             status: 'Status:'
+            uploaded_by: 'Uploaded by:'
           upload:
             upload_name: 'Upload session #%{number}'
       buyer_account:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,9 @@ Rails.application.routes.draw do
           get '/:lot_data_type/edit', action: :edit, as: :edit
           put '/:lot_data_type', action: :update, as: :update
         end
+        resources :change_logs, path: 'change-logs', only: :index do
+          get '/:change_type', action: :show, as: :show
+        end
       end
     end
 

--- a/features/facilities_management/rm6232/admin/change_logs/changes_to_details.feature
+++ b/features/facilities_management/rm6232/admin/change_logs/changes_to_details.feature
@@ -1,0 +1,79 @@
+@pipeline
+Feature: Change log for supplier details
+
+  Scenario: Changes to the supplier details are logged
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    Then I click on 'View details' for 'Hudson, Spinka and Schuppe'
+    And I am on the 'Supplier details' page
+    And I change the 'Supplier status' for the supplier details
+    Then I am on the 'Supplier status' page
+    And I select 'INACTIVE' for the supplier status
+    And I click on 'Save and return'
+    Then I am on the 'Supplier details' page
+    And I change the 'Supplier name' for the supplier details
+    Then I am on the 'Supplier name' page
+    And I enter 'New supplier' into the 'Supplier name' field
+    And I click on 'Save and return'
+    Then I am on the 'Supplier details' page
+    And I change the 'DUNS number' for the supplier details
+    Then I am on the 'Additional supplier information' page
+    Given I enter '987654321' into the 'DUNS number' field
+    Given I enter '01234567' into the 'Company registration number' field
+    And I click on 'Save and return'
+    Then I am on the 'Supplier details' page
+    And I change the 'Full address' for the supplier details
+    Then I am on the 'Supplier address' page
+    And I enter the following details into the form:
+      | Building and street | 112 Test street |
+      | Town or city        | Westminister    |
+      | Postcode            | AB2 3DF         |
+    And I click on 'Save and return'
+    Then I am on the 'Supplier details' page
+    And I click on 'Home'
+    Then I am on the 'RM6232 administration dashboard' page
+    And I click on 'Supplier data change log'
+    Then I am on the 'Supplier data change log' page
+    And I should see 5 logs
+    And log number 1 has the user 'me'
+    And log number 1 has the change type 'Details'
+    And log number 2 has the user 'me'
+    And log number 2 has the change type 'Details'
+    And log number 3 has the user 'me'
+    And log number 3 has the change type 'Details'
+    And log number 4 has the user 'me'
+    And log number 4 has the change type 'Details'
+    And I click on log number 4
+    Then I am on the 'Changes to supplier details' page
+    And the supplier who was changed is 'Hudson, Spinka and Schuppe'
+    And the change was made by 'me'
+    And I should see the following changes to the supplier details:
+      | Status  | ACTIVE  | INACTIVE  |
+    Then I click on 'Supplier data change log'
+    And I am on the 'Supplier data change log' page
+    And I click on log number 3
+    Then I am on the 'Changes to supplier details' page
+    And the supplier who was changed is 'New supplier'
+    And the change was made by 'me'
+    And I should see the following changes to the supplier details:
+      | Supplier name  | Hudson, Spinka and Schuppe  | New supplier  |
+    Then I click on 'Supplier data change log'
+    And I am on the 'Supplier data change log' page
+    And I click on log number 2
+    Then I am on the 'Changes to supplier details' page
+    And the supplier who was changed is 'New supplier'
+    And the change was made by 'me'
+    And I should see the following changes to the supplier details:
+      | DUNS number                 | 257625002 | 987654321 |
+      | Company registration number | 0390189   | 01234567  |
+    Then I click on 'Supplier data change log'
+    And I am on the 'Supplier data change log' page
+    And I click on log number 1
+    Then I am on the 'Changes to supplier details' page
+    And the supplier who was changed is 'New supplier'
+    And the change was made by 'me'
+    And I should see the following changes to the supplier details:
+      | Building and street | 161 Christian Crossing  | 112 Test street |
+      | Town or city        | North Mosesside         | Westminister    |
+      | Postcode            | W3 8BJ                  | AB2 3DF         |

--- a/features/facilities_management/rm6232/admin/change_logs/changes_to_regions.feature
+++ b/features/facilities_management/rm6232/admin/change_logs/changes_to_regions.feature
@@ -1,0 +1,82 @@
+@pipeline
+Feature: Change log for supplier regions
+
+  Scenario: Changes to the supplier regions are logged
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    Then I click on 'View lot data' for 'Muller Inc'
+    And I change the 'regions' for lot '2b'
+    Then I am on the 'Lot 2b regions' page
+    And I select the following items:
+      | Northumberland and Tyne and Wear  |
+      | West Midlands (county)            |
+      | Surrey, East and West Sussex      |
+    And I deselect the following items:
+      | Tees Valley and Durham  |
+      | Flintshire and Wrexham  |
+      | Shetland Islands        |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I change the 'regions' for lot '3b'
+    Then I am on the 'Lot 3b regions' page
+    And I select the following items:
+      | Cumbria     |
+      | Cheshire    |
+      | Merseyside  |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I change the 'regions' for lot '2c'
+    Then I am on the 'Lot 2c regions' page
+    And I deselect the following items:
+      | East Anglia                     |
+      | Bedfordshire and Hertfordshire  |
+      | Essex                           |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I click on 'Home'
+    Then I am on the 'RM6232 administration dashboard' page
+    And I click on 'Supplier data change log'
+    Then I am on the 'Supplier data change log' page
+    And I should see 4 logs
+    And log number 1 has the user 'me'
+    And log number 1 has the change type 'Regions'
+    And log number 2 has the user 'me'
+    And log number 2 has the change type 'Regions'
+    And log number 3 has the user 'me'
+    And log number 3 has the change type 'Regions'
+    And I click on log number 3
+    Then I am on the 'Changes to supplier regions' page
+    And the supplier who was changed is 'Muller Inc'
+    And the change was made by 'me'
+    And the change was made in lot '2b'
+    And the following items were added:
+      | Northumberland and Tyne and Wear  |
+      | West Midlands (county)            |
+      | Surrey, East and West Sussex      |
+    And the following items were removed:
+      | Tees Valley and Durham  |
+      | Flintshire and Wrexham  |
+      | Shetland Islands        | 
+    Then I click on 'Supplier data change log'
+    And I am on the 'Supplier data change log' page
+    And I click on log number 2
+    Then I am on the 'Changes to supplier regions' page
+    And the supplier who was changed is 'Muller Inc'
+    And the change was made by 'me'
+    And the change was made in lot '3b'
+    And the following items were added:
+      | Cumbria     |
+      | Cheshire    |
+      | Merseyside  |
+    Then I click on 'Supplier data change log'
+    And I am on the 'Supplier data change log' page
+    And I click on log number 1
+    Then I am on the 'Changes to supplier regions' page
+    And the supplier who was changed is 'Muller Inc'
+    And the change was made by 'me'
+    And the change was made in lot '2c'
+    And the following items were removed:
+      | East Anglia                     |
+      | Bedfordshire and Hertfordshire  |
+      | Essex                           |

--- a/features/facilities_management/rm6232/admin/change_logs/changes_to_services.feature
+++ b/features/facilities_management/rm6232/admin/change_logs/changes_to_services.feature
@@ -1,0 +1,76 @@
+@pipeline
+Feature: Change log for supplier services
+
+  Scenario: Changes to the supplier services are logged
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    Then I click on 'View lot data' for 'Green Group'
+    And I change the 'services' for lot '1c'
+    Then I am on the 'Lot 1c services' page
+    And I select the following items:
+      | E.16 Television cabling maintenance |
+      | J.15 Portable washroom solutions    |
+      | N.8 Footwear cobbling Services      |
+    And I deselect the following items:
+      | G.8 Cut flowers and Christmas trees                         |
+      | I.10 Reactive cleaning (outside cleaning operational hours) |
+      | P.8 Accommodation Stores Service                            |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I change the 'services' for lot '3c'
+    Then I am on the 'Lot 3c services' page
+    And I select the following items:
+      | L.14 Remote CCTV / alarm monitoring     |
+      | M.4 Recycled waste and waste for re-use |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I change the 'services' for lot '2c'
+    Then I am on the 'Lot 2c services' page
+    And I deselect the following items:
+      | E.19 Voice announcement system maintenance  |
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I click on 'Home'
+    Then I am on the 'RM6232 administration dashboard' page
+    And I click on 'Supplier data change log'
+    Then I am on the 'Supplier data change log' page
+    And I should see 4 logs
+    And log number 1 has the user 'me'
+    And log number 1 has the change type 'Services'
+    And log number 2 has the user 'me'
+    And log number 2 has the change type 'Services'
+    And log number 3 has the user 'me'
+    And log number 3 has the change type 'Services'
+    And I click on log number 3
+    Then I am on the 'Changes to supplier services' page
+    And the supplier who was changed is 'Green Group'
+    And the change was made by 'me'
+    And the change was made in lot '1c'
+    And the following items were added:
+      | E.16 Television cabling maintenance |
+      | J.15 Portable washroom solutions    |
+      | N.8 Footwear cobbling Services      |
+    And the following items were removed:
+      | G.8 Cut flowers and Christmas trees                         |
+      | I.10 Reactive cleaning (outside cleaning operational hours) |
+      | P.8 Accommodation Stores Service                            |    
+    Then I click on 'Supplier data change log'
+    And I am on the 'Supplier data change log' page
+    And I click on log number 2
+    Then I am on the 'Changes to supplier services' page
+    And the supplier who was changed is 'Green Group'
+    And the change was made by 'me'
+    And the change was made in lot '3c'
+    And the following items were added:
+      | L.14 Remote CCTV / alarm monitoring     |
+      | M.4 Recycled waste and waste for re-use |
+    Then I click on 'Supplier data change log'
+    And I am on the 'Supplier data change log' page
+    And I click on log number 1
+    Then I am on the 'Changes to supplier services' page
+    And the supplier who was changed is 'Green Group'
+    And the change was made by 'me'
+    And the change was made in lot '2c'
+    And the following items were removed:
+      | E.19 Voice announcement system maintenance  |

--- a/features/facilities_management/rm6232/admin/change_logs/data_uploaded.feature
+++ b/features/facilities_management/rm6232/admin/change_logs/data_uploaded.feature
@@ -1,0 +1,26 @@
+@pipeline
+Feature: Change log for data uploads
+
+  Scenario: Data uploads are logged
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And the user 'reiner.braun@attackontitn.pa' has uploaded some data
+    And I click on 'Supplier data change log'
+    Then I am on the 'Supplier data change log' page
+    And I should see 2 logs
+    And log number 1 has the user 'reiner.braun@attackontitn.pa'
+    And log number 1 has the change type 'Data uploaded'
+    And log number 2 has the user 'During a deployment'
+    And log number 2 has the change type 'Data uploaded'
+    And I click on log number 2
+    Then I am on the 'Supplier data upload' page
+    And the following content should be displayed on the page:
+      | This upload was created via a deployment to the application.    |
+      | You can get the data that was used by speaking to a developer.  |
+    Then I click on 'Supplier data change log'
+    And I am on the 'Supplier data change log' page
+    And I click on log number 1
+    Then I am on the 'Supplier data upload' page
+    And the change was made by 'reiner.braun@attackontitn.pa'
+    And I click on 'upload'
+    And I am on the 'Upload session' page
+    And the upload was done by 'reiner.braun@attackontitn.pa'

--- a/features/step_definitions/facilities_management/admin_steps.rb
+++ b/features/step_definitions/facilities_management/admin_steps.rb
@@ -37,12 +37,5 @@ Then('the current user has the user email') do
 end
 
 Then('I enter {string} into the {string} field') do |supplier_detail, field|
-  current_admin_page = case @framework
-                       when 'RM3830'
-                         admin_rm3830_page
-                       when 'RM6232'
-                         admin_rm6232_page
-                       end
-
-  current_admin_page.supplier_detail_form.send(field.to_sym).set(supplier_detail)
+  admin_page.supplier_detail_form.send(field.to_sym).set(supplier_detail)
 end

--- a/features/step_definitions/facilities_management/rm3830/admin_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/admin_steps.rb
@@ -18,7 +18,7 @@ Given('select {string} for sublot {string} for {string}') do |option, sublot, su
                 option
               end
 
-  supplier_section = admin_rm3830_page.find('h2', text: supplier).find(:xpath, '../..')
+  supplier_section = admin_page.find('h2', text: supplier).find(:xpath, '../..')
   sublot_section = supplier_section.find('span', text: "Sub-lot #{sublot}").find(:xpath, '..')
   sublot_section.click_on(link_text)
 end
@@ -44,7 +44,7 @@ Then('{string} is a supplier in Sub-lot {string}') do |supplier, sublot|
 end
 
 Given('I enter the user email into the user email field') do
-  admin_rm3830_page.supplier_detail_form.send(:'User email').set(@user.email)
+  admin_page.supplier_detail_form.send(:'User email').set(@user.email)
 end
 
 Given('other user accounts exist') do
@@ -54,16 +54,16 @@ Given('other user accounts exist') do
 end
 
 Given('I enter {string} into the Direct award discount filed for {string}') do |value, service|
-  admin_rm3830_page.find(:xpath, "//label[text()='#{service}']/../../../../td[1]/input").set(value)
+  admin_page.find(:xpath, "//label[text()='#{service}']/../../../../td[1]/input").set(value)
 end
 
 Given('I enter {string} into the variance for {string}') do |value, variance|
-  admin_rm3830_page.find(:xpath, "//label[text()='#{variance}']/../../td[1]/input").set(value)
+  admin_page.find(:xpath, "//label[text()='#{variance}']/../../td[1]/input").set(value)
 end
 
 Given('I enter {string} into the price for {string} under {string}') do |price, service, building_type|
   index = BUILDING_TYPES.index(building_type) + 2
-  admin_rm3830_page.find(:xpath, "//label[text()='#{service}']/../../../../td[#{index}]/input").set(price)
+  admin_page.find(:xpath, "//label[text()='#{service}']/../../../../td[#{index}]/input").set(price)
 end
 
 BUILDING_TYPES = ['General office - Customer Facing', 'General office - Non Customer Facing', 'Call Centre Operations', 'Warehouses', 'Restaurant and Catering Facilities', 'Pre-School', 'Primary School', 'Secondary Schools', 'Special Schools', 'Universities and Colleges', 'Community - Doctors, Dentist, Health Clinic', 'Nursing and Care Homes'].freeze
@@ -81,7 +81,7 @@ STANDARD_COLUMN = { 'A' => 1, 'B' => 2, 'C' => 3 }.freeze
 Given('I enter the servie rate of {string} for {string} standard {string}') do |value, field, standard|
   service_standard = standard == '' ? 'normal price' : "standard #{standard}"
 
-  admin_rm3830_page.find("input[aria-label='#{field} #{service_standard}']").set(value)
+  admin_page.find("input[aria-label='#{field} #{service_standard}']").set(value)
 end
 
 Then('I enter {string} as the {string} date') do |date, date_type|
@@ -90,7 +90,7 @@ end
 
 Then('the following services should have the following rates:') do |services_and_rates|
   services_and_rates.raw.each do |service_and_rate|
-    expect(admin_rm3830_page.find_field(service_and_rate[0]).value).to eq service_and_rate[1]
+    expect(admin_page.find_field(service_and_rate[0]).value).to eq service_and_rate[1]
   end
 end
 
@@ -98,14 +98,14 @@ Then('the following services should have the following rates for their standard:
   services_and_rates.raw.each do |service_and_rate|
     service_standard = service_and_rate[2] == '' ? 'normal price' : "standard #{service_and_rate[2]}"
 
-    expect(admin_rm3830_page.find("input[aria-label='#{service_and_rate[0]} #{service_standard}']").value).to eq service_and_rate[1]
+    expect(admin_page.find("input[aria-label='#{service_and_rate[0]} #{service_standard}']").value).to eq service_and_rate[1]
   end
 end
 
 Then('the management report has the correct date range') do
   date_range = "Report for date range: #{Time.zone.yesterday.strftime('%d/%-m/%Y')} - #{Time.zone.today.strftime('%d/%-m/%Y')}"
 
-  expect(admin_rm3830_page.management_report_date).to have_content(date_range)
+  expect(admin_page.management_report_date).to have_content(date_range)
 end
 
 Then('I enter the service requirements for {string} in the assessed value procurement') do |building_name|
@@ -139,7 +139,7 @@ Then('I enter the service requirements for {string} in the assessed value procur
 end
 
 def add_management_report_dates(date_type, day, month, year)
-  admin_rm3830_page.management_report.send("#{date_type} day").set(day)
-  admin_rm3830_page.management_report.send("#{date_type} month").set(month)
-  admin_rm3830_page.management_report.send("#{date_type} year").set(year)
+  admin_page.management_report.send("#{date_type} day").set(day)
+  admin_page.management_report.send("#{date_type} month").set(month)
+  admin_page.management_report.send("#{date_type} year").set(year)
 end

--- a/features/step_definitions/facilities_management/rm6232/admin_steps.rb
+++ b/features/step_definitions/facilities_management/rm6232/admin_steps.rb
@@ -3,32 +3,32 @@ Given('I have an inactive supplier called {string}') do |supplier_name|
 end
 
 Then('I should see all the suppliers') do
-  expect(admin_rm6232_page.suppliers.length).to eq 50
+  expect(admin_page.suppliers.length).to eq 50
 end
 
 Then('I enter {string} for the supplier search') do |supplier_name|
-  admin_rm6232_page.supplier_search_input.fill_in with: "#{supplier_name}\n"
+  admin_page.supplier_search_input.fill_in with: "#{supplier_name}\n"
 end
 
 Then('I should see the following suppliers on the page:') do |supplier_names|
-  expect(admin_rm6232_page.suppliers.length).to eq(supplier_names.raw.flatten.length)
+  expect(admin_page.suppliers.length).to eq(supplier_names.raw.flatten.length)
 
-  admin_rm6232_page.suppliers.map(&:supplier_name).zip(supplier_names.raw.flatten).each do |element, value|
+  admin_page.suppliers.map(&:supplier_name).zip(supplier_names.raw.flatten).each do |element, value|
     expect(element).to have_content(value)
   end
 end
 
 Then('I click on {string} for {string}') do |text, supplier_name|
-  admin_rm6232_page.suppliers.find { |element| element.supplier_name.text == supplier_name }.send(text).click
+  admin_page.suppliers.find { |element| element.supplier_name.text == supplier_name }.send(text).click
 end
 
 Then('the supplier name shown is {string}') do |supplier_name|
-  expect(admin_rm6232_page.supplier_name_sub_title).to have_content(supplier_name)
+  expect(admin_page.supplier_name_sub_title).to have_content(supplier_name)
 end
 
 Then('they have services and regions for the following lots {string}') do |lots|
   expected_lots = lots.split(',').map(&:strip)
-  actual_lots = admin_rm6232_page.lot_data_tables.map(&:title)
+  actual_lots = admin_page.lot_data_tables.map(&:title)
 
   expect(actual_lots.length).to eq expected_lots.length
 
@@ -38,23 +38,23 @@ Then('they have services and regions for the following lots {string}') do |lots|
 end
 
 Then('I change the {string} for lot {string}') do |lot_data_type, lot_code|
-  admin_rm6232_page.lot_data.send("lot_#{lot_code}").send(lot_data_type).change_link.click
+  admin_page.lot_data.send("lot_#{lot_code}").send(lot_data_type).change_link.click
 end
 
 Then('I deselect all checkboxes') do
-  admin_rm6232_page.all('input[type="checkbox"][checked="checked"]').each(&:uncheck)
+  admin_page.all('input[type="checkbox"][checked="checked"]').each(&:uncheck)
 end
 
 Then('I should see the following regions selected for lot {string}:') do |lot_code, regions|
   expected_regions = regions.raw.flatten
-  actual_regions = admin_rm6232_page.lot_data.send("lot_#{lot_code}").regions.names.map(&:text)
+  actual_regions = admin_page.lot_data.send("lot_#{lot_code}").regions.names.map(&:text)
 
   expect(actual_regions).to eq expected_regions
 end
 
 Then('I should see the following services selected for lot {string}:') do |lot_code, services|
   expected_services = services.raw.flatten
-  actual_services = admin_rm6232_page.lot_data.send("lot_#{lot_code}").services.names.map(&:text)
+  actual_services = admin_page.lot_data.send("lot_#{lot_code}").services.names.map(&:text)
   core_service_names = core_services(lot_code[0]).map(&:name)
 
   expect(core_service_names - actual_services).to be_empty
@@ -62,7 +62,7 @@ Then('I should see the following services selected for lot {string}:') do |lot_c
 end
 
 Then("I can't select any core services") do
-  core_service_labels = admin_rm6232_page.all('input[type="checkbox"][disabled]').map { |element| element.find(:xpath, '../label').text }
+  core_service_labels = admin_page.all('input[type="checkbox"][disabled]').map { |element| element.find(:xpath, '../label').text }
   core_service_names = core_services('1').map(&:label_name)
 
   expect(core_service_labels).to eq core_service_names
@@ -71,9 +71,9 @@ end
 Then('I select {string} for the supplier status') do |option|
   case option
   when 'ACTIVE'
-    admin_rm6232_page.active_true.choose
+    admin_page.active_true.choose
   when 'INACTIVE'
-    admin_rm6232_page.active_false.choose
+    admin_page.active_false.choose
   end
 end
 
@@ -112,6 +112,76 @@ Then('the supplier {string} {string} in the results') do |supplier, option|
   when 'is'
     expect(supplier_list).to include supplier
   end
+end
+
+Then('I should see {int} logs') do |number_of_logs|
+  expect(admin_page.log_table.log_rows.length).to eq number_of_logs
+end
+
+Then('log number {int} has the user {string}') do |log_number, email|
+  email = @user.email if email == 'me'
+
+  expect(admin_page.log_table.log_rows[log_number - 1].find('td:nth-of-type(3)')).to have_content(email)
+end
+
+Then('log number {int} has the change type {string}') do |log_number, change_type|
+  expect(admin_page.log_table.log_rows[log_number - 1].find('td:nth-of-type(4)')).to have_content(change_type)
+end
+
+Then('I click on log number {int}') do |log_number|
+  admin_page.log_table.log_rows[log_number - 1].find('td:nth-of-type(1) > a').click
+end
+
+Then('the supplier who was changed is {string}') do |supplier_name|
+  expect(admin_page.updated_supplier).to have_content(supplier_name)
+end
+
+Then('the change was made by {string}') do |email|
+  email = @user.email if email == 'me'
+
+  expect(admin_page.updated_by_email).to have_content(email)
+end
+
+Then('the change was made in lot {string}') do |lot_code|
+  expect(admin_page.updated_lot).to have_content("Lot #{lot_code}")
+end
+
+Then('I should see the following changes to the supplier details:') do |changes_table|
+  expect(admin_page.changes_table.changes_rows.length).to eq changes_table.raw.length
+
+  admin_page.changes_table.changes_rows.zip(changes_table.raw).each do |actual_row, expected_row|
+    expect(actual_row.attribute).to have_content(expected_row[0])
+    expect(actual_row.prev_value).to have_content(expected_row[1])
+    expect(actual_row.new_value).to have_content(expected_row[2])
+  end
+end
+
+Then('the following items were added:') do |added_items|
+  expect(admin_page.added_items.length).to eq(added_items.raw.flatten.length)
+
+  admin_page.added_items.zip(added_items.raw.flatten).each do |element, value|
+    expect(element).to have_content(value)
+  end
+end
+
+Then('the following items were removed:') do |removed_items|
+  expect(admin_page.removed_items.length).to eq(removed_items.raw.flatten.length)
+
+  admin_page.removed_items.zip(removed_items.raw.flatten).each do |element, value|
+    expect(element).to have_content(value)
+  end
+end
+
+Given('the user {string} has uploaded some data') do |email|
+  new_user = create(:user, email: email)
+  new_upload = create(:facilities_management_rm6232_admin_upload, user: new_user, aasm_state: 'published')
+  FacilitiesManagement::RM6232::Admin::SupplierData.create(upload: new_upload)
+end
+
+Then('the upload was done by {string}') do |email|
+  email = @user.email if email == 'me'
+
+  expect(admin_page.uploaded_by_email).to have_content(email)
 end
 
 def core_services(lot_number)

--- a/features/support/pages.rb
+++ b/features/support/pages.rb
@@ -1,6 +1,11 @@
 module Pages
   def admin_page
-    @admin_page ||= Admin.new
+    @admin_page ||= case @framework
+                    when 'RM3830'
+                      admin_rm3830_page
+                    when 'RM6232'
+                      admin_rm6232_page
+                    end
   end
 
   def admin_rm3830_page

--- a/features/support/pages/rm3830/admin.rb
+++ b/features/support/pages/rm3830/admin.rb
@@ -1,5 +1,7 @@
+require_relative '../admin'
+
 module Pages::RM3830
-  class Admin < SitePrism::Page
+  class Admin < Pages::Admin
     section :supplier_detail_form, 'form' do
       element :'User email', '#facilities_management_rm3830_admin_suppliers_admin_user_email'
       element :'Supplier name', '#facilities_management_rm3830_admin_suppliers_admin_supplier_name'

--- a/features/support/pages/rm6232/admin.rb
+++ b/features/support/pages/rm6232/admin.rb
@@ -1,3 +1,5 @@
+require_relative '../admin'
+
 module Pages::RM6232
   class LotData < SitePrism::Section
     section :services, 'dl > div:nth-child(1)' do
@@ -10,7 +12,13 @@ module Pages::RM6232
     end
   end
 
-  class Admin < SitePrism::Page
+  class ChangesRow < SitePrism::Section
+    element :attribute, 'th'
+    element :prev_value, 'td:nth-of-type(1)'
+    element :new_value, 'td:nth-of-type(2)'
+  end
+
+  class Admin < Pages::Admin
     sections :suppliers, '#fm-table-filter > tbody > tr', visible: true do
       element :supplier_name, 'th'
       element :'View details', 'td:nth-child(2) > a'
@@ -45,5 +53,21 @@ module Pages::RM6232
 
     element :active_true, '#facilities_management_rm6232_admin_suppliers_admin_active_true'
     element :active_false, '#facilities_management_rm6232_admin_suppliers_admin_active_false'
+
+    section :log_table, '#main-content > div:nth-child(5) > div > table' do
+      elements :log_rows, 'tbody > tr'
+    end
+
+    element :updated_supplier, '#updated-supplier'
+    element :updated_by_email, '#updated-by-email'
+    element :uploaded_by_email, '#uploaded-by-email'
+    element :updated_lot, '#updated-lot'
+
+    section :changes_table, '#main-content > div:nth-child(6) > div > table' do
+      sections :changes_rows, ChangesRow, 'tbody > tr'
+    end
+
+    elements :added_items, '#added-items > li'
+    elements :removed_items, '#removed-items > li'
   end
 end

--- a/spec/controllers/facilities_management/rm6232/admin/change_logs_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/change_logs_controller_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::ChangeLogsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM6232' } }
+
+  login_fm_admin
+
+  describe 'GET index' do
+    context 'when logged in as an fm admin' do
+      before { get :index }
+
+      it 'renders the index' do
+        expect(response).to render_template(:index)
+      end
+
+      it 'gets a list of all the audits' do
+        expect(assigns(:audit_logs).size).to eq 1
+      end
+    end
+
+    context 'when not logged in as an fm admin' do
+      login_fm_buyer
+
+      it 'redirects to not permitted page' do
+        get :index
+        expect(response).to redirect_to '/facilities-management/RM6232/admin/not-permitted'
+      end
+    end
+  end
+
+  describe 'GET show' do
+    let(:supplier_data) { FacilitiesManagement::RM6232::Admin::SupplierData.latest_data }
+    let(:supplier) { supplier_data.data.first }
+
+    render_views
+
+    before { get :show, params: { change_log_id: change_log_id, change_type: change_type } }
+
+    context 'when there are change_type is upload' do
+      let(:change_type) { 'upload' }
+      let(:change_log_id) { supplier_data.id }
+
+      it 'renders the upload partial' do
+        expect(response).to render_template(partial: '_upload')
+      end
+    end
+
+    context 'when there are change_type is details' do
+      let(:change_type) { 'details' }
+      let(:change_log_id) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: controller.current_user).id }
+
+      it 'renders the details partial' do
+        expect(response).to render_template(partial: '_details')
+      end
+    end
+
+    context 'when there are change_type is lot_data' do
+      let(:change_type) { 'lot_data' }
+      let(:change_log_id) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data, user: controller.current_user).id }
+
+      it 'renders the lot_data partial' do
+        expect(response).to render_template(partial: '_lot_data')
+      end
+    end
+
+    context 'when there are change_type is not upload, details or lot_data' do
+      let(:change_type) { 'service_codes' }
+      let(:change_log_id) { supplier_data.id }
+
+      it 'redirects to the index page' do
+        expect(response).to redirect_to facilities_management_rm6232_admin_change_logs_path
+      end
+    end
+  end
+end

--- a/spec/factories/facilities_management/rm6232/admin/supplier_data/edit.rb
+++ b/spec/factories/facilities_management/rm6232/admin/supplier_data/edit.rb
@@ -1,0 +1,28 @@
+FactoryBot.define do
+  factory :facilities_management_rm6232_admin_supplier_data_edit, class: 'FacilitiesManagement::RM6232::Admin::SupplierData::Edit' do
+    id { SecureRandom.uuid }
+    association :user
+
+    supplier_data do |edit|
+      supplier_data = FacilitiesManagement::RM6232::Admin::SupplierData.latest_data
+      edit.supplier_id = supplier_data.data.first['id']
+
+      FacilitiesManagement::RM6232::Admin::SupplierData.latest_data
+    end
+
+    trait :with_details do
+      change_type { 'details' }
+      data { [{ 'attribute' => 'active', 'value' => false }] }
+    end
+
+    trait :with_service_lot_data do
+      change_type { 'lot_data' }
+      data { { 'lot_code' => '1a', 'attribute' => 'service_codes', 'added' => ['A.1'], 'removed' => [] } }
+    end
+
+    trait :with_region_lot_data do
+      change_type { 'lot_data' }
+      data { { 'lot_code' => '1a', 'attribute' => 'region_codes', 'added' => [], 'removed' => ['UKC1'] } }
+    end
+  end
+end

--- a/spec/factories/facilities_management/rm6232/admin/upload.rb
+++ b/spec/factories/facilities_management/rm6232/admin/upload.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :facilities_management_rm6232_admin_upload, class: 'FacilitiesManagement::RM6232::Admin::Upload' do
+    association :user
   end
 
   factory :facilities_management_rm6232_admin_upload_with_upload, parent: :facilities_management_rm6232_admin_upload do

--- a/spec/helpers/facilities_management/rm6232/admin/change_logs_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm6232/admin/change_logs_helper_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::ChangeLogsHelper, type: :helper do
+  describe '.show_page_title' do
+    let(:result) { helper.show_page_title }
+
+    before { @change_log = change_log }
+
+    context 'when the true_change_type is details' do
+      let(:change_log) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details) }
+
+      it "returns 'Changes to supplier details'" do
+        expect(result).to eq('Changes to supplier details')
+      end
+    end
+
+    context 'when the true_change_type is region_codes' do
+      let(:change_log) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_region_lot_data) }
+
+      it "returns 'Changes to supplier regions'" do
+        expect(result).to eq('Changes to supplier regions')
+      end
+    end
+
+    context 'when the true_change_type is service_codes' do
+      let(:change_log) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data) }
+
+      it "returns 'Changes to supplier services'" do
+        expect(result).to eq('Changes to supplier services')
+      end
+    end
+
+    context 'when the true_change_type is upload' do
+      let(:change_log) { FacilitiesManagement::RM6232::Admin::SupplierData.latest_data }
+
+      it "returns 'Supplier data upload'" do
+        expect(result).to eq('Supplier data upload')
+      end
+    end
+  end
+
+  describe '.item_names' do
+    let(:result) { helper.item_names(codes) }
+
+    before { @change_log = change_log }
+
+    context 'when passing in region codes' do
+      let(:change_log) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_region_lot_data) }
+      let(:codes) { %w[UKD1 UKC1 UKM26] }
+
+      it 'returns the region names with the region codes sorted' do
+        expect(result).to eq(
+          [
+            'Tees Valley and Durham (UKC1)',
+            'Cumbria (UKD1)',
+            'Falkirk (UKM26)'
+          ]
+        )
+      end
+    end
+
+    context 'when passing in service codes' do
+      let(:change_log) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data) }
+      let(:codes) { %w[F.4 E.12 E.5 F.5] }
+
+      it 'returns the service codes with the service name sorted' do
+        expect(result).to eq(
+          [
+            'E.5 Lifts, hoists and conveyance systems maintenance',
+            'E.12 Standby power system maintenance',
+            'F.4 Portable Appliance Testing',
+            'F.5 Miscellaneous Surveys, Audits and Testing Services'
+          ]
+        )
+      end
+    end
+  end
+
+  describe '.get_attribute_value' do
+    let(:result) { helper.get_attribute_value(attribute, value) }
+
+    context "when the attribute is 'active'" do
+      let(:attribute) { 'active' }
+
+      context 'and the value is nil' do
+        let(:value) { nil }
+
+        it 'returns the active tag' do
+          expect(result).to eq '<strong class="govuk-tag govuk-tag">ACTIVE</strong>'
+        end
+      end
+
+      context 'and the value is true' do
+        let(:value) { true }
+
+        it 'returns the active tag' do
+          expect(result).to eq '<strong class="govuk-tag govuk-tag">ACTIVE</strong>'
+        end
+      end
+
+      context 'and the value is false' do
+        let(:value) { false }
+
+        it 'returns the inactive tag' do
+          expect(result).to eq '<strong class="govuk-tag govuk-tag--red">INACTIVE</strong>'
+        end
+      end
+    end
+
+    context "when the attribute is not 'active'" do
+      let(:attribute) { 'supplier_name' }
+      let(:value) { 'Fifi' }
+
+      it 'returns the value' do
+        expect(result).to eq value
+      end
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/admin/supplier_data/edit_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/supplier_data/edit_spec.rb
@@ -81,4 +81,132 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData::Edit, type: :m
       end
     end
   end
+
+  describe '.true_change_type' do
+    let(:result) { edit.true_change_type }
+
+    context 'when the change_type is details' do
+      let(:edit) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details) }
+
+      it 'returns details' do
+        expect(result).to eq('details')
+      end
+    end
+
+    context 'when the change_type is lot_data' do
+      context 'and the attribute is service_codes' do
+        let(:edit) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data) }
+
+        it 'returns service_codes' do
+          expect(result).to eq('service_codes')
+        end
+      end
+
+      context 'and the attribute is region_codes' do
+        let(:edit) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_region_lot_data) }
+
+        it 'returns region_codes' do
+          expect(result).to eq('region_codes')
+        end
+      end
+    end
+  end
+
+  describe '.short_id' do
+    let(:edit) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data) }
+
+    it 'returns the shortened uuid' do
+      expect(edit.short_id).to eq("##{edit.id[..7]}")
+    end
+  end
+
+  describe '.current_supplier_data' do
+    let(:supplier_data) { FacilitiesManagement::RM6232::Admin::SupplierData.latest_data }
+    let(:supplier) { FacilitiesManagement::RM6232::Supplier.find(supplier_data.data.first['id']) }
+    let(:edit_1) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data, created_at: dates[0]) }
+    let(:edit_2) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, created_at: dates[1]) }
+    let(:edit_3) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_region_lot_data, created_at: dates[2]) }
+    let(:dates) { [Time.zone.now - 3.days, Time.zone.now - 2.days, Time.zone.now - 1.day] }
+
+    before do
+      edit_1
+      edit_2
+      edit_3
+    end
+
+    context 'when there are no previous changes' do
+      let(:result) { edit_1.current_supplier_data }
+
+      it 'includes the changes in the returned data' do
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['service_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').service_codes + ['A.1']
+        expect(result['active']).to be_nil
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['region_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').region_codes
+      end
+    end
+
+    context 'when there is one previous changes' do
+      let(:result) { edit_2.current_supplier_data }
+
+      it 'includes the changes in the returned data' do
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['service_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').service_codes + ['A.1']
+        expect(result['active']).to be false
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['region_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').region_codes
+      end
+    end
+
+    context 'when there are multiple previous changes' do
+      let(:result) { edit_3.current_supplier_data }
+
+      it 'includes the changes in the returned data' do
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['service_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').service_codes + ['A.1']
+        expect(result['active']).to be false
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['region_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').region_codes - ['UKC1']
+      end
+    end
+  end
+
+  describe '.previous_supplier_data' do
+    let(:supplier_data) { FacilitiesManagement::RM6232::Admin::SupplierData.latest_data }
+    let(:supplier) { FacilitiesManagement::RM6232::Supplier.find(supplier_data.data.first['id']) }
+    let(:edit_1) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data, created_at: dates[0]) }
+    let(:edit_2) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, created_at: dates[1]) }
+    let(:edit_3) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_region_lot_data, created_at: dates[2]) }
+    let(:dates) { [Time.zone.now - 3.days, Time.zone.now - 2.days, Time.zone.now - 1.day] }
+
+    before do
+      edit_1
+      edit_2
+      edit_3
+    end
+
+    context 'when there are no previous changes' do
+      let(:result) { edit_1.previous_supplier_data }
+
+      it 'matches the data in supplier data' do
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['service_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').service_codes
+        expect(result['active']).to be_nil
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['region_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').region_codes
+      end
+    end
+
+    context 'when there is one previous changes' do
+      let(:result) { edit_2.previous_supplier_data }
+
+      it 'includes only previous the changes in the returned data' do
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['service_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').service_codes + ['A.1']
+        expect(result['active']).to be_nil
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['region_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').region_codes
+      end
+    end
+
+    context 'when there are multiple previous changes' do
+      let(:result) { edit_3.previous_supplier_data }
+
+      it 'includes only previous the changes in the returned data' do
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['service_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').service_codes + ['A.1']
+        expect(result['active']).to be false
+        expect(result['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['region_codes']).to eq supplier.lot_data.find_by(lot_code: '1a').region_codes
+      end
+    end
+  end
 end

--- a/spec/models/facilities_management/rm6232/admin/supplier_data_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/supplier_data_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData, type: :model do
-  describe 'latest_data' do
+  describe '.latest_data' do
     let(:latest_data) { described_class.create }
 
     before do
@@ -11,6 +11,76 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData, type: :model d
 
     it 'is the latest set of data' do
       expect(described_class.latest_data).to eq latest_data
+    end
+  end
+
+  describe '.audit_logs' do
+    let(:user_1) { create(:user) }
+    let(:user_2) { create(:user) }
+    let(:supplier_data) { described_class.latest_data }
+    let(:edit_1) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data, user: user_1, created_at: dates[1]) }
+    let(:edit_2) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: dates[2]) }
+    let(:edit_3) { create(:facilities_management_rm6232_admin_supplier_data_edit, :with_region_lot_data, user: user_1, created_at: dates[3]) }
+    let(:dates) { [Time.zone.now - 4.days, Time.zone.now - 3.days, Time.zone.now - 2.days, Time.zone.now - 1.day] }
+
+    before do
+      supplier_data.update(created_at: dates[0])
+      edit_1
+      edit_2
+      edit_3
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'creates the audit logs from the edits' do
+      expected_audit_logs = [
+        {
+          id: edit_3.id,
+          short_id: "##{edit_3.id[..7]}",
+          user_email: user_1.email,
+          change_type: 'lot_data',
+          true_change_type: 'region_codes'
+        },
+        {
+          id: edit_2.id,
+          short_id: "##{edit_2.id[..7]}",
+          user_email: user_2.email,
+          change_type: 'details',
+          true_change_type: 'details'
+        },
+        {
+          id: edit_1.id,
+          short_id: "##{edit_1.id[..7]}",
+          user_email: user_1.email,
+          change_type: 'lot_data',
+          true_change_type: 'service_codes'
+        },
+        {
+          id: supplier_data.id,
+          short_id: "##{supplier_data.id[..7]}",
+          user_email: nil,
+          change_type: 'upload',
+          true_change_type: 'upload'
+        }
+      ]
+
+      expect(described_class.audit_logs.map { |change_log| change_log.except(:created_at) }).to eq(expected_audit_logs)
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
+  describe '.true_change_type' do
+    let(:supplier_data) { described_class.latest_data }
+
+    it 'returns upload' do
+      expect(supplier_data.true_change_type).to eq('upload')
+    end
+  end
+
+  describe '.short_id' do
+    let(:supplier_data) { described_class.latest_data }
+
+    it 'returns the shortened uuid' do
+      expect(supplier_data.short_id).to eq("##{supplier_data.id[..7]}")
     end
   end
 end


### PR DESCRIPTION
Ticket: [FMFR-1249](https://crowncommercialservice.atlassian.net/browse/FMFR-1249)

There is a requirement from the admin team that all changes that are made to the supplier data are logged. In this commit I have added views which will allow the admin users to view all the changes that have been made.

As always I have added specs to make sure everything is working as expected. In a future commit I will add a section to view who made the changes.