### PR TITLE
FMFR-1253 - Add new framework banner

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -377,5 +377,9 @@ module ApplicationHelper
       ]
     end
   end
+
+  def can_show_new_framework_banner?
+    Marketplace.rm6232_live? || params[:show_new_framework_banner].present?
+  end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/app/helpers/gov_uk_helper/notification_banner.rb
+++ b/app/helpers/gov_uk_helper/notification_banner.rb
@@ -1,13 +1,13 @@
 module GovUKHelper::NotificationBanner
   def govuk_notification_banner(type, heading, &block)
-    tag.div(class: "govuk-notification-banner #{BANNER_TYPE[type][:class]}", role: 'alert', aria: { labelledby: 'govuk-notification-banner-title' }, data: { module: 'govuk-notification-banner' }) do
+    tag.div(class: "govuk-notification-banner #{BANNER_TYPE[type][:class]}", role: 'region', aria: { labelledby: 'govuk-notification-banner-title' }, data: { module: 'govuk-notification-banner' }) do
       capture do
         concat(tag.div(class: 'govuk-notification-banner__header') do
           tag.h2(BANNER_TYPE[type][:text], class: 'govuk-notification-banner__title', id: 'govuk-notification-banner-title')
         end)
         concat(tag.div(class: 'govuk-notification-banner__content') do
           capture do
-            concat(tag.h3(heading, class: 'govuk-notification-banner__heading'))
+            concat(tag.p(heading, class: 'govuk-notification-banner__heading'))
             concat(tag.p(class: 'govuk-body', &block)) if block_given?
           end
         end)

--- a/app/views/crown_marketplace/allow_list/index.html.erb
+++ b/app/views/crown_marketplace/allow_list/index.html.erb
@@ -2,6 +2,7 @@
 
 <%= govuk_notification_banner(:success, t('.added')) { t('.was_added', email_domain: params[:email_domain_added]) } unless params[:email_domain_added].blank? %>
 <%= govuk_notification_banner(:success, t('.removed')) { t('.was_removed', email_domain: params[:email_domain_removed]) } unless params[:email_domain_removed].blank? %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.heading_title') %></h1>

--- a/app/views/facilities_management/rm3830/_new_framework_banner.html.erb
+++ b/app/views/facilities_management/rm3830/_new_framework_banner.html.erb
@@ -1,0 +1,7 @@
+<% if can_show_new_framework_banner? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= govuk_notification_banner(:neutral, t('.new_fm_framework_html', new_framework_link: link_to(t('.new_agreement'), facilities_management_rm6232_path, class: 'govuk-notification-banner__link'))) %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/facilities_management/rm3830/buyer_account/index.html.erb
+++ b/app/views/facilities_management/rm3830/buyer_account/index.html.erb
@@ -1,4 +1,7 @@
 <% content_for :page_title, t('.buyer_account_dashboard') %>
+
+<%= render partial: 'facilities_management/rm3830/new_framework_banner' %>
+
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/facilities_management/rm3830/home/index.html.erb
+++ b/app/views/facilities_management/rm3830/home/index.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_title, t('.heading') %>
 
+<%= render partial: 'facilities_management/rm3830/new_framework_banner' %>
+
 <div class="govuk-body">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/facilities_management/rm3830/sessions/new.html.erb
+++ b/app/views/facilities_management/rm3830/sessions/new.html.erb
@@ -1,1 +1,3 @@
+<%= render partial: 'facilities_management/rm3830/new_framework_banner' %>
+
 <%= render partial: 'shared/sessions/new', locals: { local_header_text: t('.sign_in_header'), local_new_user_session_path: facilities_management_rm3830_new_user_session_path, local_email_hint_text: t('.email_hint_html'), registration_path: facilities_management_rm3830_new_user_registration_path, local_new_user_password_path: facilities_management_rm3830_new_user_password_path } %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -160,4 +160,8 @@ module Marketplace
   def self.can_edit_facilities_management_frameworks?
     @can_edit_facilities_management_frameworks ||= rails_env_url != 'https://marketplace.service.crowncommercial.gov.uk'
   end
+
+  def self.rm6232_live?
+    @rm6232_live ||= Time.now.in_time_zone('London') >= Time.new(2022, 7, 18, 11).in_time_zone('London')
+  end
 end

--- a/config/locales/views/facilities_management.rm3830.en.yml
+++ b/config/locales/views/facilities_management.rm3830.en.yml
@@ -664,6 +664,9 @@ en:
           learn_more: Further details (opens in a new tab)
           question: Select the facilities management services that you need
           return_text: Return to your account
+      new_framework_banner:
+        new_agreement: new agreement for Facilities Management and Workplace Services
+        new_fm_framework_html: There is a %{new_framework_link}. Before continuing with this tool please contact CCS.
       procurement_buildings:
         show:
           answer_question: Answer question

--- a/features/facilities_management/rm6232/quick_view/service_specification.feature
+++ b/features/facilities_management/rm6232/quick_view/service_specification.feature
@@ -15,4 +15,4 @@ Feature: Service specification
       | Mechanical and Electrical Engineering Maintenance | Work Package E - Maintenance Services                         | E1 - Mechanical and Electrical Engineering Maintenance  | are     |
       | Outside catering                                  | Work Package H - Catering Services                            | H7 - Outside Catering                                   | are     |
       | Sports and leisure                                | Work Package N - Miscellaneous FM Services                    | N2 - Sports and Leisure                                 | are not |
-      | CAFM system                                       | Work Package Q - Computer-aided facilities management (CAFM)  | Q3 – CAFM Services                                      | are not |
+      | CAFM system                                       | Work Package Q - Computer-aided facilities management (CAFM)  | Services Q1/Q2 – CAFM Services                          | are not |

--- a/features/step_definitions/facilities_management/rm3830/procurement_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/procurement_steps.rb
@@ -90,5 +90,5 @@ end
 
 Then('my procurement {string} has successfully been deleted') do |contract_name|
   expect(procurement_page.find('.govuk-notification-banner__heading')).to have_content('Your item was deleted')
-  expect(procurement_page.find('.govuk-notification-banner__content > p')).to have_content("'#{contract_name}' was deleted")
+  expect(procurement_page.find('.govuk-notification-banner__content > p.govuk-body')).to have_content("'#{contract_name}' was deleted")
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -149,4 +149,46 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe '.can_show_new_framework_banner?' do
+    before { allow(Marketplace).to receive(:rm6232_live?).and_return(rm6232_live) }
+
+    let(:results) { helper.can_show_new_framework_banner? }
+
+    context 'when rm6232 is live' do
+      let(:rm6232_live) { true }
+
+      context 'and the param show_new_framework_banner is present' do
+        before { helper.params[:show_new_framework_banner] = 'true' }
+
+        it 'returns true' do
+          expect(results).to be true
+        end
+      end
+
+      context 'and the param show_new_framework_banner is not present' do
+        it 'returns true' do
+          expect(results).to be true
+        end
+      end
+    end
+
+    context 'when rm6232 is not live' do
+      let(:rm6232_live) { false }
+
+      context 'and the param show_new_framework_banner is present' do
+        before { helper.params[:show_new_framework_banner] = 'true' }
+
+        it 'returns true' do
+          expect(results).to be true
+        end
+      end
+
+      context 'and the param show_new_framework_banner is not present' do
+        it 'returns false' do
+          expect(results).to be false
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: [FMFR-1253](https://crowncommercialservice.atlassian.net/browse/FMFR-1253)

Add banner for when the new framework goes live.

You can view the banner by adding `?show_new_framework_banner=true` to the URL.