### PR TITLE
FMFR-1249 - Add ability to download full audit log

### DIFF
--- a/app/controllers/facilities_management/rm6232/admin/change_logs_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/change_logs_controller.rb
@@ -7,7 +7,12 @@ module FacilitiesManagement
         helper_method :change_type
 
         def index
-          @audit_logs = Kaminari.paginate_array(SupplierData.audit_logs).page(params[:page])
+          respond_to do |format|
+            format.html { @audit_logs = Kaminari.paginate_array(SupplierData.audit_logs).page(params[:page]) }
+            format.csv do
+              send_data ChangeLogsCsvGenerator.generate_csv, filename: "Full change logs (#{DateTime.now.in_time_zone('London').strftime('%d_%m_%Y %H_%M').squish}).csv", type: 'text/csv'
+            end
+          end
         end
 
         def show; end

--- a/app/services/facilities_management/rm6232/admin/change_logs_csv_generator.rb
+++ b/app/services/facilities_management/rm6232/admin/change_logs_csv_generator.rb
@@ -1,0 +1,128 @@
+module FacilitiesManagement::RM6232
+  module Admin
+    class ChangeLogsCsvGenerator
+      COLUMN_LABELS = [
+        'Log item',
+        'Date of change',
+        'User',
+        'Supplier name',
+        'Change type',
+        'Changes'
+      ].freeze
+
+      CHANGE_TYPE_TO_TEXT = {
+        'details' => 'Details',
+        'service_codes' => 'Services',
+        'region_codes' => 'Regions'
+      }.freeze
+
+      ATTRIBUTE_TO_LABEL = {
+        'active' => 'Status',
+        'address_county' => 'County',
+        'address_line_1' => 'Building and street',
+        'address_line_2' => 'Building and street (line 2)',
+        'address_postcode' => 'Postcode',
+        'address_town' => 'Town or city',
+        'duns' => 'DUNS number',
+        'registration_number' => 'Company registration number',
+        'supplier_name' => 'Supplier name'
+      }.freeze
+
+      def self.generate_csv
+        CSV.generate do |csv|
+          csv << COLUMN_LABELS
+          audit_logs.each { |row| csv << row }
+        end
+      end
+
+      def self.audit_logs
+        SupplierData.order(created_at: :asc).map do |supplier_data|
+          current_supplier_data = supplier_data.data
+
+          [
+            get_supplier_data_row(supplier_data)
+          ] + supplier_data.edits.order(created_at: :asc).map do |edit|
+            supplier = current_supplier_data.find { |supplier_item| supplier_item['id'] == edit.supplier_id }
+
+            change_info_list = if edit.change_type == 'lot_data'
+                                 change_info_list_lot_data(edit)
+                               else
+                                 change_info_list_detail(edit, supplier)
+                               end
+
+            get_supplier_edit_row(edit, supplier, change_info_list)
+          end
+        end.flatten(1).reverse
+      end
+
+      def self.get_supplier_data_row(supplier_data)
+        [
+          supplier_data.short_id,
+          format_date_time(supplier_data.created_at),
+          supplier_data.upload&.user&.email || 'During a deployment',
+          'N/A',
+          'Data uploaded',
+          supplier_data.upload ? "Upload: #{Marketplace.rails_env_url}/facilities-management/RM6232/admin/uploads/#{supplier_data.upload.id}" : 'N/A'
+        ]
+      end
+
+      def self.get_supplier_edit_row(edit, supplier, change_info_list)
+        [
+          edit.short_id,
+          format_date_time(edit.created_at),
+          edit.user.email,
+          supplier['supplier_name'],
+          CHANGE_TYPE_TO_TEXT[edit.true_change_type],
+          change_info_list.join("\n")
+        ]
+      end
+
+      def self.change_info_list_lot_data(edit)
+        change_info_list = ["Lot code: #{edit.data['lot_code']}"]
+
+        change_info_list << "Added items: #{item_names(edit.data['attribute'], edit.data['added'])}" if edit.data['added'].any?
+        change_info_list << "Removed items: #{item_names(edit.data['attribute'], edit.data['removed'])}" if edit.data['removed'].any?
+
+        change_info_list
+      end
+
+      def self.change_info_list_detail(edit, supplier)
+        edit.data.map do |detail|
+          old_value = get_attribute_value(detail['attribute'], supplier[detail['attribute']])
+          new_value = get_attribute_value(detail['attribute'], detail['value'])
+
+          supplier[detail['attribute']] = detail['value']
+
+          "#{ATTRIBUTE_TO_LABEL[detail['attribute']]} - FROM: #{old_value} TO: #{new_value}"
+        end
+      end
+
+      def self.format_date_time(date_object)
+        date_object.in_time_zone('London').strftime('%d/%m/%Y %H:%M').squish
+      end
+
+      def self.service_codes_with_name
+        @service_codes_with_name ||= FacilitiesManagement::RM6232::Service.order(:work_package_code, :sort_order).map { |service| [service.code, "#{service.code} #{service.name}"] }.to_h
+      end
+
+      def self.region_codes_with_name
+        @region_codes_with_name ||= FacilitiesManagement::Region.all.map { |region| [region.code, "#{region.code} #{region.name}"] }.to_h
+      end
+
+      def self.item_names(attribute, codes)
+        case attribute
+        when 'region_codes'
+          region_codes_with_name.slice(*codes).values
+        when 'service_codes'
+          service_codes_with_name.slice(*codes).values
+        end.join('|')
+      end
+
+      def self.get_attribute_value(attribute, value)
+        return value unless attribute == 'active'
+
+        value || value.nil? ? 'Active' : 'Inactive'
+      end
+    end
+  end
+end

--- a/app/views/facilities_management/rm6232/admin/change_logs/index.html.erb
+++ b/app/views/facilities_management/rm6232/admin/change_logs/index.html.erb
@@ -10,6 +10,10 @@
     <p class="govuk-body">
       <%= t('.below_is_table') %>
     </p>
+    <p>
+      <%= t('.you_can_download') %>
+    </p>
+    <%= link_to t('.download_logs'), "#{facilities_management_rm6232_admin_change_logs_path}?format=csv", class: 'govuk-button govuk-button--secondary', aria: { label: t('.download_logs') }, download: '' %>
   </div>
 </div>
 

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -202,9 +202,11 @@ en:
               service_codes: Services
               upload: Data uploaded
             date_of_change: Date of change
+            download_logs: Download full change logs
             during_a_deployment: During a deployment
             heading: Supplier data change log
             user: User
+            you_can_download: You can download a CSV file of the logs by clicking on 'Download full change logs'
           lot_data:
             items_added:
               region_codes: 'The following regions were added to the supplier:'

--- a/spec/controllers/facilities_management/rm6232/admin/change_logs_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/change_logs_controller_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::ChangeLogsController, type: 
     end
   end
 
+  describe 'GET index with csv fromat' do
+    before do
+      allow(FacilitiesManagement::RM6232::Admin::ChangeLogsCsvGenerator).to receive(:generate_csv).and_return("\n")
+
+      get :index, format: :csv
+    end
+
+    it 'download the csv' do
+      expect(response.headers['Content-Disposition']).to include 'filename="Full change logs'
+      expect(response.headers['Content-Type']).to eq 'text/csv'
+    end
+  end
+
   describe 'GET show' do
     let(:supplier_data) { FacilitiesManagement::RM6232::Admin::SupplierData.latest_data }
     let(:supplier) { supplier_data.data.first }

--- a/spec/services/facilities_management/rm6232/admin/change_logs_csv_generator_spec.rb
+++ b/spec/services/facilities_management/rm6232/admin/change_logs_csv_generator_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::ChangeLogsCsvGenerator do
+  let(:user_1) { create(:user, email: 'reiner.braun@attackontitn.pa') }
+  let(:user_2) { create(:user, email: 'bertholdt.hoover@attackontitn.pa') }
+  let(:new_upload) { create(:facilities_management_rm6232_admin_upload, user: user_2) }
+  let(:supplier_data_1) { FacilitiesManagement::RM6232::Admin::SupplierData.latest_data }
+  let(:supplier_data_2) { FacilitiesManagement::RM6232::Admin::SupplierData.create(upload: new_upload, data: supplier_data_1.data, created_at: get_time(2022, 3, 8, 10, 0)) }
+  let(:supplier_1_id) { supplier_data_1.data.find { |data| data['supplier_name'] == 'Abshire, Schumm and Farrell' }['id'] }
+  let(:supplier_2_id) { supplier_data_1.data.find { |data| data['supplier_name'] == 'Skiles LLC' }['id'] }
+
+  def get_time(*time_array)
+    DateTime.new(*time_array).in_time_zone('London')
+  end
+
+  before do
+    supplier_data_1.update(created_at: get_time(2022, 3, 4, 12, 55))
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data, user: user_1, created_at: get_time(2022, 3, 5, 1, 11), supplier_id: supplier_1_id, data: { 'lot_code' => '1a', 'attribute' => 'service_codes', 'added' => %w[F.12], 'removed' => [] })
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: get_time(2022, 3, 6, 13, 26), supplier_id: supplier_1_id)
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_region_lot_data, user: user_1, created_at: get_time(2022, 3, 7, 4, 59), supplier_id: supplier_2_id)
+    supplier_data_2
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: get_time(2022, 3, 9, 12, 0), supplier_id: supplier_1_id, data: [{ 'attribute' => 'supplier_name', 'value' => 'Marc Ribillet Records' }])
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data, user: user_2, created_at: get_time(2022, 3, 10, 0, 18), supplier_id: supplier_1_id, data: { 'lot_code' => '1a', 'attribute' => 'service_codes', 'added' => %w[E.14 E.15], 'removed' => %w[I.14 J.7] })
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: get_time(2022, 3, 12, 17, 25), supplier_id: supplier_2_id, data: [{ 'attribute' => 'address_line_1', 'value' => '1 Loop daddy' }, { 'attribute' => 'address_town', 'value' => 'New York City' }])
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: get_time(2022, 3, 12, 17, 26), supplier_id: supplier_2_id, data: [{ 'attribute' => 'address_line_1', 'value' => '2 Loop daddy' }, { 'attribute' => 'address_town', 'value' => 'New Jersey City' }])
+  end
+
+  describe '.generate_csv' do
+    let(:generated_csv) { CSV.parse(described_class.generate_csv) }
+
+    it 'has the right headers' do
+      expect(generated_csv.first).to eq(['Log item', 'Date of change', 'User', 'Supplier name', 'Change type', 'Changes'])
+    end
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'has the correct data in rows' do
+      expect(generated_csv[1][1..]).to eq(['12/03/2022 17:26', 'bertholdt.hoover@attackontitn.pa', 'Skiles LLC', 'Details', "Building and street - FROM: 1 Loop daddy TO: 2 Loop daddy\nTown or city - FROM: New York City TO: New Jersey City"])
+      expect(generated_csv[2][1..]).to eq(['12/03/2022 17:25', 'bertholdt.hoover@attackontitn.pa', 'Skiles LLC', 'Details', "Building and street - FROM: 40828 Joellen Summit TO: 1 Loop daddy\nTown or city - FROM: Danialborough TO: New York City"])
+      expect(generated_csv[3][1..]).to eq(['10/03/2022 00:18', 'bertholdt.hoover@attackontitn.pa', 'Marc Ribillet Records', 'Services', "Lot code: 1a\nAdded items: E.14 Catering equipment maintenance|E.15 Audio Visual (AV) equipment maintenance\nRemoved items: I.14 Cleaning of curtains and window blinds|J.7 Clocks"])
+      expect(generated_csv[4][1..]).to eq(['09/03/2022 12:00', 'bertholdt.hoover@attackontitn.pa', 'Marc Ribillet Records', 'Details', 'Supplier name - FROM: Abshire, Schumm and Farrell TO: Marc Ribillet Records'])
+      expect(generated_csv[5][1..]).to eq(['08/03/2022 10:00', 'bertholdt.hoover@attackontitn.pa', 'N/A', 'Data uploaded', "Upload: http://localhost:3000/facilities-management/RM6232/admin/uploads/#{new_upload.id}"])
+      expect(generated_csv[6][1..]).to eq(['07/03/2022 04:59', 'reiner.braun@attackontitn.pa', 'Skiles LLC', 'Regions', "Lot code: 1a\nRemoved items: UKC1 Tees Valley and Durham"])
+      expect(generated_csv[7][1..]).to eq(['06/03/2022 13:26', 'bertholdt.hoover@attackontitn.pa', 'Abshire, Schumm and Farrell', 'Details', 'Status - FROM: Active TO: Inactive'])
+      expect(generated_csv[8][1..]).to eq(['05/03/2022 01:11', 'reiner.braun@attackontitn.pa', 'Abshire, Schumm and Farrell', 'Services', "Lot code: 1a\nAdded items: F.12 Radon Gas Management Services"])
+      expect(generated_csv[9][1..]).to eq(['04/03/2022 12:55', 'During a deployment', 'N/A', 'Data uploaded', 'N/A'])
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+  end
+end


### PR DESCRIPTION
There is a requirement from the admin team that all changes that are made to the supplier data are logged. In this commit I have added the ability to download the complete change log in a CSV.

As always I have added specs to make sure everything is working as expected.