### PR TITLE
FMFR-1254 - Update RM6238 live at date

### DIFF
--- a/lib/tasks/facilities_management/frameworks.rake
+++ b/lib/tasks/facilities_management/frameworks.rake
@@ -3,8 +3,7 @@ module Frameworks
     if Rails.env.test?
       Time.zone.now - 1.day
     else
-      # This is not correct but it is far in the future and we can update it with another migration later on
-      Time.new(2025, 7, 17).in_time_zone('London')
+      Time.new(2022, 7, 14).in_time_zone('London')
     end
   end
 


### PR DESCRIPTION
Ticket: [FMR-1254](https://crowncommercialservice.atlassian.net/browse/FMFR-1254)

Make it so framework is live on the 14th of July 2022.
We are going to use load balancer rules in order to restrict access.

We will need to run the following task:


Environment variable | value
-- | --
`/Environment/ccs/cmp/RAKE_TASK_LIST` | `db:rm6232:fm_frameworks`
`/Environment/ccs/cmp/APP_RUN_RAKE_TASKS` | `TRUE`

