### PR TITLE
FMFR-1249 - Download snapshot of supplier data

### DIFF
--- a/app/assets/javascripts/facilities-management/rm6232/admin/supplier-data-snapshot.js
+++ b/app/assets/javascripts/facilities-management/rm6232/admin/supplier-data-snapshot.js
@@ -1,0 +1,17 @@
+$(() => {
+  const enableZipButton = () => $('#generate-supplier-zip-button').attr('disabled', false);
+
+  const disableZipButtonAndHideErrors = () => {
+    $('.govuk-error-message').remove();
+    $('.govuk-form-group').removeClass('govuk-form-group--error');
+    $('#generate-supplier-zip-button').attr('disabled', true);
+  };
+
+  $('#facilities_management_rm6232_admin_supplier_data_snapshot_snapshot_date_dd').on('input', enableZipButton);
+  $('#facilities_management_rm6232_admin_supplier_data_snapshot_snapshot_date_mm').on('input', enableZipButton);
+  $('#facilities_management_rm6232_admin_supplier_data_snapshot_snapshot_date_yyyy').on('input', enableZipButton);
+  $('#facilities_management_rm6232_admin_supplier_data_snapshot_snapshot_time_hh').on('input', enableZipButton);
+  $('#facilities_management_rm6232_admin_supplier_data_snapshot_snapshot_time_mm').on('input', enableZipButton);
+
+  $('#generate-supplier-zip').on('submit', disableZipButtonAndHideErrors);
+});

--- a/app/controllers/facilities_management/rm6232/admin/supplier_data_snapshots_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/supplier_data_snapshots_controller.rb
@@ -1,0 +1,32 @@
+module FacilitiesManagement
+  module RM6232
+    module Admin
+      class SupplierDataSnapshotsController < FacilitiesManagement::Admin::FrameworkController
+        def new
+          @snapshot = SupplierData::Snapshot.new
+        end
+
+        def create
+          @snapshot = SupplierData::Snapshot.new(snapshot_params)
+          if @snapshot.valid?
+            send_data @snapshot.generate_snapshot_zip, filename: @snapshot.snapshot_filename, type: 'application/zip'
+          else
+            render :new
+          end
+        end
+
+        private
+
+        def snapshot_params
+          params.require(:facilities_management_rm6232_admin_supplier_data_snapshot).permit(
+            :snapshot_date_yyyy,
+            :snapshot_date_mm,
+            :snapshot_date_dd,
+            :snapshot_time_hh,
+            :snapshot_time_mm,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/models/facilities_management/rm6232/admin/supplier_data.rb
+++ b/app/models/facilities_management/rm6232/admin/supplier_data.rb
@@ -9,6 +9,14 @@ module FacilitiesManagement
           order(created_at: :desc).first
         end
 
+        def self.oldest_data_created_at
+          order(created_at: :asc).first.created_at
+        end
+
+        def self.oldest_data_created_at_string
+          oldest_data_created_at.in_time_zone('London').strftime('%e %B %Y, %k:%M')
+        end
+
         def self.audit_logs
           order(created_at: :desc).map do |supplier_data|
             [

--- a/app/models/facilities_management/rm6232/admin/supplier_data/snapshot.rb
+++ b/app/models/facilities_management/rm6232/admin/supplier_data/snapshot.rb
@@ -1,0 +1,78 @@
+module FacilitiesManagement
+  module RM6232
+    module Admin
+      class SupplierData::Snapshot
+        include ActiveModel::Model
+
+        attr_accessor :snapshot_date_time, :snapshot_date, :snapshot_time,
+                      :snapshot_date_yyyy, :snapshot_date_mm, :snapshot_date_dd, :snapshot_time_hh, :snapshot_time_mm
+
+        validate :snapshot_date_present, :snapshot_date_real, :snapshot_time_real, :supplier_data_present
+
+        def initialize(attributes = {})
+          super(attributes)
+          create_snapshot_date_time
+        end
+
+        def generate_snapshot_zip
+          snapshot_generator = SupplierDataSnapshotGenerator.new(snapshot_date_time)
+          snapshot_generator.build_zip_file
+          snapshot_generator.to_zip
+        end
+
+        def snapshot_filename
+          "Supplier data spreadsheets (#{snapshot_date_time.in_time_zone('London').strftime(format_time_string).squish}).zip"
+        end
+
+        private
+
+        def create_snapshot_date_time
+          self.snapshot_date_time = if snapshot_time_blank?
+                                      Time.find_zone('London').local(*date_parameters).in_time_zone('UTC').end_of_day
+                                    else
+                                      Time.find_zone('London').local(*date_parameters, snapshot_time_hh.to_i, snapshot_time_mm.to_i).in_time_zone('UTC')
+                                    end
+        rescue ArgumentError
+          # We can do nothing and leave snapshot_date_time as nil
+        end
+
+        def snapshot_date_present
+          errors.add(:snapshot_date, :blank) if snapshot_date_yyyy.blank? || snapshot_date_mm.blank? || snapshot_date_dd.blank?
+        end
+
+        def snapshot_date_real
+          errors.add(:snapshot_date, :not_a_date) unless Date.valid_date?(*date_parameters)
+        end
+
+        def snapshot_time_real
+          return if snapshot_time_blank?
+
+          hours = Integer(snapshot_time_hh)
+          minutes = Integer(snapshot_time_mm)
+
+          errors.add(:snapshot_time, :not_a_time) if hours > 23 || hours.negative? || minutes > 59 || minutes.negative?
+        rescue ArgumentError, TypeError
+          errors.add(:snapshot_time, :not_a_time)
+        end
+
+        def supplier_data_present
+          return if errors.any?
+
+          errors.add(:snapshot_date_time, :no_supplier_data, oldest_data_created_at: SupplierData.oldest_data_created_at_string) if snapshot_date_time + 1.minute < SupplierData.oldest_data_created_at
+        end
+
+        def snapshot_time_blank?
+          snapshot_time_hh.blank? && snapshot_time_mm.blank?
+        end
+
+        def date_parameters
+          [snapshot_date_yyyy.to_i, snapshot_date_mm.to_i, snapshot_date_dd.to_i]
+        end
+
+        def format_time_string
+          snapshot_time_blank? ? '%d_%m_%Y' : '%d_%m_%Y %H_%M'
+        end
+      end
+    end
+  end
+end

--- a/app/services/facilities_management/rm6232/admin/supplier_data_snapshot_generator.rb
+++ b/app/services/facilities_management/rm6232/admin/supplier_data_snapshot_generator.rb
@@ -1,0 +1,75 @@
+module FacilitiesManagement::RM6232
+  module Admin
+    class SupplierDataSnapshotGenerator
+      def initialize(snapshot_date_time)
+        @snapshot_date_time = snapshot_date_time + 1.minute
+      end
+
+      def build_zip_file
+        set_data
+        create_file_stream
+      end
+
+      def to_zip
+        @file_stream.read
+      end
+
+      private
+
+      def set_data
+        supplier_data = FacilitiesManagement::RM6232::Admin::SupplierData.where('created_at <= ?', @snapshot_date_time).order(created_at: :desc).first
+
+        supplier_data.edits.where('created_at <= ?', @snapshot_date_time).order(:created_at).each do |edit|
+          supplier = supplier_data.data.find { |supplier_item| supplier_item['id'] == edit.supplier_id }
+
+          if edit.change_type == 'lot_data'
+            update_lot_data(edit, supplier)
+          else
+            update_details(edit, supplier)
+          end
+        end
+
+        @supplier_data = supplier_data.data
+      end
+
+      def update_lot_data(edit, supplier)
+        supplier_lot_data = supplier['lot_data'].find { |lot_data| lot_data['lot_code'] == edit.data['lot_code'] }
+
+        edit.data['removed'].each { |code| supplier_lot_data[edit.data['attribute']].delete(code) }
+        edit.data['added'].each { |code| supplier_lot_data[edit.data['attribute']] << code }
+      end
+
+      def update_details(edit, supplier)
+        edit.data.each { |detail| supplier[detail['attribute']] = detail['value'] }
+      end
+
+      def snapshot_date_time_string
+        @snapshot_date_time_string ||= (@snapshot_date_time - 1.minute).in_time_zone('London').strftime('%d_%m_%Y %H_%M').squish
+      end
+
+      def create_file_stream
+        supplier_details_spreadsheet = FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet::Details.new(@supplier_data, nil, true)
+        supplier_details_spreadsheet.build
+
+        supplier_services_spreadsheet = FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet::Services.new(@supplier_data)
+        supplier_services_spreadsheet.build
+
+        supplier_regions_spreadsheet = FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet::Regions.new(@supplier_data)
+        supplier_regions_spreadsheet.build
+
+        @file_stream = Zip::OutputStream.write_buffer do |zip|
+          zip.put_next_entry "RM6232 Suppliers Details (#{snapshot_date_time_string}).xlsx"
+          zip.print supplier_details_spreadsheet.to_xlsx
+
+          zip.put_next_entry "RM6232 Suppliers Services (#{snapshot_date_time_string}).xlsx"
+          zip.print supplier_services_spreadsheet.to_xlsx
+
+          zip.put_next_entry "RM6232 Suppliers Regions (#{snapshot_date_time_string}).xlsx"
+          zip.print supplier_regions_spreadsheet.to_xlsx
+        end
+
+        @file_stream.rewind
+      end
+    end
+  end
+end

--- a/app/services/facilities_management/rm6232/admin/supplier_spreadsheet.rb
+++ b/app/services/facilities_management/rm6232/admin/supplier_spreadsheet.rb
@@ -1,0 +1,53 @@
+module FacilitiesManagement::RM6232
+  module Admin
+    class SupplierSpreadsheet
+      def initialize(supplier_data, filename = nil)
+        @supplier_data = supplier_data
+        @filename = filename
+      end
+
+      def build
+        @package = Axlsx::Package.new
+        @workbook = @package.workbook
+
+        add_styles
+        create_spreadsheet
+      end
+
+      def to_xlsx
+        @package.to_stream.read
+      end
+
+      def save_spreadsheet
+        file_path = Rails.root.join('data', 'facilities_management', 'rm6232', @filename)
+
+        File.write(file_path, to_xlsx, binmode: true)
+      end
+
+      private
+
+      def add_styles(&block)
+        @styles = {}
+
+        @workbook.styles(&block)
+      end
+
+      def lot_suppliers(lot_code)
+        suppliers = @supplier_data.map do |supplier|
+          supplier_lot_data = supplier['lot_data'].find { |lot_data| lot_data['lot_code'] == lot_code } if supplier['lot_data'].any?
+
+          next unless supplier_lot_data
+
+          {
+            'supplier_name' => supplier['supplier_name'],
+            'duns' => supplier['duns'],
+            'service_codes' => supplier_lot_data['service_codes'],
+            'region_codes' => supplier_lot_data['region_codes']
+          }
+        end
+
+        suppliers.reject(&:blank?).sort_by { |supplier| supplier['supplier_name'] }
+      end
+    end
+  end
+end

--- a/app/services/facilities_management/rm6232/admin/supplier_spreadsheet/details.rb
+++ b/app/services/facilities_management/rm6232/admin/supplier_spreadsheet/details.rb
@@ -1,0 +1,60 @@
+module FacilitiesManagement::RM6232
+  module Admin
+    class SupplierSpreadsheet::Details < FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet
+      def initialize(supplier_data, filename = nil, active_required = false)
+        super(supplier_data, filename)
+        @active_required = active_required
+      end
+
+      private
+
+      def add_styles
+        super do |styles|
+          @styles[:heading_style] = styles.add_style sz: 12, b: true, bg_color: '4571C4', fg_color: 'FFFFFF', alignment: { horizontal: :left, vertical: :center }, border: { style: :thin, color: '000000' }
+          @styles[:even_row]      = styles.add_style sz: 12, b: false, bg_color: 'D8E2F2', fg_color: '000000', alignment: { horizontal: :left, vertical: :center }, border: { style: :thin, color: '000000' }
+          @styles[:odd_row]       = styles.add_style sz: 12, b: false, bg_color: 'FFFFFF', fg_color: '000000', alignment: { horizontal: :left, vertical: :center }, border: { style: :thin, color: '000000' }
+          @styles[:row_height]    = 25
+        end
+      end
+
+      def create_spreadsheet
+        @workbook.add_worksheet(name: 'RM6232 Suppliers Details') do |sheet|
+          sheet.add_row headers, style: @styles[:heading_style], height: @styles[:row_height]
+
+          @supplier_data.sort_by { |supplier| supplier['supplier_name'] }.each_with_index do |supplier, index|
+            row_data = get_row_data(supplier)
+
+            style = index.even? ? @styles[:even_row] : @styles[:odd_row]
+            sheet.add_row row_data.values, style: style, height: @styles[:row_height], types: [:string] * attributes.length
+          end
+
+          sheet.column_widths(*column_widths)
+        end
+      end
+
+      def get_row_data(supplier)
+        row_data = supplier.slice(*attributes)
+        row_data['sme'] = row_data['sme'] ? 'Yes' : 'No'
+        row_data['active'] = row_data['active'] || row_data['active'].nil? ? 'Active' : 'Inactive' if @active_required
+
+        row_data
+      end
+
+      def attributes
+        @attributes ||= @active_required ? ATTRIBUTES + ['active'] : ATTRIBUTES
+      end
+
+      def headers
+        @headers ||= @active_required ? HEADERS + ['Status'] : HEADERS
+      end
+
+      def column_widths
+        @column_widths ||= @active_required ? COLUMN_WIDTHS + [10] : COLUMN_WIDTHS
+      end
+
+      HEADERS = ['Supplier name', 'SME', 'DUNS number', 'Registration number', 'Address line 1', 'Address line 2', 'Town', 'County', 'Postcode'].freeze
+      ATTRIBUTES = ['supplier_name', 'sme', 'duns', 'registration_number', 'address_line_1', 'address_line_2', 'address_town', 'address_county', 'address_postcode'].freeze
+      COLUMN_WIDTHS = [20, 5, 15, 20, 25, 25, 20, 20, 15].freeze
+    end
+  end
+end

--- a/app/services/facilities_management/rm6232/admin/supplier_spreadsheet/regions.rb
+++ b/app/services/facilities_management/rm6232/admin/supplier_spreadsheet/regions.rb
@@ -1,0 +1,40 @@
+module FacilitiesManagement::RM6232
+  module Admin
+    class SupplierSpreadsheet::Regions < FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet
+      private
+
+      def add_styles
+        super do |styles|
+          @styles[:heading_style] = styles.add_style sz: 12, b: true, bg_color: 'FBE4D5', fg_color: '000000', alignment: { horizontal: :left, vertical: :center }, border: { style: :thin, color: '000000' }
+          @styles[:normal_row]    = styles.add_style sz: 12, b: false, alignment: { horizontal: :left, vertical: :center }, border: { style: :thin, color: '000000' }
+          @styles[:row_height]    = 25
+        end
+      end
+
+      def create_spreadsheet
+        %w[1 2 3].each do |lot_number|
+          %w[a b c].each do |lot_letter|
+            lot_code = "#{lot_number}#{lot_letter}"
+
+            suppliers = lot_suppliers(lot_code)
+
+            @workbook.add_worksheet(name: "Lot #{lot_code}") do |sheet|
+              sheet.add_row ['Supplier', 'DUNS Number'] + region_codes, style: @styles[:heading_style], height: @styles[:row_height]
+
+              suppliers.each do |supplier|
+                supplier_regions_marked = region_codes.map { |region_code| 'X' if supplier['region_codes'].include?(region_code) }
+                sheet.add_row [supplier['supplier_name'], supplier['duns']] + supplier_regions_marked, style: @styles[:normal_row], height: @styles[:row_height], types: [:string] * NUMBER_OF_COLUMNS
+              end
+            end
+          end
+        end
+      end
+
+      def region_codes
+        @region_codes ||= FacilitiesManagement::Region.all.map(&:code)[0..-2] + ['NC01', 'OS01']
+      end
+
+      NUMBER_OF_COLUMNS = 78
+    end
+  end
+end

--- a/app/services/facilities_management/rm6232/admin/supplier_spreadsheet/services.rb
+++ b/app/services/facilities_management/rm6232/admin/supplier_spreadsheet/services.rb
@@ -1,0 +1,92 @@
+module FacilitiesManagement::RM6232
+  module Admin
+    class SupplierSpreadsheet::Services < FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet
+      private
+
+      def add_styles
+        super do |styles|
+          @styles[:normal_row]              = styles.add_style sz: 11, alignment: { horizontal: :center, vertical: :center }, border: { style: :thin, color: '000000' }
+          @styles[:work_package_row]        = styles.add_style sz: 11, b: true, border: { style: :thin, color: '000000' }
+          @styles[:header_row]              = styles.add_style sz: 9, b: true
+          @styles[:supplier_names_row]      = styles.add_style sz: 12, b: true, alignment: { horizontal: :center, vertical: :bottom, wrap_text: true }, border: { style: :thin, color: '000000' }, bg_color: 'FFFF00'
+          @styles[:normal_row_with_colour]  = styles.add_style sz: 11, alignment: { horizontal: :center, vertical: :center }, border: { style: :thin, color: '000000' }, bg_color: 'FFFF00'
+          @styles[:normal_row_left_align]   = styles.add_style sz: 11, alignment: { horizontal: :left, vertical: :center }, border: { style: :thin, color: '000000' }
+        end
+      end
+
+      def create_spreadsheet
+        %w[1 2 3].each do |lot_number|
+          %w[a b c].each do |lot_letter|
+            lot_code = "#{lot_number}#{lot_letter}"
+
+            suppliers = lot_suppliers(lot_code)
+
+            @workbook.add_worksheet(name: "Lot #{lot_code}") do |sheet|
+              add_header_rows(sheet, lot_code, suppliers)
+              add_service_rows(sheet, lot_number, suppliers)
+              style_sheet(sheet, lot_number, suppliers)
+            end
+          end
+        end
+      end
+
+      def add_header_rows(sheet, lot_code, suppliers)
+        sheet.add_row ["If you are bidding for Lot #{lot_code}, please confirm within the Yellow highlighted cells, that you are able to provide the relevant additional service"], style: @styles[:header_row]
+        sheet.add_row [nil] * 4 + suppliers.map { |supplier_data| supplier_data['supplier_name'] }
+        sheet.add_row [nil] * 4 + suppliers.map { |supplier_data| supplier_data['duns'] }, types: [:string] * (4 + suppliers.length)
+        sheet.add_row ['Work package Description', 'Work Package Standard Reference (where applicable)', 'Work Package Section Reference', 'Service'] + (['Are you able to provide this additional service?'] * suppliers.length), style: @styles[:header_row]
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def add_service_rows(sheet, lot_number, suppliers)
+        work_packages[lot_number].each do |work_package_services|
+          work_package = work_package_services.first.work_package
+          sheet.add_row ["Work Package #{work_package.code} - #{work_package.name}"], style: @styles[:work_package_row]
+
+          work_package_services.each do |service|
+            service_code = service.code
+
+            supplier_answers = suppliers.map { |supplier_data| supplier_data['service_codes'].include?(service_code) ? 'Yes' : 'No' }
+
+            sheet.add_row ["Service #{service_code.gsub('.', ':')} - #{service.name}", "S#{service_code.gsub('.', '')}", service_codes.index(service_code) + 2, 'Additional'] + supplier_answers, style: @styles[:normal_row]
+          end
+          sheet.add_row []
+        end
+      end
+
+      def style_sheet(sheet, lot_number, suppliers)
+        sheet.column_widths(*(COLUMN_WIDTHS + ([SUPPLIER_COLUMN_WIDTH] * suppliers.length)))
+        sheet.rows[1..2].each { |row| row.cells[4..].each { |cell| cell.style = @styles[:supplier_names_row] } }
+
+        current_row = 5
+
+        work_packages[lot_number].map(&:length).each do |number_of_services|
+          sheet.rows[current_row..(current_row - 1 + number_of_services)].each do |row|
+            row.cells[0].style = @styles[:normal_row_left_align]
+            row.cells[4..].each { |cell| cell.style = @styles[:normal_row_with_colour] }
+          end
+
+          current_row += number_of_services + 2
+        end
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def work_packages
+        @work_packages ||= {
+          '1' => FacilitiesManagement::RM6232::WorkPackage.selectable.map { |work_package| work_package.supplier_services.where(total: true, core: false) }.reject(&:empty?),
+          '2' => FacilitiesManagement::RM6232::WorkPackage.selectable.map { |work_package| work_package.supplier_services.where(hard: true, core: false) }.reject(&:empty?),
+          '3' => FacilitiesManagement::RM6232::WorkPackage.selectable.map { |work_package| work_package.supplier_services.where(soft: true, core: false) }.reject(&:empty?)
+        }
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
+
+      def service_codes
+        @service_codes ||= FacilitiesManagement::RM6232::Service.order(:work_package_code, :sort_order).pluck(:code)
+      end
+
+      COLUMN_WIDTHS = [75, 10, 10, 10].freeze
+      SUPPLIER_COLUMN_WIDTH = 20
+    end
+  end
+end

--- a/app/views/facilities_management/rm6232/admin/change_logs/index.html.erb
+++ b/app/views/facilities_management/rm6232/admin/change_logs/index.html.erb
@@ -14,6 +14,9 @@
       <%= t('.you_can_download') %>
     </p>
     <%= link_to t('.download_logs'), "#{facilities_management_rm6232_admin_change_logs_path}?format=csv", class: 'govuk-button govuk-button--secondary', aria: { label: t('.download_logs') }, download: '' %>
+    <p>
+      <%= t('.you_can_get_a_snapshot_html', snapshot_link: link_to(t('.supplier_data_snapshot'), new_facilities_management_rm6232_admin_supplier_data_snapshot_path, class: 'govuk-link govuk-link--no-visited-state')) %>
+    </p>
   </div>
 </div>
 

--- a/app/views/facilities_management/rm6232/admin/supplier_data_snapshots/new.html.erb
+++ b/app/views/facilities_management/rm6232/admin/supplier_data_snapshots/new.html.erb
@@ -1,0 +1,65 @@
+<%= content_for :page_title, t('.heading') %>
+<%= admin_breadcrumbs(
+  { text: t('facilities_management.rm6232.admin.change_logs.index.heading'), link: facilities_management_rm6232_admin_change_logs_path },
+  { text: t('.heading') }
+)%>
+
+<%= render partial: 'shared/error_summary', locals: { errors: @snapshot.errors } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('.heading') %>
+    </h1>
+    <p class="govuk-body">
+      <%= t('.enter_a_date') %>
+    </p>
+    <p class="govuk-body">
+      <%= t('.when_you_click') %>
+    </p>
+    <p>
+      <%= warning_text(t('.the_date_you_enter', oldest_data_created_at: FacilitiesManagement::RM6232::Admin::SupplierData.oldest_data_created_at_string )) %>
+    </p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @snapshot, url: facilities_management_rm6232_admin_supplier_data_snapshots_path, method: :post, id: 'generate-supplier-zip', local: 'false', html: { specialvalidation: true, novalidate: true } do |f| %>
+      <%= form_group_with_error f.object, :snapshot_date_time do |displayed_date_time_error| %>
+        <%= displayed_date_time_error %>
+
+        <%= form_group_with_error f.object, :snapshot_date do |displayed_error| %>
+          <%= f.label :snapshot_date, t('.snapshot_date_label'), class: 'govuk-label govuk-label--m' %>
+          <%= displayed_error %>
+          <%= f.gov_uk_date_field :snapshot_date, legend_options: { page_heading: false, visually_hidden: true } %>
+        <% end %>
+
+        <%= form_group_with_error f.object, :snapshot_time do |displayed_error| %>
+          <%= f.label :snapshot_time, t('.snapshot_time_label'), class: 'govuk-label govuk-label--m' %>
+          <%= displayed_error %>
+
+          <div class="govuk-date-input">
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <%= f.label :snapshot_time_hh, t('.hour'), class: 'govuk-label govuk-date-input__label' %>
+                <%= f.text_field :snapshot_time_hh, class: "govuk-input govuk-date-input__input govuk-input--width-2 #{ 'govuk-input--error' if f.object.errors[:snapshot_time].any? }", inputmode: :numeric %>
+              </div>
+            </div>
+            <div class="govuk-date-input__item govuk-!-font-size-27">
+              :
+            </div>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <%= f.label :snapshot_time_mm, t('.minute'), class: 'govuk-label govuk-date-input__label' %>
+                <%= f.text_field :snapshot_time_mm, class: "govuk-input govuk-date-input__input govuk-input--width-2 #{ 'govuk-input--error' if f.object.errors[:snapshot_time].any? }", inputmode: :numeric %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+
+      <%= f.submit t('.generate_spreadsheets'), class: 'govuk-button', id: 'generate-supplier-zip-button', data: { module: 'govuk-button' }, aria: { label: t('.generate_spreadsheets')} %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -3,6 +3,15 @@ en:
   activemodel:
     errors:
       models:
+        facilities_management/rm6232/admin/supplier_data/snapshot:
+          attributes:
+            snapshot_date:
+              blank: Enter a valid 'snapshot' date
+              not_a_date: Enter a valid 'snapshot' date
+            snapshot_date_time:
+              no_supplier_data: You must enter a data and time on or after %{oldest_data_created_at} (when the supplier data was imported for the first time)
+            snapshot_time:
+              not_a_time: Enter a valid 'snapshot' time (23:59 or earlier)
         facilities_management/rm6232/journey/annual_contract_value:
           attributes:
             annual_contract_value:
@@ -216,8 +225,10 @@ en:
             download_logs: Download full change logs
             during_a_deployment: During a deployment
             heading: Supplier data change log
+            supplier_data_snapshot: Supplier data snapshot
             user: User
-            you_can_download: You can download a CSV file of the logs by clicking on 'Download full change logs'
+            you_can_download: You can download a CSV file of the full logs by clicking on 'Download full change logs'
+            you_can_get_a_snapshot_html: You can get a snapshot of the supplier data at any point in time by going to the '%{snapshot_link}' section.
           lot_data:
             items_added:
               region_codes: 'The following regions were added to the supplier:'
@@ -263,6 +274,17 @@ en:
             view_details: View details
             view_lot_data: View lot data
             view_supplier_data: You can view the full supplier details by clicking 'View details' or view the full supplier lot data by clicking 'View lot data'.
+        supplier_data_snapshots:
+          new:
+            enter_a_date: Enter the date for which you want to create a snapshot of the supplier data. You also have the option of entering the time if you need to be more specific.
+            generate_spreadsheets: Download supplier data spreadsheets
+            heading: Supplier data snapshot
+            hour: Hour
+            minute: Minute
+            snapshot_date_label: Snapshot date
+            snapshot_time_label: Snapshot time (optional)
+            the_date_you_enter: The date and time you enter should be on or after %{oldest_data_created_at} which is when the supplier data was first uploaded into the application.
+            when_you_click: When you click 'Download the supplier spreadsheets', a zip file containing the 'Supplier details', 'Supplier services' and 'Supplier regions' will be downloaded.
         supplier_details:
           index:
             heading: Supplier data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,6 +213,7 @@ Rails.application.routes.draw do
         resources :change_logs, path: 'change-logs', only: :index do
           get '/:change_type', action: :show, as: :show
         end
+        resources :supplier_data_snapshots, path: 'supplier-data-snapshots', only: %i[new create]
       end
     end
 

--- a/lib/tasks/facilities_management/rm6232/generate_supplier_lot_data.rake
+++ b/lib/tasks/facilities_management/rm6232/generate_supplier_lot_data.rake
@@ -112,183 +112,25 @@ module FM::RM6232
     end
 
     def self.convert_to_spreadsheets
-      FM::RM6232::ServiceDataSpreadsheet.new.convert_to_spreadsheet
-      FM::RM6232::RegionDataSpreadsheet.new.convert_to_spreadsheet
-    end
-  end
-end
+      supplier_data = FacilitiesManagement::RM6232::Supplier.order(:supplier_name).map do |supplier|
+        lot_data = supplier.lot_data.map(&:attributes)
 
-module FM::RM6232
-  class SupplierSpreadsheet
-    def initialize(filename)
-      @filename = filename
-      @package = Axlsx::Package.new
-      @workbook = @package.workbook
-      @styles = {}
-    end
+        supplier_data = supplier.attributes
+        supplier_data['lot_data'] = lot_data
 
-    def convert_to_spreadsheet
-      set_up_spreadsheet
-      create_spreadsheet
-      save_spreadsheet
-    end
-
-    private
-
-    def save_spreadsheet
-      file_path = Rails.root.join('data', 'facilities_management', 'rm6232', @filename)
-
-      File.write(file_path, @package.to_stream.read, binmode: true)
-    end
-
-    def lot_suppliers(lot_code)
-      suppliers = FacilitiesManagement::RM6232::Supplier::LotData.where(lot_code: lot_code).map do |lot_data|
-        supplier = lot_data.supplier
-
-        {
-          supplier_name: supplier.supplier_name,
-          duns: supplier.duns,
-          service_codes: lot_data.service_codes,
-          region_codes: lot_data.region_codes
-        }
+        supplier_data
       end
 
-      suppliers.sort_by { |supplier_data| supplier_data[:supplier_name] }
+      filename = 'RM6232 Supplier Services (for Dev & Test).xlsx'
+      supplier_services_spreadsheet = FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet::Services.new(supplier_data, filename)
+      supplier_services_spreadsheet.build
+      supplier_services_spreadsheet.save_spreadsheet
+
+      filename = 'RM6232 Supplier Regions (for Dev & Test).xlsx'
+      supplier_regions_spreadsheet = FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet::Regions.new(supplier_data, filename)
+      supplier_regions_spreadsheet.build
+      supplier_regions_spreadsheet.save_spreadsheet
     end
-  end
-
-  class ServiceDataSpreadsheet < SupplierSpreadsheet
-    def initialize
-      super('RM6232 Supplier Services (for Dev & Test).xlsx')
-    end
-
-    private
-
-    def set_up_spreadsheet
-      @workbook.styles do |styles|
-        @styles[:normal_row] = styles.add_style sz: 11, alignment: { horizontal: :center, vertical: :center }, border: { style: :thin, color: '000000' }
-        @styles[:work_package_row] = styles.add_style sz: 11, b: true, border: { style: :thin, color: '000000' }
-        @styles[:header_row] = styles.add_style sz: 9, b: true
-        @styles[:supplier_names_row] = styles.add_style sz: 12, b: true, alignment: { horizontal: :center, vertical: :bottom, wrap_text: true }, border: { style: :thin, color: '000000' }, bg_color: 'FFFF00'
-        @styles[:normal_row_with_colour] = styles.add_style sz: 11, alignment: { horizontal: :center, vertical: :center }, border: { style: :thin, color: '000000' }, bg_color: 'FFFF00'
-        @styles[:normal_row_left_align] = styles.add_style sz: 11, alignment: { horizontal: :left, vertical: :center }, border: { style: :thin, color: '000000' }
-      end
-    end
-
-    def create_spreadsheet
-      %w[1 2 3].each do |lot_number|
-        %w[a b c].each do |lot_letter|
-          lot_code = "#{lot_number}#{lot_letter}"
-
-          suppliers = lot_suppliers(lot_code)
-
-          @workbook.add_worksheet(name: "Lot #{lot_code}") do |sheet|
-            add_header_rows(sheet, lot_code, suppliers)
-            add_service_rows(sheet, lot_number, suppliers)
-            style_sheet(sheet, lot_number, suppliers)
-          end
-        end
-      end
-    end
-
-    def add_header_rows(sheet, lot_code, suppliers)
-      sheet.add_row ["If you are bidding for Lot #{lot_code}, please confirm within the Yellow highlighted cells, that you are able to provide the relevant additional service"], style: @styles[:header_row]
-      sheet.add_row [nil] * 4 + suppliers.map { |supplier_data| supplier_data[:supplier_name] }
-      sheet.add_row [nil] * 4 + suppliers.map { |supplier_data| supplier_data[:duns] }, types: [:string] * (4 + suppliers.length)
-      sheet.add_row ['Work package Description', 'Work Package Standard Reference (where applicable)', 'Work Package Section Reference', 'Service'] + (['Are you able to provide this additional service?'] * suppliers.length), style: @styles[:header_row]
-    end
-
-    # rubocop:disable Metrics/AbcSize
-    def add_service_rows(sheet, lot_number, suppliers)
-      work_packages[lot_number].each do |work_package_services|
-        work_package = work_package_services.first.work_package
-        sheet.add_row ["Work Package #{work_package.code} - #{work_package.name}"], style: @styles[:work_package_row]
-
-        work_package_services.each do |service|
-          service_code = service.code
-
-          supplier_answers = suppliers.map { |supplier_data| supplier_data[:service_codes].include?(service_code) ? 'Yes' : 'No' }
-
-          sheet.add_row ["Service #{service_code.gsub('.', ':')} - #{service.name}", "S#{service_code.gsub('.', '')}", service_codes.index(service_code) + 2, 'Additional'] + supplier_answers, style: @styles[:normal_row]
-        end
-        sheet.add_row []
-      end
-    end
-
-    def style_sheet(sheet, lot_number, suppliers)
-      sheet.column_widths(*(COLUMN_WIDTHS + ([SUPPLIER_COLUMN_WIDTH] * suppliers.length)))
-      sheet.rows[1..2].each { |row| row.cells[4..].each { |cell| cell.style = @styles[:supplier_names_row] } }
-
-      current_row = 5
-
-      work_packages[lot_number].map(&:length).each do |number_of_services|
-        sheet.rows[current_row..(current_row - 1 + number_of_services)].each do |row|
-          row.cells[0].style = @styles[:normal_row_left_align]
-          row.cells[4..].each { |cell| cell.style = @styles[:normal_row_with_colour] }
-        end
-
-        current_row += number_of_services + 2
-      end
-    end
-    # rubocop:enable Metrics/AbcSize
-
-    # rubocop:disable Metrics/CyclomaticComplexity
-    def work_packages
-      @work_packages ||= {
-        '1' => FacilitiesManagement::RM6232::WorkPackage.selectable.map { |work_package| work_package.supplier_services.where(total: true, core: false) }.reject(&:empty?),
-        '2' => FacilitiesManagement::RM6232::WorkPackage.selectable.map { |work_package| work_package.supplier_services.where(hard: true, core: false) }.reject(&:empty?),
-        '3' => FacilitiesManagement::RM6232::WorkPackage.selectable.map { |work_package| work_package.supplier_services.where(soft: true, core: false) }.reject(&:empty?)
-      }
-    end
-    # rubocop:enable Metrics/CyclomaticComplexity
-
-    def service_codes
-      @service_codes ||= FacilitiesManagement::RM6232::Service.order(:work_package_code, :sort_order).pluck(:code)
-    end
-
-    COLUMN_WIDTHS = [75, 10, 10, 10].freeze
-    SUPPLIER_COLUMN_WIDTH = 20
-  end
-
-  class RegionDataSpreadsheet < SupplierSpreadsheet
-    def initialize
-      super('RM6232 Supplier Regions (for Dev & Test).xlsx')
-    end
-
-    private
-
-    def set_up_spreadsheet
-      @workbook.styles do |styles|
-        @styles[:heading_style] = styles.add_style sz: 12, b: true, bg_color: 'FBE4D5', fg_color: '000000', alignment: { horizontal: :left, vertical: :center }, border: { style: :thin, color: '000000' }
-        @styles[:normal_row]    = styles.add_style sz: 12, b: false, alignment: { horizontal: :left, vertical: :center }, border: { style: :thin, color: '000000' }
-        @styles[:row_height]    = 25
-      end
-    end
-
-    def create_spreadsheet
-      %w[1 2 3].each do |lot_number|
-        %w[a b c].each do |lot_letter|
-          lot_code = "#{lot_number}#{lot_letter}"
-
-          suppliers = lot_suppliers(lot_code)
-
-          @workbook.add_worksheet(name: "Lot #{lot_code}") do |sheet|
-            sheet.add_row ['Supplier', 'DUNS Number'] + region_codes, style: @styles[:heading_style], height: @styles[:row_height]
-
-            suppliers.each do |supplier|
-              supplier_regions_marked = region_codes.map { |region_code| 'X' if supplier[:region_codes].include?(region_code) }
-              sheet.add_row [supplier[:supplier_name], supplier[:duns]] + supplier_regions_marked, style: @styles[:normal_row], height: @styles[:row_height], types: [:string] * NUMBER_OF_COLUMNS
-            end
-          end
-        end
-      end
-    end
-
-    def region_codes
-      @region_codes ||= FacilitiesManagement::Region.all.map(&:code)[0..-2] + ['NC01', 'OS01']
-    end
-
-    NUMBER_OF_COLUMNS = 78
   end
 end
 
@@ -296,7 +138,7 @@ end
 # You should need to run it again as it will change the tests data and break tests
 namespace :db do
   namespace :rm6232 do
-    desc 'Generate the supplier lot data and converts to JSON'
+    desc 'Generate the supplier lot data and converts to XLSX'
     task generate_supplier_lot_data: :environment do
       DistributedLocks.distributed_lock(192) do
         ActiveRecord::Base.transaction do
@@ -309,8 +151,17 @@ namespace :db do
       end
     end
 
+    desc 'Generate spreadsheets from the current supplier lot data'
+    task generate_supplier_lot_data_spreadsheets: :environment do
+      FM::RM6232::GenerateSupplierLotData.convert_to_spreadsheets
+    end
+
     desc 'Part of generating the full supplier details'
     task generate_suppliers: :generate_supplier_lot_data do
+    end
+
+    desc 'Part of generating the full supplier spreadsheets'
+    task generate_supplier_spreadsheets: :generate_supplier_lot_data_spreadsheets do
     end
   end
 end

--- a/spec/controllers/facilities_management/rm6232/admin/supplier_data_snapshots_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/supplier_data_snapshots_controller_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierDataSnapshotsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM6232' } }
+
+  login_fm_admin
+
+  describe 'GET #new' do
+    context 'when logged in as an fm admin' do
+      it 'renders the new' do
+        get :new
+
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when not logged in as an fm admin' do
+      login_fm_buyer
+
+      it 'redirects to not permitted page' do
+        get :new
+
+        expect(response).to redirect_to '/facilities-management/RM6232/admin/not-permitted'
+      end
+    end
+  end
+
+  describe 'POST create' do
+    let(:snapshot_generator) { instance_double('snapshot_generator') }
+    let(:fake_zip_file) { Tempfile.new(['supplier_data', '.zip']) }
+    let(:create_params) { { snapshot_date_yyyy: snapshot_date_time.year.to_s, snapshot_date_mm: snapshot_date_time.month.to_s, snapshot_date_dd: snapshot_date_time.day.to_s, snapshot_time_hh: '', snapshot_time_mm: '' } }
+    let(:valid) { true }
+
+    before do
+      FacilitiesManagement::RM6232::Admin::SupplierData.latest_data.update(created_at: snapshot_date_time - 1.day)
+      allow(FacilitiesManagement::RM6232::Admin::SupplierDataSnapshotGenerator).to receive(:new).and_return(snapshot_generator)
+      allow(snapshot_generator).to receive(:build_zip_file)
+      allow(snapshot_generator).to receive(:to_zip).and_return(fake_zip_file)
+
+      post :create, params: { facilities_management_rm6232_admin_supplier_data_snapshot: create_params }
+    end
+
+    after { fake_zip_file.unlink }
+
+    context 'when the data is valid in BST' do
+      let(:snapshot_date_time) { Time.find_zone('London').local(2022, 11, 11) }
+
+      it 'download the zip with the right filename' do
+        expect(response.headers['Content-Disposition']).to include "filename=\"Supplier data spreadsheets %28#{format('%02d', snapshot_date_time.day)}_#{format('%02d', snapshot_date_time.month)}_#{snapshot_date_time.year}%29.zip\""
+        expect(response.headers['Content-Type']).to eq 'application/zip'
+      end
+    end
+
+    context 'when the data is valid in GMT' do
+      let(:snapshot_date_time) { Time.find_zone('London').local(2022, 7, 7) }
+
+      it 'download the zip with the right filename' do
+        expect(response.headers['Content-Disposition']).to include "filename=\"Supplier data spreadsheets %28#{format('%02d', snapshot_date_time.day)}_#{format('%02d', snapshot_date_time.month)}_#{snapshot_date_time.year}%29.zip\""
+        expect(response.headers['Content-Type']).to eq 'application/zip'
+      end
+    end
+
+    context 'when the data is invliad' do
+      let(:snapshot_date_time) { Time.zone.now + 1.day }
+      let(:create_params) { { snapshot_date_yyyy: '', snapshot_date_mm: '', snapshot_date_dd: '', snapshot_time_hh: '', snapshot_time_mm: '' } }
+
+      it 'renders the new page' do
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/admin/supplier_data/snapshot_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/supplier_data/snapshot_spec.rb
@@ -1,0 +1,288 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData::Snapshot, type: :model do
+  let(:snapshot) do
+    described_class.new(
+      snapshot_date_yyyy: snapshot_date_yyyy,
+      snapshot_date_mm: snapshot_date_mm,
+      snapshot_date_dd: snapshot_date_dd,
+      snapshot_time_hh: snapshot_time_hh,
+      snapshot_time_mm: snapshot_time_mm
+    )
+  end
+  let(:snapshot_date) { Time.zone.now + 1.day }
+  let(:snapshot_date_yyyy) { snapshot_date.year.to_s }
+  let(:snapshot_date_mm) { snapshot_date.month.to_s }
+  let(:snapshot_date_dd) { snapshot_date.day.to_s }
+  let(:snapshot_time_hh) { snapshot_date.hour.to_s }
+  let(:snapshot_time_mm) { snapshot_date.min.to_s }
+
+  describe 'validating the snapshot date time' do
+    context 'when considering snapshot_date_yyyy and it is nil' do
+      let(:snapshot_date_yyyy) { nil }
+
+      it 'is not valid and has the correct error message' do
+        expect(snapshot.valid?).to eq false
+        expect(snapshot.errors[:snapshot_date].first).to eq 'Enter a valid \'snapshot\' date'
+      end
+    end
+
+    context 'when considering snapshot_date_mm and it is blank' do
+      let(:snapshot_date_mm) { '' }
+
+      it 'is not valid and has the correct error message' do
+        expect(snapshot.valid?).to eq false
+        expect(snapshot.errors[:snapshot_date].first).to eq 'Enter a valid \'snapshot\' date'
+      end
+    end
+
+    context 'when considering snapshot_date_dd and it is empty' do
+      let(:snapshot_date_dd) { '    ' }
+
+      it 'is not valid and has the correct error message' do
+        expect(snapshot.valid?).to eq false
+        expect(snapshot.errors[:snapshot_date].first).to eq 'Enter a valid \'snapshot\' date'
+      end
+    end
+
+    context 'when considering the snapshot_date' do
+      context 'and it is not a real date' do
+        let(:snapshot_date_yyyy) { snapshot_date.year.to_s }
+        let(:snapshot_date_mm) { '2' }
+        let(:snapshot_date_dd) { '30' }
+
+        it 'is not valid and has the correct error message' do
+          expect(snapshot.valid?).to eq false
+          expect(snapshot.errors[:snapshot_date].first).to eq 'Enter a valid \'snapshot\' date'
+        end
+      end
+    end
+
+    context 'when considering snapshot_time_hh' do
+      let(:snapshot_time_mm) { nil }
+
+      context 'and it is nil' do
+        let(:snapshot_time_hh) { nil }
+
+        it 'is valid' do
+          expect(snapshot.valid?).to be true
+        end
+      end
+
+      context 'and it is blank' do
+        let(:snapshot_time_hh) { '' }
+
+        it 'is valid' do
+          expect(snapshot.valid?).to be true
+        end
+      end
+
+      context 'and it is empty' do
+        let(:snapshot_time_hh) { '    ' }
+
+        it 'is valid' do
+          expect(snapshot.valid?).to be true
+        end
+      end
+
+      context 'and it is not a number' do
+        let(:snapshot_time_hh) { 'Go Beyond' }
+
+        it 'is not valid and has the correct error message' do
+          expect(snapshot.valid?).to eq false
+          expect(snapshot.errors[:snapshot_time].first).to eq "Enter a valid 'snapshot' time (23:59 or earlier)"
+        end
+      end
+
+      context 'and it is less than 0' do
+        let(:snapshot_time_hh) { '-6' }
+
+        it 'is not valid and has the correct error message' do
+          expect(snapshot.valid?).to eq false
+          expect(snapshot.errors[:snapshot_time].first).to eq "Enter a valid 'snapshot' time (23:59 or earlier)"
+        end
+      end
+
+      context 'and it is greater than 23' do
+        let(:snapshot_time_hh) { '24' }
+
+        it 'is not valid and has the correct error message' do
+          expect(snapshot.valid?).to eq false
+          expect(snapshot.errors[:snapshot_time].first).to eq "Enter a valid 'snapshot' time (23:59 or earlier)"
+        end
+      end
+    end
+
+    context 'when considering snapshot_time_mm' do
+      let(:snapshot_time_hh) { nil }
+
+      context 'and it is nil' do
+        let(:snapshot_time_mm) { nil }
+
+        it 'is valid' do
+          expect(snapshot.valid?).to be true
+        end
+      end
+
+      context 'and it is blank' do
+        let(:snapshot_time_mm) { '' }
+
+        it 'is valid' do
+          expect(snapshot.valid?).to be true
+        end
+      end
+
+      context 'and it is empty' do
+        let(:snapshot_time_mm) { '    ' }
+
+        it 'is valid' do
+          expect(snapshot.valid?).to be true
+        end
+      end
+
+      context 'and it is not a number' do
+        let(:snapshot_time_mm) { 'Plus Ultra!' }
+
+        it 'is not valid and has the correct error message' do
+          expect(snapshot.valid?).to eq false
+          expect(snapshot.errors[:snapshot_time].first).to eq "Enter a valid 'snapshot' time (23:59 or earlier)"
+        end
+      end
+
+      context 'and it is less than 0' do
+        let(:snapshot_time_mm) { '-1' }
+
+        it 'is not valid and has the correct error message' do
+          expect(snapshot.valid?).to eq false
+          expect(snapshot.errors[:snapshot_time].first).to eq "Enter a valid 'snapshot' time (23:59 or earlier)"
+        end
+      end
+
+      context 'and it is greater than 59' do
+        let(:snapshot_time_mm) { '60' }
+
+        it 'is not valid and has the correct error message' do
+          expect(snapshot.valid?).to eq false
+          expect(snapshot.errors[:snapshot_time].first).to eq "Enter a valid 'snapshot' time (23:59 or earlier)"
+        end
+      end
+    end
+
+    context 'when considering the snapshot_date_time' do
+      let(:created_at) { DateTime.new(2022, 7, 5, 12, 45, 30).in_time_zone('London') }
+      let(:snapshot_date) { created_at }
+
+      before { FacilitiesManagement::RM6232::Admin::SupplierData.latest_data.update(created_at: created_at) }
+
+      context 'and the date and time entered is before the oldest supplier data' do
+        let(:snapshot_time_mm) { '44' }
+
+        it 'is not valid and has the correct error message' do
+          expect(snapshot.valid?).to eq false
+          expect(snapshot.errors[:snapshot_date_time].first).to eq 'You must enter a data and time on or after  5 July 2022, 13:45 (when the supplier data was imported for the first time)'
+        end
+      end
+
+      context 'and the date and time entered is on the oldest supplier data' do
+        it 'is valid' do
+          expect(snapshot.valid?).to eq true
+        end
+      end
+
+      context 'and the date and time entered is after the oldest supplier data' do
+        let(:snapshot_time_mm) { '46' }
+
+        it 'is valid' do
+          expect(snapshot.valid?).to eq true
+        end
+      end
+    end
+  end
+
+  describe 'create_snapshot_date_time' do
+    context 'when in BST' do
+      let(:snapshot_date) { Time.find_zone('London').local(2022, 7, 7) }
+
+      context 'when the minutes and hours are blank' do
+        let(:snapshot_time_hh) { nil }
+        let(:snapshot_time_mm) { nil }
+
+        it 'sets the snapshot_date_time time as 23:59' do
+          expect(snapshot.snapshot_date_time.hour).to eq 23
+          expect(snapshot.snapshot_date_time.min).to eq 59
+        end
+      end
+
+      context 'when the minutes and hours are present' do
+        let(:snapshot_time_hh) { 7 }
+        let(:snapshot_time_mm) { 11 }
+
+        it 'sets the snapshot_date_time time as minutes and hours passed' do
+          expect(snapshot.snapshot_date_time.hour).to eq 6
+          expect(snapshot.snapshot_date_time.min).to eq 11
+        end
+      end
+    end
+
+    context 'when in GMT' do
+      let(:snapshot_date) { Time.find_zone('London').local(2022, 11, 11) }
+
+      context 'when the minutes and hours are blank' do
+        let(:snapshot_time_hh) { nil }
+        let(:snapshot_time_mm) { nil }
+
+        it 'sets the snapshot_date_time time as 23:59' do
+          expect(snapshot.snapshot_date_time.hour).to eq 23
+          expect(snapshot.snapshot_date_time.min).to eq 59
+        end
+      end
+
+      context 'when the minutes and hours are present' do
+        let(:snapshot_time_hh) { 7 }
+        let(:snapshot_time_mm) { 11 }
+
+        it 'sets the snapshot_date_time time as minutes and hours passed' do
+          expect(snapshot.snapshot_date_time.hour).to eq 7
+          expect(snapshot.snapshot_date_time.min).to eq 11
+        end
+      end
+    end
+  end
+
+  describe 'snapshot_filename' do
+    let(:snapshot_date) { Time.zone.local(2022, 7, 5, 13, 45, 30) }
+
+    context 'when there are hours and minutes' do
+      it 'returns the file name with the date and time formatted' do
+        expect(snapshot.snapshot_filename).to eq('Supplier data spreadsheets (05_07_2022 13_45).zip')
+      end
+    end
+
+    context 'when there are no hours and minutes' do
+      let(:snapshot_time_hh) { '' }
+      let(:snapshot_time_mm) { '' }
+
+      it 'returns the file name with the date formatted' do
+        expect(snapshot.snapshot_filename).to eq('Supplier data spreadsheets (05_07_2022).zip')
+      end
+    end
+  end
+
+  describe 'generate_snapshot_zip' do
+    let(:snapshot_generator) { instance_double('snapshot_generator') }
+
+    before do
+      allow(FacilitiesManagement::RM6232::Admin::SupplierDataSnapshotGenerator).to receive(:new).and_return(snapshot_generator)
+      allow(snapshot_generator).to receive(:build_zip_file)
+      allow(snapshot_generator).to receive(:to_zip)
+    end
+
+    it 'calls the expected methods' do
+      snapshot.generate_snapshot_zip
+
+      expect(FacilitiesManagement::RM6232::Admin::SupplierDataSnapshotGenerator).to have_received(:new).with(snapshot.snapshot_date_time)
+      expect(snapshot_generator).to have_received(:build_zip_file)
+      expect(snapshot_generator).to have_received(:to_zip)
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/admin/supplier_data_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/supplier_data_spec.rb
@@ -14,6 +14,26 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData, type: :model d
     end
   end
 
+  describe '.oldest_data_created_at' do
+    let(:created_at) { Time.zone.local(2022, 7, 5, 13, 45) }
+
+    before { described_class.latest_data.update(created_at: created_at) }
+
+    it 'returns the 5th of July 2022' do
+      expect(described_class.oldest_data_created_at).to eq(created_at)
+    end
+  end
+
+  describe '.oldest_data_created_at_string' do
+    let(:created_at) { Time.zone.local(2022, 7, 5, 12, 45) }
+
+    before { described_class.latest_data.update(created_at: created_at) }
+
+    it 'returns 5 July 2022, 13:45' do
+      expect(described_class.oldest_data_created_at_string).to eq(' 5 July 2022, 13:45')
+    end
+  end
+
   describe '.audit_logs' do
     let(:user_1) { create(:user) }
     let(:user_2) { create(:user) }

--- a/spec/services/facilities_management/rm6232/admin/change_logs_csv_generator_spec.rb
+++ b/spec/services/facilities_management/rm6232/admin/change_logs_csv_generator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::ChangeLogsCsvGenerator do
   let(:supplier_2_id) { supplier_data_1.data.find { |data| data['supplier_name'] == 'Skiles LLC' }['id'] }
 
   def get_time(*time_array)
-    DateTime.new(*time_array).in_time_zone('London')
+    Time.zone.local(*time_array).in_time_zone('London')
   end
 
   before do

--- a/spec/services/facilities_management/rm6232/admin/supplier_data_snapshot_generator_spec.rb
+++ b/spec/services/facilities_management/rm6232/admin/supplier_data_snapshot_generator_spec.rb
@@ -1,0 +1,137 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierDataSnapshotGenerator do
+  let(:user_1) { create(:user, email: 'reiner.braun@attackontitn.pa') }
+  let(:user_2) { create(:user, email: 'bertholdt.hoover@attackontitn.pa') }
+  let(:new_upload) { create(:facilities_management_rm6232_admin_upload, user: user_2) }
+  let(:supplier_data_1) { FacilitiesManagement::RM6232::Admin::SupplierData.latest_data }
+  let(:supplier_data_2) { FacilitiesManagement::RM6232::Admin::SupplierData.create(upload: new_upload, data: supplier_data_1.data, created_at: get_time(2022, 3, 8, 10, 0, 30)) }
+  let(:supplier_1_id) { supplier_data_1.data.find { |data| data['supplier_name'] == 'Abshire, Schumm and Farrell' }['id'] }
+  let(:supplier_2_id) { supplier_data_1.data.find { |data| data['supplier_name'] == 'Skiles LLC' }['id'] }
+
+  def get_time(*time_array)
+    Time.zone.local(*time_array).in_time_zone('London')
+  end
+
+  before do
+    supplier_data_1.update(created_at: get_time(2022, 3, 4, 12, 55, 30))
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data, user: user_1, created_at: get_time(2022, 3, 5, 1, 11, 30), supplier_id: supplier_1_id, data: { 'lot_code' => '1a', 'attribute' => 'service_codes', 'added' => %w[F.12], 'removed' => [] })
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: get_time(2022, 3, 6, 13, 26, 30), supplier_id: supplier_1_id)
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_region_lot_data, user: user_1, created_at: get_time(2022, 3, 7, 4, 59, 30), supplier_id: supplier_2_id)
+    supplier_data_2
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: get_time(2022, 3, 9, 12, 0, 30), supplier_id: supplier_1_id, data: [{ 'attribute' => 'supplier_name', 'value' => 'Marc Ribillet Records' }])
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data, user: user_2, created_at: get_time(2022, 3, 10, 0, 18, 30), supplier_id: supplier_1_id, data: { 'lot_code' => '1a', 'attribute' => 'service_codes', 'added' => %w[E.14 E.15], 'removed' => %w[I.14 J.7] })
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: get_time(2022, 3, 12, 17, 25, 30), supplier_id: supplier_2_id, data: [{ 'attribute' => 'address_line_1', 'value' => '1 Loop daddy' }, { 'attribute' => 'address_town', 'value' => 'New York City' }])
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: get_time(2022, 3, 12, 17, 26, 30), supplier_id: supplier_2_id, data: [{ 'attribute' => 'address_line_1', 'value' => '2 Loop daddy' }, { 'attribute' => 'address_town', 'value' => 'New Jersey City' }])
+  end
+
+  describe '.set_data' do
+    let(:snapshot_generator) { described_class.new(snapshot_date_time) }
+    let(:supplier_data) { snapshot_generator.instance_variable_get(:@supplier_data) }
+    let(:supplier_1_data) { supplier_data.find { |supplier| supplier['id'] == supplier_1_id } }
+    let(:supplier_2_data) { supplier_data.find { |supplier| supplier['id'] == supplier_2_id } }
+
+    before { snapshot_generator.send(:set_data) }
+
+    context 'and the snapshot_date_time is 2022/3/6 13:00' do
+      let(:snapshot_date_time) { get_time(2022, 3, 6, 13, 0) }
+
+      it 'has the right data for the first supplier' do
+        expect(supplier_1_data['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['service_codes']).to include('F.12')
+        expect(supplier_1_data['active']).to be_nil
+      end
+
+      it 'has the right data for the second supplier' do
+        expect(supplier_2_data['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['region_codes']).to include('UKC1')
+      end
+    end
+
+    context 'and the snapshot_date_time is 2022/3/8 9:00' do
+      let(:snapshot_date_time) { get_time(2022, 3, 8, 9, 0) }
+
+      it 'has the right data for the first supplier' do
+        expect(supplier_1_data['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['service_codes']).to include('F.12')
+        expect(supplier_1_data['active']).to be false
+      end
+
+      it 'has the right data for the second supplier' do
+        expect(supplier_2_data['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['region_codes']).not_to include('UKC1')
+      end
+    end
+
+    context 'and the snapshot_date_time is 2022/3/12 17:25' do
+      let(:snapshot_date_time) { get_time(2022, 3, 12, 17, 25) }
+
+      it 'has the right data for the first supplier' do
+        service_codes = supplier_1_data['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['service_codes']
+
+        expect(supplier_1_data['supplier_name']).to eq('Marc Ribillet Records')
+        expect(service_codes).to include('E.14', 'E.15')
+        expect(service_codes).not_to include('I.14', 'J.7')
+      end
+
+      it 'has the right data for the second supplier' do
+        expect(supplier_2_data['address_line_1']).to eq('1 Loop daddy')
+        expect(supplier_2_data['address_town']).to eq('New York City')
+      end
+    end
+
+    context 'and the snapshot_date_time is 2022/3/12 17:27' do
+      let(:snapshot_date_time) { get_time(2022, 3, 12, 17, 27) }
+
+      it 'has the right data for the first supplier' do
+        service_codes = supplier_1_data['lot_data'].find { |lot_data| lot_data['lot_code'] == '1a' }['service_codes']
+
+        expect(supplier_1_data['supplier_name']).to eq('Marc Ribillet Records')
+        expect(service_codes).to include('E.14', 'E.15')
+        expect(service_codes).not_to include('I.14', 'J.7')
+      end
+
+      it 'has the right data for the second supplier' do
+        expect(supplier_2_data['address_line_1']).to eq('2 Loop daddy')
+        expect(supplier_2_data['address_town']).to eq('New Jersey City')
+      end
+    end
+  end
+
+  describe '.build_zip_file' do
+    let(:snapshot_generator) { described_class.new(snapshot_date_time) }
+    let(:snapshot_date_time) { get_time(2022, 3, 6, 13, 0) }
+    let(:supplier_data) { snapshot_generator.instance_variable_get(:@supplier_data) }
+
+    let(:supplier_spreadsheet) { instance_double('supplier_spreadsheet') }
+    let(:fake_spreadsheet_file) { Tempfile.new(['supplier_data', '.xlsx']) }
+
+    before do
+      allow(FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet::Details).to receive(:new).and_return(supplier_spreadsheet)
+      allow(FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet::Services).to receive(:new).and_return(supplier_spreadsheet)
+      allow(FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet::Regions).to receive(:new).and_return(supplier_spreadsheet)
+      allow(supplier_spreadsheet).to receive(:build)
+      allow(supplier_spreadsheet).to receive(:to_xlsx).and_return('')
+      snapshot_generator.build_zip_file
+    end
+
+    after { fake_spreadsheet_file.unlink }
+
+    it 'calls the spreadsheet generators' do
+      expect(FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet::Details).to have_received(:new).with(supplier_data, nil, true)
+      expect(FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet::Services).to have_received(:new).with(supplier_data)
+      expect(FacilitiesManagement::RM6232::Admin::SupplierSpreadsheet::Regions).to have_received(:new).with(supplier_data)
+    end
+
+    it 'builds the spreadsheet and converts it to xlsx' do
+      expect(supplier_spreadsheet).to have_received(:build).exactly(3).time
+      expect(supplier_spreadsheet).to have_received(:to_xlsx).exactly(3).time
+    end
+
+    context 'and to_zip is called' do
+      it 'includes all the files' do
+        expect(snapshot_generator.to_zip).to include(
+          'RM6232 Suppliers Details (06_03_2022 13_00).xlsx',
+          'RM6232 Suppliers Services (06_03_2022 13_00).xlsx',
+          'RM6232 Suppliers Regions (06_03_2022 13_00).xlsx'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: [FMFR-1249](https://crowncommercialservice.atlassian.net/browse/FMFR-1249)

There is a requirement from the admin team that all changes that are made to the supplier data are logged.

In this commit I have added the ability to download the supplier data at any instant in time. This may be needed for auditing purposes if, for example, a supplier complained that they were not being included in any searches.

As always I have added specs to make sure everything is working as expected.