### PR TITLE
FMFR-1251 - Add job and service to generate management report

### DIFF
--- a/app/controllers/active_storage/blobs_controller.rb
+++ b/app/controllers/active_storage/blobs_controller.rb
@@ -27,7 +27,8 @@ class ActiveStorage::BlobsController < ActiveStorage::BaseController
   end
 
   KEY_TO_MODEL = {
-    management_report_id: FacilitiesManagement::RM3830::Admin::ManagementReport,
+    rm3830_management_report_id: FacilitiesManagement::RM3830::Admin::ManagementReport,
+    rm6232_management_report_id: FacilitiesManagement::RM6232::Admin::ManagementReport,
     rm3830_admin_upload_id: FacilitiesManagement::RM3830::Admin::Upload,
     rm6232_admin_upload_id: FacilitiesManagement::RM6232::Admin::Upload,
     contract_id: FacilitiesManagement::RM3830::ProcurementSupplier,

--- a/app/controllers/facilities_management/admin/management_reports_controller.rb
+++ b/app/controllers/facilities_management/admin/management_reports_controller.rb
@@ -6,17 +6,17 @@ module FacilitiesManagement
       helper_method :show_path, :new_path, :index_path
 
       def index
-        @management_reports = service::Admin::ManagementReport.order(created_at: :desc).page(params[:page])
+        @management_reports = service::ManagementReport.order(created_at: :desc).page(params[:page])
       end
 
       def show; end
 
       def new
-        @management_report = service::Admin::ManagementReport.new
+        @management_report = service::ManagementReport.new
       end
 
       def create
-        @management_report = service::Admin::ManagementReport.new(user: current_user)
+        @management_report = service::ManagementReport.new(user: current_user)
 
         @management_report.assign_attributes(management_report_params)
 
@@ -34,11 +34,11 @@ module FacilitiesManagement
       private
 
       def service
-        @service ||= self.class.module_parent.module_parent
+        @service ||= self.class.module_parent
       end
 
       def set_management_report
-        @management_report = service::Admin::ManagementReport.find(params[:id])
+        @management_report = service::ManagementReport.find(params[:id])
       end
 
       def index_path

--- a/app/controllers/facilities_management/admin/uploads_controller.rb
+++ b/app/controllers/facilities_management/admin/uploads_controller.rb
@@ -4,18 +4,18 @@ module FacilitiesManagement
       before_action :set_upload, only: %i[show progress]
 
       def index
-        @latest_upload = service::Admin::Upload.latest_upload
-        @uploads = service::Admin::Upload.all.page params[:page]
+        @latest_upload = service::Upload.latest_upload
+        @uploads = service::Upload.all.page params[:page]
       end
 
       def show; end
 
       def new
-        @upload = service::Admin::Upload.new
+        @upload = service::Upload.new
       end
 
       def create
-        @upload = service::Admin::Upload.new(user: current_user)
+        @upload = service::Upload.new(user: current_user)
 
         @upload.assign_attributes(upload_params)
 
@@ -34,15 +34,15 @@ module FacilitiesManagement
       private
 
       def set_upload
-        @upload = service::Admin::Upload.find(params[:id] || params[:upload_id])
+        @upload = service::Upload.find(params[:id] || params[:upload_id])
       end
 
       def authorize_user
-        authorize! :manage, service::Admin::Upload
+        authorize! :manage, service::Upload
       end
 
       def service
-        @service ||= self.class.module_parent.module_parent
+        @service ||= self.class.module_parent
       end
 
       def upload_params

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -32,6 +32,7 @@ class Ability
     can :read, :all
     can :manage, FacilitiesManagement::Admin
     can :manage, FacilitiesManagement::RM3830::Admin::ManagementReport
+    can :manage, FacilitiesManagement::RM6232::Admin::ManagementReport
     can :manage, FacilitiesManagement::RM3830::Admin::Upload
     can :manage, FacilitiesManagement::RM6232::Admin::Upload
   end

--- a/app/models/facilities_management/admin/management_report.rb
+++ b/app/models/facilities_management/admin/management_report.rb
@@ -20,6 +20,10 @@ class FacilitiesManagement::Admin::ManagementReport < ApplicationRecord
     end
   end
 
+  def generate_report_csv
+    self.class.module_parent::ManagementReportWorker.perform_async(id) unless management_report_csv.attached?
+  end
+
   def short_id
     "##{id[..7]}"
   end

--- a/app/models/facilities_management/rm3830/admin/management_report.rb
+++ b/app/models/facilities_management/rm3830/admin/management_report.rb
@@ -5,12 +5,6 @@ module FacilitiesManagement
         belongs_to :user, inverse_of: :rm3830_management_reports
 
         acts_as_gov_uk_date :start_date, :end_date, error_clash_behaviour: :omit_gov_uk_date_field_error
-
-        private
-
-        def generate_report_csv
-          ManagementReportWorker.perform_async(id) unless management_report_csv.attached?
-        end
       end
     end
   end

--- a/app/models/facilities_management/rm6232/admin/management_report.rb
+++ b/app/models/facilities_management/rm6232/admin/management_report.rb
@@ -5,12 +5,6 @@ module FacilitiesManagement
         belongs_to :user, inverse_of: :rm6232_management_reports
 
         acts_as_gov_uk_date :start_date, :end_date, error_clash_behaviour: :omit_gov_uk_date_field_error
-
-        private
-
-        def generate_report_csv
-          # ManagementReportWorker.perform_async(id) unless management_report_csv.attached?
-        end
       end
     end
   end

--- a/app/models/facilities_management/rm6232/procurement.rb
+++ b/app/models/facilities_management/rm6232/procurement.rb
@@ -32,6 +32,10 @@ module FacilitiesManagement
         @quick_view_suppliers ||= SuppliersSelector.new(service_codes_without_cafm, region_codes, annual_contract_value)
       end
 
+      def supplier_names
+        SuppliersSelector.new(service_codes_without_cafm, region_codes, annual_contract_value, lot_number).selected_suppliers.pluck(:supplier_name)
+      end
+
       def suppliers
         @suppliers ||= SuppliersSelector.new(procurement_buildings_service_codes_without_cafm, procurement_buildings_region_codes, annual_contract_value)
       end

--- a/app/services/facilities_management/rm6232/admin/management_report_csv_generator.rb
+++ b/app/services/facilities_management/rm6232/admin/management_report_csv_generator.rb
@@ -1,0 +1,131 @@
+module FacilitiesManagement::RM6232
+  module Admin
+    class ManagementReportCsvGenerator
+      def initialize(id)
+        @management_report = ManagementReport.find(id)
+        @start_date = @management_report.start_date
+        @end_date = @management_report.end_date
+      end
+
+      def generate
+        report_csv = StringIO.new generate_csv
+        @management_report.management_report_csv.attach(io: report_csv, filename: "procurements_data_#{created_at}_#{date_to_string(@start_date)}-#{date_to_string(@end_date)}.csv", content_type: 'text/csv')
+        @management_report.complete
+        @management_report.save
+      end
+
+      private
+
+      def generate_csv
+        CSV.generate do |csv|
+          csv << COLUMN_LABELS
+          find_procurements.each { |procurement| csv << create_procurement_row(procurement) }
+        end
+      end
+
+      def find_procurements
+        Procurement.where(created_at: (@start_date..(@end_date + 1))).order(created_at: :desc)
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def create_procurement_row(procurement)
+        [
+          procurement.contract_number,
+          procurement.contract_name,
+          localised_datetime(procurement.created_at),
+          procurement.user.buyer_detail.organisation_name,
+          procurement.user.buyer_detail.full_organisation_address,
+          procurement.user.buyer_detail.central_government ? 'Central government' : 'Wider public sector',
+          procurement.user.buyer_detail.full_name,
+          procurement.user.buyer_detail.job_title, # 10
+          procurement.user.email,
+          string_as_formula(procurement.user.buyer_detail.telephone_number),
+          expand_services(procurement.service_codes),
+          expand_regions(procurement.region_codes),
+          delimited_contract_value(procurement.annual_contract_value),
+          procurement.lot_number,
+          shortlisted_suppliers(procurement)
+        ]
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      def date_to_string(date)
+        date&.in_time_zone('London')&.strftime '%Y%m%d'
+      end
+
+      def created_at
+        @management_report.created_at&.in_time_zone('London')&.strftime '%Y%m%d-%H%M'
+      end
+
+      def localised_datetime(datetime)
+        datetime.in_time_zone(TIME_ZONE).strftime(TIME_FORMAT)
+      end
+
+      def string_as_formula(string)
+        return if string.blank?
+
+        "=\"#{string}\""
+      end
+
+      def expand_services(service_codes)
+        return if service_codes.blank?
+
+        service_codes.compact.map do |code|
+          "#{code} #{service_names[code] || 'service description not found'};\n"
+        end.join
+      end
+
+      def service_names
+        @service_names ||= FacilitiesManagement::RM6232::Service.pluck(:code, :name).to_h
+      end
+
+      def expand_regions(region_codes)
+        return if region_codes.blank?
+
+        region_codes.compact.map do |code|
+          "#{code} #{region_names[code] || 'region description not found'};\n"
+        end.join
+      end
+
+      def region_names
+        @region_names ||= FacilitiesManagement::Region.all.map { |region| [region.code, region.name] }.to_h
+      end
+
+      def delimited_contract_value(value)
+        return if value.blank?
+
+        helpers.number_with_precision(value, precision: 2, delimiter: ',')
+      end
+
+      def shortlisted_suppliers(procurement)
+        procurement.supplier_names.join(LIST_ITEM_SEPARATOR)
+      end
+
+      def helpers
+        @helpers ||= ActionController::Base.helpers
+      end
+
+      COLUMN_LABELS = [
+        'Reference number',
+        'Contract name',
+        'Date created',
+        'Buyer organisation',
+        'Buyer organisation address',
+        'Buyer sector',
+        'Buyer contact name',
+        'Buyer contact job title',
+        'Buyer contact email address',
+        'Buyer contact telephone number',
+        'Services',
+        'Regions',
+        'Annual contract cost',
+        'Lot',
+        'Shortlisted Suppliers'
+      ].freeze
+
+      TIME_FORMAT = '%e %B %Y, %l:%M%P'.freeze
+      TIME_ZONE = 'London'.freeze
+      LIST_ITEM_SEPARATOR = ";\n".freeze
+    end
+  end
+end

--- a/app/services/facilities_management/rm6232/suppliers_selector.rb
+++ b/app/services/facilities_management/rm6232/suppliers_selector.rb
@@ -2,8 +2,8 @@ module FacilitiesManagement::RM6232
   class SuppliersSelector
     attr_reader :lot_number, :selected_suppliers
 
-    def initialize(service_codes, region_codes, annual_contract_value)
-      @lot_number = Service.find_lot_number(service_codes, annual_contract_value)
+    def initialize(service_codes, region_codes, annual_contract_value, lot_number = nil)
+      @lot_number = lot_number || Service.find_lot_number(service_codes, annual_contract_value)
       @selected_suppliers = Supplier.select_suppliers(@lot_number, service_codes, region_codes)
     end
   end

--- a/app/views/facilities_management/admin/management_reports/_completed.html.erb
+++ b/app/views/facilities_management/admin/management_reports/_completed.html.erb
@@ -2,5 +2,5 @@
   <%= govuk_tag_with_text(:blue, t('.generated')) %>
 </p>
 <p>
-  <%= link_to_file_for_download("#{rails_blob_path(@management_report.management_report_csv, disposition: 'attachment', key: :management_report_id, value: @management_report.id)}&format=csv", :csv, @management_report.management_report_csv.filename, true) %>
+  <%= link_to_file_for_download("#{rails_blob_path(@management_report.management_report_csv, disposition: 'attachment', key: "#{params[:framework].downcase}_management_report_id", value: @management_report.id)}&format=csv", :csv, @management_report.management_report_csv.filename, true) %>
 </p>

--- a/app/workers/facilities_management/rm6232/admin/management_report_worker.rb
+++ b/app/workers/facilities_management/rm6232/admin/management_report_worker.rb
@@ -1,0 +1,14 @@
+module FacilitiesManagement
+  module RM6232
+    module Admin
+      class ManagementReportWorker
+        include Sidekiq::Worker
+        sidekiq_options queue: 'fm', retry: false
+
+        def perform(id)
+          ManagementReportCsvGenerator.new(id).generate
+        end
+      end
+    end
+  end
+end

--- a/features/accessibility/facilities_management/rm6232/admin/management_report_accessibility.feature
+++ b/features/accessibility/facilities_management/rm6232/admin/management_report_accessibility.feature
@@ -1,0 +1,24 @@
+@accessibility @javascript @management_report
+Feature: Management report - accessibility
+
+  Background: Navigate to the management report
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Management report'
+    Then I am on the 'Management reports' page
+
+  Scenario: Management reports page
+    Then the page should be axe clean
+
+  Scenario: Generate a management report
+    And I click on 'Generate a new management report'
+    Then I am on the 'Generate a management report' page
+    Then the page should be axe clean
+
+  Scenario: Management report show page
+    And I click on 'Generate a new management report'
+    Then I am on the 'Generate a management report' page
+    Given I enter 'yesterday' as the 'From' date
+    And I enter 'today' as the 'To' date
+    And I click on 'Generate report'
+    Then I am on the 'Management report' page
+    Then the page should be axe clean

--- a/features/facilities_management/rm6232/admin/management_report/management_report.feature
+++ b/features/facilities_management/rm6232/admin/management_report/management_report.feature
@@ -1,0 +1,42 @@
+@management_report
+Feature: Management report
+
+  Background: Navigate to the management report page
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Management report'
+    Then I am on the 'Management reports' page
+
+  Scenario: Return links work on management reports page
+    Given I click on 'Home'
+    Then I am on the 'RM6232 administration dashboard' page
+
+  Scenario Outline: Return links work on management report page
+    And I click on 'Generate a new management report'
+    Then I am on the 'Generate a management report' page
+    Given I click on '<text>'
+    Then I am on the '<page>' page
+
+    Examples:
+      | text                | page                            |
+      | Home                | RM6232 administration dashboard |
+      | Management reports  | Management reports              |
+
+  Scenario: Able to download the management report
+    And I click on 'Generate a new management report'
+    Then I am on the 'Generate a management report' page
+    Given I enter 'yesterday' as the 'From' date
+    And I enter 'today' as the 'To' date
+    And I click on 'Generate report'
+    Then I am on the 'Management report' page
+    And the management report has the correct date range
+
+  Scenario: Links on the show page work
+    And I click on 'Generate a new management report'
+    Then I am on the 'Generate a management report' page
+    Given I enter 'yesterday' as the 'From' date
+    And I enter 'today' as the 'To' date
+    And I click on 'Generate report'
+    Then I am on the 'Management report' page
+    Then I click on 'Management reports'
+    Then I am on the 'Management reports' page
+    And there should be 1 management reports

--- a/features/facilities_management/rm6232/admin/management_report/validations/management_report_validations.feature
+++ b/features/facilities_management/rm6232/admin/management_report/validations/management_report_validations.feature
@@ -1,0 +1,47 @@
+@pipeline
+Feature: Management report  - validations
+
+  Background: Navigate to the management report page
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Management reports'
+    Then I am on the 'Management reports' page
+    And I click on 'Generate a new management report'
+    Then I am on the 'Generate a management report' page
+
+  Scenario Outline: Blank date validation
+    And I enter 'yesterday' as the '<date_type>' date
+    And I click on 'Generate report'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | date_type | error_message             |
+      | From      | Enter a valid ‘To’ date   |
+      | To        | Enter a valid ‘From’ date |
+
+  Scenario Outline: From date validation
+    Given I enter '<date>' as the 'From' date
+    And I enter 'today' as the 'To' date
+    And I click on 'Generate report'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | date        | error_message                                 |
+      | tomorrow    | The ‘From’ date must be today or in the past  |
+      | 89/45/0161  | Enter a valid ‘From’ date                     |
+      | a/b/c       | Enter a valid ‘From’ date                     |
+
+  Scenario Outline: From date validation
+    Given I enter '<date>' as the 'To' date
+    And I enter 'today' as the 'From' date
+    And I click on 'Generate report'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | date      | error_message                                           |
+      | tomorrow  | The ‘To’ date must be today or in the past              |
+      | yesterday | The ‘To’ date must be the same or after the ‘From’ date |
+      | 29/2/2021 | Enter a valid ‘To’ date                                 |
+      | a/b/c     | Enter a valid ‘To’ date                                 |

--- a/features/helpers/facilities_management/management_report.rb
+++ b/features/helpers/facilities_management/management_report.rb
@@ -1,3 +1,4 @@
 def stub_management_report
   allow(FacilitiesManagement::RM3830::Admin::ManagementReportWorker).to receive(:perform_async).and_return(nil)
+  allow(FacilitiesManagement::RM6232::Admin::ManagementReportWorker).to receive(:perform_async).and_return(nil)
 end

--- a/features/support/pages/admin.rb
+++ b/features/support/pages/admin.rb
@@ -19,16 +19,6 @@ module Pages
       section :'Full address', SupplierDetailsSection, '#supplier-details--full_address'
     end
 
-    section :management_report, 'form' do
-      element :'From day', '#facilities_management_rm3830_admin_management_report_start_date_dd'
-      element :'From month', '#facilities_management_rm3830_admin_management_report_start_date_mm'
-      element :'From year', '#facilities_management_rm3830_admin_management_report_start_date_yyyy'
-
-      element :'To day', '#facilities_management_rm3830_admin_management_report_end_date_dd'
-      element :'To month', '#facilities_management_rm3830_admin_management_report_end_date_mm'
-      element :'To year', '#facilities_management_rm3830_admin_management_report_end_date_yyyy'
-    end
-
     element :management_report_date, '#main-content > div:nth-child(4) > div > p:nth-child(2)'
     elements :management_reports, '#main-content > div:nth-child(5) > div > table > tbody > tr'
   end

--- a/features/support/pages/rm3830/admin.rb
+++ b/features/support/pages/rm3830/admin.rb
@@ -11,5 +11,15 @@ module Pages::RM3830
       element :'DUNS number', '#facilities_management_rm3830_admin_suppliers_admin_duns'
       element :'Company registration number', '#facilities_management_rm3830_admin_suppliers_admin_registration_number'
     end
+
+    section :management_report, 'form' do
+      element :'From day', '#facilities_management_rm3830_admin_management_report_start_date_dd'
+      element :'From month', '#facilities_management_rm3830_admin_management_report_start_date_mm'
+      element :'From year', '#facilities_management_rm3830_admin_management_report_start_date_yyyy'
+
+      element :'To day', '#facilities_management_rm3830_admin_management_report_end_date_dd'
+      element :'To month', '#facilities_management_rm3830_admin_management_report_end_date_mm'
+      element :'To year', '#facilities_management_rm3830_admin_management_report_end_date_yyyy'
+    end
   end
 end

--- a/features/support/pages/rm6232/admin.rb
+++ b/features/support/pages/rm6232/admin.rb
@@ -69,5 +69,15 @@ module Pages::RM6232
 
     elements :added_items, '#added-items > li'
     elements :removed_items, '#removed-items > li'
+
+    section :management_report, 'form' do
+      element :'From day', '#facilities_management_rm6232_admin_management_report_start_date_dd'
+      element :'From month', '#facilities_management_rm6232_admin_management_report_start_date_mm'
+      element :'From year', '#facilities_management_rm6232_admin_management_report_start_date_yyyy'
+
+      element :'To day', '#facilities_management_rm6232_admin_management_report_end_date_dd'
+      element :'To month', '#facilities_management_rm6232_admin_management_report_end_date_mm'
+      element :'To year', '#facilities_management_rm6232_admin_management_report_end_date_yyyy'
+    end
   end
 end

--- a/spec/controllers/active_storage/blobs_controller_spec.rb
+++ b/spec/controllers/active_storage/blobs_controller_spec.rb
@@ -13,12 +13,96 @@ RSpec.describe ActiveStorage::BlobsController, type: :controller do
 
   # rubocop:disable RSpec/NestedGroups
   describe '#show' do
-    context 'when trying to download a management report' do
+    context 'when trying to download an RM3830 management report' do
       let(:signed_id) { management_report.management_report_csv.blob.signed_id }
       let(:filename) { management_report.management_report_csv.blob.filename }
-      let(:object_id_key) { :management_report_id }
+      let(:object_id_key) { :rm3830_management_report_id }
       let(:object_id) { management_report.id }
       let(:management_report) { create(:facilities_management_rm3830_admin_management_report_with_report, user: create(:user)) }
+
+      context 'when signed in as a buyer' do
+        login_fm_buyer_with_details
+
+        it 'redirects to the not permitted path' do
+          get :show
+
+          expect(response).to redirect_to facilities_management_rm3830_not_permitted_path
+        end
+      end
+
+      context 'when signed in as a supplier' do
+        login_fm_supplier
+
+        it 'redirects to the not permitted path' do
+          get :show
+
+          expect(response).to redirect_to facilities_management_rm3830_not_permitted_path
+        end
+      end
+
+      context 'when signed in as an admin' do
+        login_fm_admin
+
+        it 'allows the blob to be downloaded' do
+          get :show
+
+          expect(response).to have_http_status(:found)
+        end
+
+        context 'when the key is not passed' do
+          it 'redirects to the not permitted path' do
+            default_params.delete(:key)
+
+            get :show
+
+            expect(response).to redirect_to facilities_management_rm3830_not_permitted_path
+          end
+        end
+
+        context 'when the value is not passed' do
+          it 'redirects to the not permitted path' do
+            default_params.delete(:value)
+
+            get :show
+
+            expect(response).to redirect_to facilities_management_rm3830_not_permitted_path
+          end
+        end
+
+        context 'when the key is not valid' do
+          let(:object_id_key) { :fake_procurement_id_key }
+
+          it 'redirects to the not permitted path' do
+            get :show
+
+            expect(response).to redirect_to facilities_management_rm3830_not_permitted_path
+          end
+        end
+
+        context 'when the object does not exist' do
+          let(:object_id) { SecureRandom.uuid }
+
+          it 'is raise a routing error' do
+            expect { get :show }.to raise_error(ActionController::RoutingError)
+          end
+        end
+      end
+
+      context 'when not signed in' do
+        it 'returns unauthorized' do
+          get :show
+
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+    end
+
+    context 'when trying to download an RM6232 management report' do
+      let(:signed_id) { management_report.management_report_csv.blob.signed_id }
+      let(:filename) { management_report.management_report_csv.blob.filename }
+      let(:object_id_key) { :rm6232_management_report_id }
+      let(:object_id) { management_report.id }
+      let(:management_report) { create(:facilities_management_rm6232_admin_management_report_with_report, user: create(:user)) }
 
       context 'when signed in as a buyer' do
         login_fm_buyer_with_details

--- a/spec/controllers/facilities_management/rm6232/admin/management_reports_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/management_reports_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::ManagementReportsController,
 
   login_fm_admin
 
-  # before { allow(FacilitiesManagement::RM6232::Admin::ManagementReportWorker).to receive(:perform_async).with(anything).and_return(true) }
+  before { allow(FacilitiesManagement::RM6232::Admin::ManagementReportWorker).to receive(:perform_async).with(anything).and_return(true) }
 
   describe 'GET new' do
     it 'renders the new page' do

--- a/spec/services/facilities_management/rm6232/admin/management_report_csv_generator_spec.rb
+++ b/spec/services/facilities_management/rm6232/admin/management_report_csv_generator_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::ManagementReportCsvGenerator do
+  let(:management_report_csv_generator) { described_class.new(management_report.id) }
+  let(:management_report) { create(:facilities_management_rm6232_admin_management_report, user: create(:user), start_date: start_date, end_date: end_date) }
+  let(:start_date) { Time.zone.today - 1.year }
+  let(:end_date) { Time.zone.today - 1.day }
+
+  before { allow(FacilitiesManagement::RM6232::Admin::ManagementReportWorker).to receive(:perform_async).with(anything).and_return(true) }
+
+  describe '.initialize' do
+    it 'finds the management report' do
+      expect(management_report_csv_generator.instance_variable_get(:@management_report)).to eq management_report
+    end
+
+    it 'sets the dates' do
+      expect(management_report_csv_generator.instance_variable_get(:@start_date)).to eq start_date
+      expect(management_report_csv_generator.instance_variable_get(:@end_date)).to eq end_date
+    end
+  end
+
+  describe '.generate' do
+    before do
+      allow(management_report_csv_generator).to receive(:generate_csv).and_return('')
+      management_report_csv_generator.generate
+      management_report.reload
+    end
+
+    it 'attaches the file to the management report' do
+      expect(management_report.management_report_csv).to be_attached
+    end
+
+    it 'attaches the file with the correct filename' do
+      expect(management_report.management_report_csv.content_type).to eq 'text/csv'
+    end
+
+    it 'attaches the file with the correct content type' do
+      created_at_string = management_report.created_at.in_time_zone('London').strftime '%Y%m%d-%H%M'
+      start_date_string = start_date.strftime '%Y%m%d'
+      end_date_string = end_date.strftime '%Y%m%d'
+
+      expect(management_report.management_report_csv.filename.to_s).to eq "procurements_data_#{created_at_string}_#{start_date_string}-#{end_date_string}.csv"
+    end
+
+    it 'changes the management_report to completed' do
+      expect(management_report.completed?).to be true
+    end
+  end
+
+  describe 'generate_csv' do
+    let(:user_1) { create(:user, :with_detail) }
+    let(:user_2) { create(:user) }
+
+    let(:buyer_detail) { create(:buyer_detail, user: user_2, full_name: 'Obi-Wan Kenobi', job_title: 'Jedi', telephone_number: '0750050607', organisation_name: 'The Jedi Council', organisation_address_line_1: 'The Jedi Temple', organisation_address_line_2: nil, organisation_address_town: 'Coruscant', organisation_address_county: nil, organisation_address_postcode: 'SW1R 0TS', central_government: false) }
+
+    let(:procurement_1) { create(:facilities_management_rm6232_procurement_what_happens_next, user: user_1, created_at: Time.zone.now - 3.days, contract_name: 'Procurement 1') }
+    let(:procurement_2) { create(:facilities_management_rm6232_procurement_what_happens_next, user: user_2, created_at: Time.zone.now - 2.days, contract_name: 'Procurement 2', contract_number: 'RM6232-000002-2022') }
+    let(:procurement_3) { create(:facilities_management_rm6232_procurement_what_happens_next, user: user_1, created_at: Time.zone.now - 1.day, contract_name: 'Procurement 3', contract_number: 'RM6232-000003-2022', service_codes: %w[E.1 G.1 J.1], annual_contract_value: 50_000_000, lot_number: '1c') }
+    let(:procurement_4) { create(:facilities_management_rm6232_procurement_what_happens_next, user: user_2, created_at: Time.zone.now, contract_name: 'Procurement 4', contract_number: 'RM6232-000004-2022', region_codes: %w[UKN01], annual_contract_value: 5_000_000) }
+
+    let(:generated_csv) { CSV.parse(management_report.management_report_csv.download, headers: true) }
+
+    before do
+      buyer_detail
+      procurement_1
+      procurement_2
+      procurement_3
+      procurement_4
+      management_report_csv_generator.generate
+      management_report.reload
+    end
+
+    context 'when the dates are between 1 and 2 days ago' do
+      let(:start_date) { Time.zone.now - 2.days - 1.hour }
+      let(:end_date) { Time.zone.now - 1.day + 1.hour }
+
+      it 'has 2 rows with 2nd and 3rd procurement' do
+        expect(generated_csv.map { |row| row[1] }).to eq ['Procurement 3', 'Procurement 2']
+      end
+    end
+
+    context 'when the dates are between 1 and 3 days ago' do
+      let(:start_date) { Time.zone.now - 3.days - 1.hour }
+      let(:end_date) { Time.zone.now - 1.day + 1.hour }
+
+      it 'has 3 rows with 1st, 2nd and 3rd procurement' do
+        expect(generated_csv.map { |row| row[1] }).to eq ['Procurement 3', 'Procurement 2', 'Procurement 1']
+      end
+    end
+
+    context 'when the dates cover the range' do
+      let(:start_date) { Time.zone.now - 5.days }
+      let(:end_date) { Time.zone.now }
+
+      let(:generated_csv) { CSV.parse(management_report.management_report_csv.download) }
+
+      it 'has the correct headers' do
+        expect(generated_csv.first).to eq ['Reference number', 'Contract name', 'Date created', 'Buyer organisation', 'Buyer organisation address', 'Buyer sector', 'Buyer contact name', 'Buyer contact job title', 'Buyer contact email address', 'Buyer contact telephone number', 'Services', 'Regions', 'Annual contract cost', 'Lot', 'Shortlisted Suppliers']
+      end
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it 'has the correct data' do
+        expect(generated_csv[1][0..1] + generated_csv[1][3..]).to eq ['RM6232-000004-2022', 'Procurement 4', 'The Jedi Council', 'The Jedi Temple, Coruscant SW1R 0TS', 'Wider public sector', 'Obi-Wan Kenobi', 'Jedi', user_2.email, '="0750050607"', "E.1 Mechanical and Electrical Engineering Maintenance;\nE.2 Ventilation and air conditioning systems maintenance;\n", "UKN01 Belfast;\n", '5,000,000.00', '2a', "Conn, Hayes and Lakin;\nDach Inc;\nDonnelly, Wiegand and Krajcik;\nEmard, Green and Zboncak;\nFeest Group;\nHowell, Sanford and Shanahan;\nJenkins, Price and White;\nKirlin-Glover;\nMetz Inc;\nMoore Inc;\nSchulist-Wuckert;\nTorphy Inc;\nTremblay, Jacobi and Kozey;\nTurcotte and Sons;\nTurner-Pouros"]
+        expect(generated_csv[2][0..1] + generated_csv[2][3..]).to eq ['RM6232-000003-2022',  'Procurement 3',  'MyString', 'MyString, MyString, MyString, MyString SW1W 9SZ', 'Central government', 'MyString', 'MyString', user_1.email, '="07500404040"', "E.1 Mechanical and Electrical Engineering Maintenance;\nG.1 Hard Landscaping Services;\nJ.1 Mail Services;\n", "UKI4 Inner London - East;\nUKI5 Outer London - East and North East;\n", '50,000,000.00', '1c', "Berge-Koepp;\nBernier, Luettgen and Bednar;\nBins, Yost and Donnelly;\nBlick, O'Kon and Larkin;\nBreitenberg-Mante;\nCummerata, Lubowitz and Ebert;\nGoyette Group;\nHarris LLC;\nHeidenreich Inc;\nLind, Stehr and Dickinson;\nLowe, Abernathy and Toy;\nMiller, Walker and Leffler;\nMuller Inc;\nRohan-Windler;\nSatterfield LLC;\nSchmeler Inc;\nSchmeler-Leffler;\nSchultz-Wilkinson;\nTerry-Greenholt;\nYost LLC;\nZboncak and Sons"]
+        expect(generated_csv[3][0..1] + generated_csv[3][3..]).to eq ['RM6232-000002-2022',  'Procurement 2',  'The Jedi Council', 'The Jedi Temple, Coruscant SW1R 0TS',  'Wider public sector', 'Obi-Wan Kenobi', 'Jedi', user_2.email, '="0750050607"', "E.1 Mechanical and Electrical Engineering Maintenance;\nE.2 Ventilation and air conditioning systems maintenance;\n", "UKI4 Inner London - East;\nUKI5 Outer London - East and North East;\n", '12,345.00', '2a', "Abshire, Schumm and Farrell;\nBrakus, Lueilwitz and Blanda;\nConn, Hayes and Lakin;\nDach Inc;\nFeest Group;\nHarber LLC;\nHudson, Spinka and Schuppe;\nJenkins, Price and White;\nKirlin-Glover;\nMetz Inc;\nMoore Inc;\nO'Reilly, Emmerich and Reichert;\nRoob-Kessler;\nSchulist-Wuckert;\nSkiles LLC;\nTorphy Inc;\nTremblay, Jacobi and Kozey;\nTurner-Pouros"]
+        expect(generated_csv[4][0..1] + generated_csv[4][3..]).to eq ['RM6232-000001-2022',  'Procurement 1',  'MyString', 'MyString, MyString, MyString, MyString SW1W 9SZ', 'Central government', 'MyString', 'MyString', user_1.email, '="07500404040"', "E.1 Mechanical and Electrical Engineering Maintenance;\nE.2 Ventilation and air conditioning systems maintenance;\n", "UKI4 Inner London - East;\nUKI5 Outer London - East and North East;\n", '12,345.00', '2a', "Abshire, Schumm and Farrell;\nBrakus, Lueilwitz and Blanda;\nConn, Hayes and Lakin;\nDach Inc;\nFeest Group;\nHarber LLC;\nHudson, Spinka and Schuppe;\nJenkins, Price and White;\nKirlin-Glover;\nMetz Inc;\nMoore Inc;\nO'Reilly, Emmerich and Reichert;\nRoob-Kessler;\nSchulist-Wuckert;\nSkiles LLC;\nTorphy Inc;\nTremblay, Jacobi and Kozey;\nTurner-Pouros"]
+      end
+      # rubocop:enable RSpec/MultipleExpectations
+    end
+  end
+end

--- a/spec/services/facilities_management/rm6232/suppliers_selector_spec.rb
+++ b/spec/services/facilities_management/rm6232/suppliers_selector_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
-  subject(:suppliers_selector) { described_class.new(service_codes[..-3], region_codes[..2], annual_contract_value) }
+  subject(:suppliers_selector) { described_class.new(service_codes[..-3], region_codes[..2], annual_contract_value, known_lot_number) }
 
+  let(:known_lot_number) { nil }
   let(:lot_number) { suppliers_selector.lot_number }
   let(:supplier_names) { suppliers_selector.selected_suppliers.map(&:supplier_name) }
 
@@ -43,6 +44,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
             expect(supplier_names).not_to include my_supplier.supplier_name
           end
         end
+
+        context 'and known_lot_number is 1a' do
+          let(:known_lot_number) { '1a' }
+
+          it 'returns 1a for the lot number' do
+            expect(lot_number).to eq '1a'
+          end
+        end
       end
 
       context 'and the annual_contract_value is a more than 1,500,000 and less than 10,000,000' do
@@ -64,6 +73,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
             expect(supplier_names).not_to include my_supplier.supplier_name
           end
         end
+
+        context 'and known_lot_number is 1b' do
+          let(:known_lot_number) { '1b' }
+
+          it 'returns 1b for the lot number' do
+            expect(lot_number).to eq '1b'
+          end
+        end
       end
 
       context 'and the annual_contract_value is more than 10,000,000' do
@@ -83,6 +100,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
 
           it 'returns a list of suppliers that does not include my_supplier' do
             expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and known_lot_number is 1c' do
+          let(:known_lot_number) { '1c' }
+
+          it 'returns 1c for the lot number' do
+            expect(lot_number).to eq '1c'
           end
         end
       end
@@ -110,6 +135,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
             expect(supplier_names).not_to include my_supplier.supplier_name
           end
         end
+
+        context 'and known_lot_number is 1a' do
+          let(:known_lot_number) { '1a' }
+
+          it 'returns 1a for the lot number' do
+            expect(lot_number).to eq '1a'
+          end
+        end
       end
 
       context 'and the annual_contract_value is a more than 1,000,000 and less than 7,000,000' do
@@ -131,6 +164,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
             expect(supplier_names).not_to include my_supplier.supplier_name
           end
         end
+
+        context 'and known_lot_number is 1b' do
+          let(:known_lot_number) { '1b' }
+
+          it 'returns 1b for the lot number' do
+            expect(lot_number).to eq '1b'
+          end
+        end
       end
 
       context 'and the annual_contract_value is more than 7,000,000' do
@@ -150,6 +191,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
 
           it 'returns a list of suppliers that does not include my_supplier' do
             expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and known_lot_number is 1c' do
+          let(:known_lot_number) { '1c' }
+
+          it 'returns 1c for the lot number' do
+            expect(lot_number).to eq '1c'
           end
         end
       end


### PR DESCRIPTION
Ticket: [FMFR-1251](https://crowncommercialservice.atlassian.net/browse/FMFR-1251)

There is a requirement from the admin team that they are able to download a management report so they can see who is using the service.

In this commit, I have created the job and service in order to generate the report. This report is similar to the one in the previous framework.

I have added specs and feature tests to make sure everything is working as expected.