### PR TITLE
FMFR-1271 - Allow special access to change framework dates

### DIFF
--- a/app/controllers/active_storage/blobs_controller.rb
+++ b/app/controllers/active_storage/blobs_controller.rb
@@ -23,7 +23,7 @@ class ActiveStorage::BlobsController < ActiveStorage::BaseController
 
     raise ActionController::RoutingError, 'not found' if object.blank?
 
-    authorize! :view, object if object.present?
+    authorize! :read, object if object.present?
   end
 
   KEY_TO_MODEL = {

--- a/app/controllers/facilities_management/admin/frameworks_controller.rb
+++ b/app/controllers/facilities_management/admin/frameworks_controller.rb
@@ -32,6 +32,12 @@ module FacilitiesManagement
                 :live_at_yyyy,
               )
       end
+
+      protected
+
+      def authorize_user
+        authorize! :manage, FacilitiesManagement::Framework
+      end
     end
   end
 end

--- a/app/controllers/facilities_management/admin/uploads_controller.rb
+++ b/app/controllers/facilities_management/admin/uploads_controller.rb
@@ -37,10 +37,6 @@ module FacilitiesManagement
         @upload = service::Upload.find(params[:id] || params[:upload_id])
       end
 
-      def authorize_user
-        authorize! :manage, service::Upload
-      end
-
       def service
         @service ||= self.class.module_parent
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -31,10 +31,10 @@ class Ability
 
     can :read, :all
     can :manage, FacilitiesManagement::Admin
-    can :manage, FacilitiesManagement::RM3830::Admin::ManagementReport
-    can :manage, FacilitiesManagement::RM6232::Admin::ManagementReport
-    can :manage, FacilitiesManagement::RM3830::Admin::Upload
-    can :manage, FacilitiesManagement::RM6232::Admin::Upload
+
+    return unless user.has_role?(:ccs_developer)
+
+    can :manage, FacilitiesManagement::Framework
   end
 
   def fm_supplier_specific_auth(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,7 +72,7 @@ class User < ApplicationRecord
 
   # declare the valid roles -- do not change the order if you add more
   # roles later, always append them at the end!
-  roles :buyer, :supplier, :ccs_employee, :ccs_admin, :st_access, :fm_access, :ls_access, :mc_access, :allow_list_access
+  roles :buyer, :supplier, :ccs_employee, :ccs_admin, :st_access, :fm_access, :ls_access, :mc_access, :allow_list_access, :ccs_developer
 
   attr_accessor :password, :password_confirmation
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,7 +104,7 @@ Rails.application.routes.draw do
 
     namespace :admin, path: 'admin', defaults: { service: 'facilities_management/admin' } do
       concerns :framework
-      resources :frameworks, only: %i[index edit update] if Marketplace.can_edit_facilities_management_frameworks?
+      resources :frameworks, only: %i[index edit update]
     end
 
     resources :admin_supplier_details, path: '/:framework/admin/supplier-details', only: %i[show edit update], defaults: { service: 'facilities_management/admin' }, controller: 'admin/supplier_details'

--- a/spec/controllers/facilities_management/admin/frameworks_controller_spec.rb
+++ b/spec/controllers/facilities_management/admin/frameworks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe FacilitiesManagement::Admin::FrameworksController do
   let(:default_params) { { service: 'facilities_management/admin' } }
 
-  login_fm_admin
+  login_ccs_developer
 
   describe 'GET index' do
     it 'renders the index page' do
@@ -22,6 +22,15 @@ RSpec.describe FacilitiesManagement::Admin::FrameworksController do
 
     context 'when logged in as a supplier' do
       login_fm_supplier
+
+      it 'redirects to not permitted' do
+        get :index
+        expect(response).to redirect_to '/facilities-management/RM6232/admin/not-permitted'
+      end
+    end
+
+    context 'when logged in as a normal amdin' do
+      login_fm_admin
 
       it 'redirects to not permitted' do
         get :index

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -57,4 +57,12 @@ module ControllerMacros
       sign_in user
     end
   end
+
+  def login_ccs_developer
+    before do
+      @request.env['devise.mapping'] = Devise.mappings[:user]
+      user = FactoryBot.create(:user, confirmed_at: Time.zone.now, roles: %i[fm_access ccs_employee ccs_developer])
+      sign_in user
+    end
+  end
 end


### PR DESCRIPTION
Ticket: [FMR-1271](https://crowncommercialservice.atlassian.net/browse/FMFR-1271)

To make it easier to change the framework dates in production, i.e. without the need for a deployment, I have added the new role `ccs_developer` which gives limited access to change the framework dates.