### PR TITLE
FMFR-1269 - Allow supplier to suspended on a lot by lot basis

### DIFF
--- a/app/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller.rb
@@ -33,6 +33,7 @@ module FacilitiesManagement
           @lot_data = @supplier.lot_data.order('REVERSE(lot_code)').map do |lot_data|
             {
               id: lot_data.id,
+              current_status: lot_data.current_status,
               lot_code: lot_data.lot_code,
               service_names: lot_data.services.map(&:name),
               region_names: lot_data.regions.map(&:name)
@@ -72,6 +73,7 @@ module FacilitiesManagement
         def lot_data_params
           if params[:facilities_management_rm6232_supplier_lot_data]
             params.require(:facilities_management_rm6232_supplier_lot_data).permit(
+              :active,
               service_codes: [],
               region_codes: [],
             )
@@ -80,7 +82,7 @@ module FacilitiesManagement
           end
         end
 
-        RECOGNISED_LOT_DATA_TYPES = %w[service_codes region_codes].freeze
+        RECOGNISED_LOT_DATA_TYPES = %w[lot_status service_codes region_codes].freeze
         LOT_NUMBER_TO_QUERY_PARAMS = {
           '1' => { total: true },
           '2' => { hard: true },

--- a/app/models/facilities_management/rm6232/supplier.rb
+++ b/app/models/facilities_management/rm6232/supplier.rb
@@ -6,6 +6,7 @@ module FacilitiesManagement
       def self.select_suppliers(lot_code, service_codes, region_codes)
         where(active: true)
           .joins(:lot_data)
+          .where('facilities_management_rm6232_supplier_lot_data.active': true)
           .where('facilities_management_rm6232_supplier_lot_data.lot_code': lot_code)
           .where('facilities_management_rm6232_supplier_lot_data.service_codes @> ?', "{#{service_codes.join(',')}}")
           .where('facilities_management_rm6232_supplier_lot_data.region_codes @> ?', "{#{region_codes.join(',')}}")

--- a/app/models/facilities_management/rm6232/supplier/lot_data.rb
+++ b/app/models/facilities_management/rm6232/supplier/lot_data.rb
@@ -6,6 +6,7 @@ module FacilitiesManagement
       delegate :supplier_name, to: :supplier
 
       validates :region_codes, length: { minimum: 1 }, on: :region_codes
+      validates :active, inclusion: { in: [true, false] }, on: :lot_status
 
       def services
         Service.where(code: service_codes)
@@ -15,10 +16,21 @@ module FacilitiesManagement
         Region.where(code: region_codes)
       end
 
+      def current_status
+        if active
+          [:blue, 'ACTIVE']
+        else
+          [:red, 'INACTIVE']
+        end
+      end
+
       def changed_data
         model_changes = saved_changes.except(:updated_at).first
         data_before = model_changes.last.first
         data_after = model_changes.last.last
+
+        added = data_after.is_a?(Array) ? data_after - data_before : data_after
+        removed = data_before.is_a?(Array) ? data_before - data_after : data_before
 
         [
           supplier.id,
@@ -26,8 +38,8 @@ module FacilitiesManagement
           {
             attribute: model_changes.first,
             lot_code: lot_code,
-            added: data_after - data_before,
-            removed: data_before - data_after
+            added: added,
+            removed: removed
           }
         ]
       end

--- a/app/services/facilities_management/rm6232/admin/change_logs_csv_generator.rb
+++ b/app/services/facilities_management/rm6232/admin/change_logs_csv_generator.rb
@@ -13,7 +13,8 @@ module FacilitiesManagement::RM6232
       CHANGE_TYPE_TO_TEXT = {
         'details' => 'Details',
         'service_codes' => 'Services',
-        'region_codes' => 'Regions'
+        'region_codes' => 'Regions',
+        'active' => 'Lot status'
       }.freeze
 
       ATTRIBUTE_TO_LABEL = {
@@ -80,8 +81,14 @@ module FacilitiesManagement::RM6232
       def self.change_info_list_lot_data(edit)
         change_info_list = ["Lot code: #{edit.data['lot_code']}"]
 
-        change_info_list << "Added items: #{item_names(edit.data['attribute'], edit.data['added'])}" if edit.data['added'].any?
-        change_info_list << "Removed items: #{item_names(edit.data['attribute'], edit.data['removed'])}" if edit.data['removed'].any?
+        if edit.data['attribute'] == 'active'
+          old_value = get_attribute_value('active', edit.data['removed'])
+          new_value = get_attribute_value('active', edit.data['added'])
+
+          change_info_list << "Lot status - FROM: #{old_value} TO: #{new_value}"
+        else
+          ['added', 'removed'].each { |change| change_info_list << "#{change.capitalize} items: #{item_names(edit.data['attribute'], edit.data[change])}" if edit.data[change].any? }
+        end
 
         change_info_list
       end

--- a/app/services/facilities_management/rm6232/admin/supplier_data_snapshot_generator.rb
+++ b/app/services/facilities_management/rm6232/admin/supplier_data_snapshot_generator.rb
@@ -35,8 +35,12 @@ module FacilitiesManagement::RM6232
       def update_lot_data(edit, supplier)
         supplier_lot_data = supplier['lot_data'].find { |lot_data| lot_data['lot_code'] == edit.data['lot_code'] }
 
-        edit.data['removed'].each { |code| supplier_lot_data[edit.data['attribute']].delete(code) }
-        edit.data['added'].each { |code| supplier_lot_data[edit.data['attribute']] << code }
+        lot_data_changes(edit, supplier_lot_data, 'removed', :delete)
+        lot_data_changes(edit, supplier_lot_data, 'added', :push)
+      end
+
+      def lot_data_changes(edit, supplier_lot_data, key, method)
+        edit.data[key].is_a?(Array) ? edit.data[key].each { |code| supplier_lot_data[edit.data['attribute']].send(method, code) } : supplier_lot_data[edit.data['attribute']] = edit.data[key]
       end
 
       def update_details(edit, supplier)

--- a/app/views/facilities_management/rm6232/admin/change_logs/_lot_data.html.erb
+++ b/app/views/facilities_management/rm6232/admin/change_logs/_lot_data.html.erb
@@ -1,35 +1,59 @@
 <%= render partial: 'change_log_details' %>
 
-<% if @change_log.data['added'].any? %>
-  <hr class="govuk-section-break govuk-!-margin-3">
-
+<% if @change_log.data['attribute'] == 'active' %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m">
-        <%= t(".items_added.#{@change_log.data['attribute']}") %>
-      </h2>
-      <ul id="added-items" class="govuk-list govuk-list--bullet">
-        <% item_names(@change_log.data['added']).each do |item_name| %>
-          <li><%= item_name %></li>
-        <% end %>
-      </ul>
+    <div class="govuk-grid-column-three-quarters">
+
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header"><%= t('.attribute') %></th>
+            <th scope="col" class="govuk-table__header"><%= t('.prev_value') %></th>
+            <th scope="col" class="govuk-table__header"><%= t('.new_value') %></th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= t('.lot_status') %></th>
+            <td class="govuk-table__cell"><%= get_attribute_value(@change_log.data['attribute'], @change_log.data['removed']) %></td>
+            <td class="govuk-table__cell"><%= get_attribute_value(@change_log.data['attribute'], @change_log.data['added']) %></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
-<% end %>
+<% else %>
+  <% if @change_log.data['added'].any? %>
+    <hr class="govuk-section-break govuk-!-margin-3">
 
-<% if @change_log.data['removed'].any? %>
-  <hr class="govuk-section-break govuk-!-margin-3">
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m">
-        <%= t(".items_removed.#{@change_log.data['attribute']}") %>
-      </h2>
-      <ul id="removed-items" class="govuk-list govuk-list--bullet">
-        <% item_names(@change_log.data['removed']).each do |item_name| %>
-          <li><%= item_name %></li>
-        <% end %>
-      </ul>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">
+          <%= t(".items_added.#{@change_log.data['attribute']}") %>
+        </h2>
+        <ul id="added-items" class="govuk-list govuk-list--bullet">
+          <% item_names(@change_log.data['added']).each do |item_name| %>
+            <li><%= item_name %></li>
+          <% end %>
+        </ul>
+      </div>
     </div>
-  </div>
+  <% end %>
+
+  <% if @change_log.data['removed'].any? %>
+    <hr class="govuk-section-break govuk-!-margin-3">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">
+          <%= t(".items_removed.#{@change_log.data['attribute']}") %>
+        </h2>
+        <ul id="removed-items" class="govuk-list govuk-list--bullet">
+          <% item_names(@change_log.data['removed']).each do |item_name| %>
+            <li><%= item_name %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/facilities_management/rm6232/admin/supplier_lot_data/_lot_status.html.erb
+++ b/app/views/facilities_management/rm6232/admin/supplier_lot_data/_lot_status.html.erb
@@ -1,0 +1,24 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_group_with_error(f.object, :active) do |displayed_error, any_errors| %>
+      <%= f.hidden_field :active %>
+      <%= f.label(:active, t('.supplier_status_question'), class: 'govuk-heading-m govuk-!-margin-bottom-0 govuk-!-padding-left-0') %>
+      <p class="govuk-body govuk-!-margin-top-4"><%= t('.status_hint') %></p>
+      <%= displayed_error %>
+      <div class="govuk-radios govuk-radios--inline">
+        <div class="govuk-radios__item">
+          <%= f.radio_button :active, true, class: 'govuk-radios__input', required: true %>
+          <%= f.label :active, value: true, class: 'govuk-label govuk-radios__label' do %>
+            <%= govuk_tag_with_text(:blue, t('.active')) %>
+          <% end %>
+        </div>
+        <div class="govuk-radios__item">
+          <%= f.radio_button :active, false, class: 'govuk-radios__input', required: true %>
+          <%= f.label :active, value: false , class: 'govuk-label govuk-radios__label' do %>
+            <%= govuk_tag_with_text(:red, t('.inactive')) %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/facilities_management/rm6232/admin/supplier_lot_data/edit.html.erb
+++ b/app/views/facilities_management/rm6232/admin/supplier_lot_data/edit.html.erb
@@ -15,9 +15,11 @@
     <h1 class="govuk-heading-xl">
       <%= t(".heading.#{@lot_data_type}", lot_code: @lot_code) %>
     </h1>
-    <p class="govuk-hint">
-      <%= t(".the_check_boxes.#{@lot_data_type}") %>
-    </p>
+    <% unless @lot_data_type == 'lot_status' %>
+      <p class="govuk-hint">
+        <%= t(".the_check_boxes.#{@lot_data_type}") %>
+      </p>
+    <% end %>
   </div>
 </div>
 <div class="govuk-grid-row">

--- a/app/views/facilities_management/rm6232/admin/supplier_lot_data/show.html.erb
+++ b/app/views/facilities_management/rm6232/admin/supplier_lot_data/show.html.erb
@@ -28,6 +28,19 @@
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
+            <%= t('.status') %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= govuk_tag_with_text(*lot_data[:current_status]) %>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <%= link_to facilities_management_rm6232_admin_supplier_lot_datum_edit_path(supplier_lot_datum_id: lot_data[:id], lot_data_type: 'lot_status'), class: 'govuk-link--no-visited-state' do %>
+              <%= t('.change') %> <span class="govuk-visually-hidden"><%= t('.lot_status', lot_code: lot_data[:lot_code]) %></span>
+            <% end %>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
             <%= t('.services') %>
           </dt>
           <dd class="govuk-summary-list__value">

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -187,6 +187,8 @@ en:
               too_short: You must select at least one service for this building
         facilities_management/rm6232/supplier/lot_data:
           attributes:
+            active:
+              inclusion: You must select a status for the lot data
             region_codes:
               too_short: You must select at least one region for this lot
   facilities_management:
@@ -217,6 +219,7 @@ en:
             change: Change
             change_log_item: Log item
             change_made:
+              active: Lot status
               details: Details
               region_codes: Regions
               service_codes: Services
@@ -230,14 +233,19 @@ en:
             you_can_download: You can download a CSV file of the full logs by clicking on 'Download full change logs'
             you_can_get_a_snapshot_html: You can get a snapshot of the supplier data at any point in time by going to the '%{snapshot_link}' section.
           lot_data:
+            attribute: Attribute
             items_added:
               region_codes: 'The following regions were added to the supplier:'
               service_codes: 'The following services were added to the supplier:'
             items_removed:
               region_codes: 'The following regions were removed from the supplier:'
               service_codes: 'The following services were removed from the supplier:'
+            lot_status: Lot status
+            new_value: New value
+            prev_value: Previous value
           show:
             heading:
+              active: Changes to supplier lot data status
               details: Changes to supplier details
               region_codes: Changes to supplier regions
               service_codes: Changes to supplier services
@@ -287,22 +295,30 @@ en:
         supplier_lot_data:
           edit:
             heading:
+              lot_status: Lot %{lot_code} status
               region_codes: Lot %{lot_code} regions
               service_codes: Lot %{lot_code} services
             save_and_return: Save and return
             the_check_boxes:
               region_codes: The check boxes in the first column indicate what regions the supplier can provide their services in.
               service_codes: The check boxes in the first column indicate what services the supplier can provide. This is in addition to the core services which are greyed out.
+          lot_status:
+            active: Active
+            inactive: Inactive
+            status_hint: To prevent the supplier from appearing in search results for this lot, change the supplier status to 'INACTIVE'
+            supplier_status_question: What is the status of this lot?
           show:
             change: Change
             heading: View lot data
             lot_code: 'Lot code: %{lot_code}'
             lot_regions: lot %{lot_code} regions
             lot_services: lot %{lot_code} services
+            lot_status: lot %{lot_code} status
             regions: Regions
             services: Services
             show_regions: Show regions
             show_services: Show services
+            status: Lot status
             you_can_edit: You can edit the lot data for a supplier by clicking on change.
         uploads:
           failed:

--- a/db/migrate/20220815090054_add_status_to_supplier_lot_data.rb
+++ b/db/migrate/20220815090054_add_status_to_supplier_lot_data.rb
@@ -1,0 +1,5 @@
+class AddStatusToSupplierLotData < ActiveRecord::Migration[6.0]
+  def change
+    add_column :facilities_management_rm6232_supplier_lot_data, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_05_112131) do
+ActiveRecord::Schema.define(version: 2022_08_15_090054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -478,6 +478,7 @@ ActiveRecord::Schema.define(version: 2022_07_05_112131) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "region_codes", default: [], array: true
+    t.boolean "active", default: true
     t.index ["facilities_management_rm6232_supplier_id"], name: "index_fm_rm6232_supplier_lot_data_on_fm_rm6232_supplier_id"
     t.index ["lot_code"], name: "index_fm_rm6232_supplier_lot_data_on_lot_number"
   end

--- a/features/facilities_management/rm6232/admin/change_logs/changes_to_lot_status.feature
+++ b/features/facilities_management/rm6232/admin/change_logs/changes_to_lot_status.feature
@@ -1,0 +1,59 @@
+@pipeline
+Feature: Change log for supplier lot status
+
+  Scenario: Changes to the supplier services are logged
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    Then I click on 'View lot data' for 'Schmeler Inc'
+    And I change the 'lot status' for lot '1c'
+    Then I am on the 'Lot 1c status' page
+    And I select 'INACTIVE' for the lot status
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I change the 'lot status' for lot '3c'
+    Then I am on the 'Lot 3c status' page
+    And I select 'INACTIVE' for the lot status
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I change the 'lot status' for lot '1c'
+    Then I am on the 'Lot 1c status' page
+    And I select 'ACTIVE' for the lot status
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And I click on 'Home'
+    Then I am on the 'RM6232 administration dashboard' page
+    And I click on 'Supplier data change log'
+    Then I am on the 'Supplier data change log' page
+    And I should see 4 logs
+    And log number 1 has the user 'me'
+    And log number 1 has the change type 'Lot status'
+    And log number 2 has the user 'me'
+    And log number 1 has the change type 'Lot status'
+    And log number 3 has the user 'me'
+    And log number 1 has the change type 'Lot status'
+    And I click on log number 3
+    Then I am on the 'Changes to supplier lot data status' page
+    And the supplier who was changed is 'Schmeler Inc'
+    And the change was made by 'me'
+    And the change was made in lot '1c'
+    And I should see the following changes to the lot status:
+      | ACTIVE  | INACTIVE  |
+    Then I click on 'Supplier data change log'
+    And I am on the 'Supplier data change log' page
+    And I click on log number 2
+    Then I am on the 'Changes to supplier lot data status' page
+    And the supplier who was changed is 'Schmeler Inc'
+    And the change was made by 'me'
+    And the change was made in lot '3c'
+    And I should see the following changes to the lot status:
+      | ACTIVE  | INACTIVE  |
+    Then I click on 'Supplier data change log'
+    And I am on the 'Supplier data change log' page
+    And I click on log number 1
+    Then I am on the 'Changes to supplier lot data status' page
+    And the supplier who was changed is 'Schmeler Inc'
+    And the change was made by 'me'
+    And the change was made in lot '1c'
+    And I should see the following changes to the lot status:
+      | INACTIVE  | ACTIVE  |

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/lot_status.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/lot_status.feature
@@ -1,0 +1,54 @@
+Feature: Changing the lot status
+
+  Background: I navigate to the supplier data page
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+
+  Scenario Outline: I can got to all lots and change the status
+    Then I click on 'View lot data' for '<supplier_name>'
+    And I am on the 'View lot data' page
+    And I change the 'lot status' for lot '<lot>'
+    Then I am on the 'Lot <lot> status' page
+    And the supplier name shown is '<supplier_name>'
+
+    Examples:
+      | supplier_name                 | lot |
+      | Donnelly, Wiegand and Krajcik | 1b  |
+      | Schulist-Wuckert              | 2a  |
+      | Zboncak and Sons              | 3c  |
+
+  @pipline
+  Scenario Outline: I change the status and it changes on View lot data
+    Then I click on 'View lot data' for '<supplier_name>'
+    And I am on the 'View lot data' page
+    And the status is 'ACTIVE' for lot '<lot>'
+    And I change the 'lot status' for lot '<lot>'
+    Then I am on the 'Lot <lot> status' page
+    And the supplier name shown is '<supplier_name>'
+    And I select 'INACTIVE' for the lot status
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    And the status is 'INACTIVE' for lot '<lot>'
+
+    Examples:
+      | supplier_name                 | lot |
+      | Donnelly, Wiegand and Krajcik | 1b  |
+      | Schulist-Wuckert              | 2a  |
+      | Zboncak and Sons              | 3c  |
+
+  @pipline
+  Scenario Outline: Breadcrumb links work from lot status
+    Then I click on 'View lot data' for 'Yost LLC'
+    And I am on the 'View lot data' page
+    And I change the 'lot status' for lot '1c'
+    Then I am on the 'Lot 1c status' page
+    And the supplier name shown is 'Yost LLC'
+    And I click on '<link_text>'
+    Then I am on the '<page_title>' page
+
+    Examples:
+      | link_text     | page_title                      |
+      | Home          | RM6232 administration dashboard |
+      | Supplier data | Supplier data                   |
+      | View lot data | View lot data                   |

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/quick_view/lot_status_selection.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/quick_view/lot_status_selection.feature
@@ -1,0 +1,93 @@
+Feature: Changing the lot status for suppliers on the admin tool and seeing the effect on the results
+
+  Background: Sign in and navigate to the admin dashboard
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+
+  Scenario Outline: Total services - lot status
+    Given I go to a quick view with the following services, regions and annual contract cost:
+      | F.1  | UKH1  | <contract_value>  |
+      | K.1  | UKH2  |                   |
+    Then I should be in sub-lot '<lot_number>'
+    And I 'should' see the supplier "<supplier_name>" in the results
+    Given I go to the admin dashboard for 'RM6232'
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    And I click on 'View lot data' for '<supplier_name>'
+    Then I am on the 'View lot data' page
+    And I change the 'lot status' for lot '<lot_number>'
+    Then I am on the 'Lot <lot_number> status' page
+    And the supplier name shown is '<supplier_name>'
+    And I select 'INACTIVE' for the lot status
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    Given I go to a quick view with the following services, regions and annual contract cost:
+      | F.1  | UKH1  | <contract_value>  |
+      | K.1  | UKH2  |                   |
+    Then I should be in sub-lot '<lot_number>'
+    And I 'should not' see the supplier "<supplier_name>" in the results
+
+    Examples:
+      | contract_value  | lot_number  | supplier_name                 |
+      | 500000          | 1a          | Sawayn, Abbott and Huels      |
+      | 2000000         | 1b          | Zboncak and Sons              |
+      | 11000000        | 1c          | Cummerata, Lubowitz and Ebert |
+
+
+  @pipeline
+  Scenario Outline: Hard services - lot status
+    Given I go to a quick view with the following services, regions and annual contract cost:
+      | F.2  | UKL18  | <contract_value>  |
+      | N.10 | UKL24  |                   |
+    Then I should be in sub-lot '<lot_number>'
+    And I 'should' see the supplier "<supplier_name>" in the results
+    Given I go to the admin dashboard for 'RM6232'
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    And I click on 'View lot data' for '<supplier_name>'
+    Then I am on the 'View lot data' page
+    And I change the 'lot status' for lot '<lot_number>'
+    Then I am on the 'Lot <lot_number> status' page
+    And the supplier name shown is '<supplier_name>'
+    And I select 'INACTIVE' for the lot status
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    Given I go to a quick view with the following services, regions and annual contract cost:
+      | F.2  | UKL18  | <contract_value>  |
+      | N.10 | UKL24  |                   |
+    Then I should be in sub-lot '<lot_number>'
+    And I 'should not' see the supplier "<supplier_name>" in the results
+
+    Examples:
+      | contract_value  | lot_number  | supplier_name             |
+      | 500000          | 2a          | Harber LLC                |
+      | 2000000         | 2b          | Lind, Stehr and Dickinson |
+      | 11000000        | 2c          | Breitenberg-Mante         |
+
+  Scenario Outline: Soft services - lot status
+    Given I go to a quick view with the following services, regions and annual contract cost:
+      | H.1  | UKH3  | <contract_value>  |
+      | I.5  | UKK4  |                   |
+    Then I should be in sub-lot '<lot_number>'
+    And I 'should' see the supplier "<supplier_name>" in the results
+    Given I go to the admin dashboard for 'RM6232'
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    And I click on 'View lot data' for "<supplier_name>"
+    Then I am on the 'View lot data' page
+    And I change the 'lot status' for lot '<lot_number>'
+    Then I am on the 'Lot <lot_number> status' page
+    And the supplier name shown is "<supplier_name>"
+    And I select 'INACTIVE' for the lot status
+    And I click on 'Save and return'
+    And I am on the 'View lot data' page
+    Given I go to a quick view with the following services, regions and annual contract cost:
+      | H.1  | UKH3  | <contract_value>  |
+      | I.5  | UKK4  |                   |
+    Then I should be in sub-lot '<lot_number>'
+    And I 'should not' see the supplier "<supplier_name>" in the results
+
+    Examples:
+      | contract_value  | lot_number  | supplier_name                   |
+      | 500000          | 3a          | O'Reilly, Emmerich and Reichert |
+      | 2000000         | 3b          | Howell, Sanford and Shanahan    |
+      | 11000000        | 3c          | Muller Inc                      |

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/region_codes.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/region_codes.feature
@@ -13,10 +13,10 @@ Feature: Selecting region codes
     And the supplier name shown is '<supplier_name>'
 
     Examples:
-      | supplier_name               | lot | title         |
-      | Abshire, Schumm and Farrell | 1a   | Lot 1a regions |
-      | Terry-Greenholt             | 2b   | Lot 2b regions |
-      | Schultz-Wilkinson           | 3c   | Lot 3c regions |
+      | supplier_name               | lot | title           |
+      | Abshire, Schumm and Farrell | 1a  | Lot 1a regions  |
+      | Terry-Greenholt             | 2b  | Lot 2b regions  |
+      | Schultz-Wilkinson           | 3c  | Lot 3c regions  |
 
   @pipline
   Scenario: I change the regions and it changes on View lot data - lot 1a

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/validations/lot_status_validations.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_lot_data/validations/lot_status_validations.feature
@@ -1,0 +1,16 @@
+@pipline
+Feature: Changing the lot status validations
+
+  Scenario: Validate supplier status
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I have an inactive supplier called 'Colony Iota INC.'
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    Then I click on 'View lot data' for 'Colony Iota INC.'
+    And I am on the 'View lot data' page
+    And the supplier name shown is 'Colony Iota INC.'
+    And I change the 'lot status' for lot '1a'
+    Then I am on the 'Lot 1a status' page
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | You must select a status for the lot data |

--- a/features/support/pages/rm6232/admin.rb
+++ b/features/support/pages/rm6232/admin.rb
@@ -2,11 +2,15 @@ require_relative '../admin'
 
 module Pages::RM6232
   class LotData < SitePrism::Section
-    section :services, 'dl > div:nth-child(1)' do
+    section :'lot status', 'dl > div:nth-child(1)' do
+      element :status, 'dd.govuk-summary-list__value'
+      element :change_link, 'dd.govuk-summary-list__actions > a'
+    end
+    section :services, 'dl > div:nth-child(2)' do
       elements :names, 'details > div > ul > li'
       element :change_link, 'dd.govuk-summary-list__actions > a'
     end
-    section :regions, 'dl > div:nth-child(2)' do
+    section :regions, 'dl > div:nth-child(3)' do
       elements :names, 'details > div > ul > li'
       element :change_link, 'dd.govuk-summary-list__actions > a'
     end
@@ -54,6 +58,9 @@ module Pages::RM6232
     element :active_true, '#facilities_management_rm6232_admin_suppliers_admin_active_true'
     element :active_false, '#facilities_management_rm6232_admin_suppliers_admin_active_false'
 
+    element :lot_active_true, '#facilities_management_rm6232_supplier_lot_data_active_true'
+    element :lot_active_false, '#facilities_management_rm6232_supplier_lot_data_active_false'
+
     section :log_table, '#main-content > div:nth-child(5) > div > table' do
       elements :log_rows, 'tbody > tr'
     end
@@ -64,6 +71,10 @@ module Pages::RM6232
     element :updated_lot, '#updated-lot'
 
     section :changes_table, '#main-content > div:nth-child(6) > div > table' do
+      sections :changes_rows, ChangesRow, 'tbody > tr'
+    end
+
+    section :lot_status_changes_table, '#main-content > div:nth-child(5) > div > table' do
       sections :changes_rows, ChangesRow, 'tbody > tr'
     end
 

--- a/spec/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/supplier_lot_data_controller_spec.rb
@@ -61,6 +61,24 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierLotDataController, t
       end
     end
 
+    context 'when the lot data type is lot status' do
+      let(:lot_data_type) { 'lot_status' }
+
+      it 'renders the edit template' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'renders the service_codes partial' do
+        expect(response).to render_template(partial: 'facilities_management/rm6232/admin/supplier_lot_data/_lot_status')
+      end
+
+      it 'sets the lot data' do
+        expect(assigns(:lot_data)).to eq lot_data
+        expect(assigns(:lot_code)).to eq lot_data.lot_code
+        expect(assigns(:supplier).supplier_name).to eq lot_data.supplier_name
+      end
+    end
+
     context 'when the lot data type is service codes' do
       let(:lot_data_type) { 'service_codes' }
 
@@ -122,6 +140,48 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierLotDataController, t
       allow(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to receive(:log_change)
       allow(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to receive(:log_change).with(controller.current_user, lot_data)
       put :update, params: { supplier_lot_datum_id: lot_data.id, lot_data_type: lot_data_type, facilities_management_rm6232_supplier_lot_data: attributes }
+    end
+
+    context 'when the lot data type is lot status' do
+      let(:lot_data_type) { 'lot_status' }
+
+      context 'and the data is valid' do
+        let(:attributes) { { active: 'true' } }
+
+        it 'redirects to facilities_management_rm6232_admin_supplier_lot_datum_path' do
+          expect(response).to redirect_to facilities_management_rm6232_admin_supplier_lot_datum_path(lot_data.supplier.id)
+        end
+
+        it 'sets the lot data' do
+          expect(assigns(:lot_data)).to eq lot_data
+          expect(assigns(:lot_code)).to eq lot_data.lot_code
+          expect(assigns(:supplier).supplier_name).to eq lot_data.supplier_name
+        end
+
+        it 'adds a log to the database' do
+          expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, lot_data)
+        end
+      end
+
+      context 'and the data is invalid' do
+        let(:attributes) { { active: nil } }
+
+        render_views
+
+        it 'renders the edit template' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the region_codes partial' do
+          expect(response).to render_template(partial: 'facilities_management/rm6232/admin/supplier_lot_data/_lot_status')
+        end
+
+        it 'sets the lot data' do
+          expect(assigns(:lot_data)).to eq lot_data
+          expect(assigns(:lot_code)).to eq lot_data.lot_code
+          expect(assigns(:supplier).supplier_name).to eq lot_data.supplier_name
+        end
+      end
     end
 
     context 'when the lot data type is region codes' do

--- a/spec/factories/facilities_management/rm6232/admin/supplier_data/edit.rb
+++ b/spec/factories/facilities_management/rm6232/admin/supplier_data/edit.rb
@@ -24,5 +24,10 @@ FactoryBot.define do
       change_type { 'lot_data' }
       data { { 'lot_code' => '1a', 'attribute' => 'region_codes', 'added' => [], 'removed' => ['UKC1'] } }
     end
+
+    trait :with_status do
+      change_type { 'lot_data' }
+      data { { 'lot_code' => '1a', 'attribute' => 'active', 'added' => false, 'removed' => true } }
+    end
   end
 end

--- a/spec/models/facilities_management/rm6232/supplier/lot_data_spec.rb
+++ b/spec/models/facilities_management/rm6232/supplier/lot_data_spec.rb
@@ -62,6 +62,44 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData, type: :model do
   end
 
   describe 'validations' do
+    context 'when validating the lot status' do
+      let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier, active: active) }
+
+      context 'and active is nil' do
+        let(:active) { nil }
+
+        it 'is not valid and has the correct error message' do
+          expect(lot_data).not_to be_valid(:lot_status)
+          expect(lot_data.errors[:active].first).to eq 'You must select a status for the lot data'
+        end
+      end
+
+      context 'and active is blank' do
+        let(:active) { '' }
+
+        it 'is not valid and has the correct error message' do
+          expect(lot_data).not_to be_valid(:lot_status)
+          expect(lot_data.errors[:active].first).to eq 'You must select a status for the lot data'
+        end
+      end
+
+      context 'and active is true' do
+        let(:active) { 'true' }
+
+        it 'is valid' do
+          expect(lot_data).to be_valid(:lot_status)
+        end
+      end
+
+      context 'and active is false' do
+        let(:active) { 'false' }
+
+        it 'is valid' do
+          expect(lot_data).to be_valid(:lot_status)
+        end
+      end
+    end
+
     context 'when validating the region codes' do
       let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier, region_codes: region_codes) }
 
@@ -90,6 +128,22 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData, type: :model do
     let(:result) { lot_data.changed_data }
 
     before { lot_data.update(**attributes) }
+
+    context 'when changing the status' do
+      let(:attributes) { { active: false } }
+      let(:data) do
+        {
+          attribute: 'active',
+          lot_code: '1a',
+          added: false,
+          removed: true
+        }
+      end
+
+      it 'returns the correct data' do
+        expect(result).to eq([supplier.id, :lot_data, data])
+      end
+    end
 
     context 'when changing the services' do
       let(:attributes) { { service_codes: service_codes } }
@@ -192,6 +246,26 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData, type: :model do
         it 'returns the correct data' do
           expect(result).to eq([supplier.id, :lot_data, data])
         end
+      end
+    end
+  end
+
+  describe '.current_status' do
+    let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier, active: active) }
+
+    context 'when the lot data is active' do
+      let(:active) { true }
+
+      it 'returns blue and ACTIVE' do
+        expect(lot_data.current_status).to eq [:blue, 'ACTIVE']
+      end
+    end
+
+    context 'when the lot data is not active' do
+      let(:active) { false }
+
+      it 'returns red and INACTIVE' do
+        expect(lot_data.current_status).to eq [:red, 'INACTIVE']
       end
     end
   end

--- a/spec/models/facilities_management/rm6232/supplier_spec.rb
+++ b/spec/models/facilities_management/rm6232/supplier_spec.rb
@@ -24,10 +24,11 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
 
     let(:my_supplier) do
       create(:facilities_management_rm6232_supplier) do |supplier|
-        supplier.lot_data = build_list(:facilities_management_rm6232_supplier_lot_data, 1, lot_code: lot_code, service_codes: supplier_services, region_codes: supplier_regions)
+        supplier.lot_data = build_list(:facilities_management_rm6232_supplier_lot_data, 1, lot_code: lot_code, service_codes: supplier_services, region_codes: supplier_regions, active: active)
       end
     end
 
+    let(:active) { true }
     let(:selection_two) { { total: false, hard: false, soft: false } }
     let(:service_codes) { FacilitiesManagement::RM6232::Service.where(**selection_one).sample(5).pluck(:code) + FacilitiesManagement::RM6232::Service.where(**selection_two).sample(5).pluck(:code) }
     let(:region_codes) { FacilitiesManagement::Region.all[..-2].sample(5).map(&:code) }
@@ -66,6 +67,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
               expect(supplier_names).not_to include my_supplier.supplier_name
             end
           end
+
+          context 'and the lot is not active' do
+            let(:active) { false }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is b (lot: 1b)' do
@@ -82,6 +91,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
               expect(supplier_names).not_to include my_supplier.supplier_name
             end
           end
+
+          context 'and the lot is not active' do
+            let(:active) { false }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is c (lot: 1c)' do
@@ -93,6 +110,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
 
           context 'and my_supplier is not active' do
             before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
+
+          context 'and the lot is not active' do
+            let(:active) { false }
 
             it 'returns a list of suppliers that does not include my_supplier' do
               expect(supplier_names).not_to include my_supplier.supplier_name
@@ -118,6 +143,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
               expect(supplier_names).not_to include my_supplier.supplier_name
             end
           end
+
+          context 'and the lot is not active' do
+            let(:active) { false }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is b (lot: 2b)' do
@@ -134,6 +167,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
               expect(supplier_names).not_to include my_supplier.supplier_name
             end
           end
+
+          context 'and the lot is not active' do
+            let(:active) { false }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is c (lot: 2c)' do
@@ -145,6 +186,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
 
           context 'and my_supplier is not active' do
             before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
+
+          context 'and the lot is not active' do
+            let(:active) { false }
 
             it 'returns a list of suppliers that does not include my_supplier' do
               expect(supplier_names).not_to include my_supplier.supplier_name
@@ -170,6 +219,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
               expect(supplier_names).not_to include my_supplier.supplier_name
             end
           end
+
+          context 'and the lot is not active' do
+            let(:active) { false }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is b (lot: 3b)' do
@@ -186,6 +243,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
               expect(supplier_names).not_to include my_supplier.supplier_name
             end
           end
+
+          context 'and the lot is not active' do
+            let(:active) { false }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
         end
 
         context 'and the lot code is c (lot: 3c)' do
@@ -197,6 +262,14 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier, type: :model do
 
           context 'and my_supplier is not active' do
             before { my_supplier.update(active: false) }
+
+            it 'returns a list of suppliers that does not include my_supplier' do
+              expect(supplier_names).not_to include my_supplier.supplier_name
+            end
+          end
+
+          context 'and the lot is not active' do
+            let(:active) { false }
 
             it 'returns a list of suppliers that does not include my_supplier' do
               expect(supplier_names).not_to include my_supplier.supplier_name

--- a/spec/services/facilities_management/rm6232/admin/change_logs_csv_generator_spec.rb
+++ b/spec/services/facilities_management/rm6232/admin/change_logs_csv_generator_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::ChangeLogsCsvGenerator do
     supplier_data_2
     create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: get_time(2022, 3, 9, 12, 0), supplier_id: supplier_1_id, data: [{ 'attribute' => 'supplier_name', 'value' => 'Marc Ribillet Records' }])
     create(:facilities_management_rm6232_admin_supplier_data_edit, :with_service_lot_data, user: user_2, created_at: get_time(2022, 3, 10, 0, 18), supplier_id: supplier_1_id, data: { 'lot_code' => '1a', 'attribute' => 'service_codes', 'added' => %w[E.14 E.15], 'removed' => %w[I.14 J.7] })
+    create(:facilities_management_rm6232_admin_supplier_data_edit, :with_status, user: user_1, created_at: get_time(2022, 3, 11, 0, 18), supplier_id: supplier_1_id, data: { 'lot_code' => '1a', 'attribute' => 'active', 'added' => true, 'removed' => false })
     create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: get_time(2022, 3, 12, 17, 25), supplier_id: supplier_2_id, data: [{ 'attribute' => 'address_line_1', 'value' => '1 Loop daddy' }, { 'attribute' => 'address_town', 'value' => 'New York City' }])
     create(:facilities_management_rm6232_admin_supplier_data_edit, :with_details, user: user_2, created_at: get_time(2022, 3, 12, 17, 26), supplier_id: supplier_2_id, data: [{ 'attribute' => 'address_line_1', 'value' => '2 Loop daddy' }, { 'attribute' => 'address_town', 'value' => 'New Jersey City' }])
   end
@@ -36,13 +37,14 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::ChangeLogsCsvGenerator do
     it 'has the correct data in rows' do
       expect(generated_csv[1][1..]).to eq(['12/03/2022 17:26', 'bertholdt.hoover@attackontitn.pa', 'Skiles LLC', 'Details', "Building and street - FROM: 1 Loop daddy TO: 2 Loop daddy\nTown or city - FROM: New York City TO: New Jersey City"])
       expect(generated_csv[2][1..]).to eq(['12/03/2022 17:25', 'bertholdt.hoover@attackontitn.pa', 'Skiles LLC', 'Details', "Building and street - FROM: 40828 Joellen Summit TO: 1 Loop daddy\nTown or city - FROM: Danialborough TO: New York City"])
-      expect(generated_csv[3][1..]).to eq(['10/03/2022 00:18', 'bertholdt.hoover@attackontitn.pa', 'Marc Ribillet Records', 'Services', "Lot code: 1a\nAdded items: E.14 Catering equipment maintenance|E.15 Audio Visual (AV) equipment maintenance\nRemoved items: I.14 Cleaning of curtains and window blinds|J.7 Clocks"])
-      expect(generated_csv[4][1..]).to eq(['09/03/2022 12:00', 'bertholdt.hoover@attackontitn.pa', 'Marc Ribillet Records', 'Details', 'Supplier name - FROM: Abshire, Schumm and Farrell TO: Marc Ribillet Records'])
-      expect(generated_csv[5][1..]).to eq(['08/03/2022 10:00', 'bertholdt.hoover@attackontitn.pa', 'N/A', 'Data uploaded', "Upload: http://localhost:3000/facilities-management/RM6232/admin/uploads/#{new_upload.id}"])
-      expect(generated_csv[6][1..]).to eq(['07/03/2022 04:59', 'reiner.braun@attackontitn.pa', 'Skiles LLC', 'Regions', "Lot code: 1a\nRemoved items: UKC1 Tees Valley and Durham"])
-      expect(generated_csv[7][1..]).to eq(['06/03/2022 13:26', 'bertholdt.hoover@attackontitn.pa', 'Abshire, Schumm and Farrell', 'Details', 'Status - FROM: Active TO: Inactive'])
-      expect(generated_csv[8][1..]).to eq(['05/03/2022 01:11', 'reiner.braun@attackontitn.pa', 'Abshire, Schumm and Farrell', 'Services', "Lot code: 1a\nAdded items: F.12 Radon Gas Management Services"])
-      expect(generated_csv[9][1..]).to eq(['04/03/2022 12:55', 'During a deployment', 'N/A', 'Data uploaded', 'N/A'])
+      expect(generated_csv[3][1..]).to eq(['11/03/2022 00:18', 'reiner.braun@attackontitn.pa', 'Marc Ribillet Records', 'Lot status', "Lot code: 1a\nLot status - FROM: Inactive TO: Active"])
+      expect(generated_csv[4][1..]).to eq(['10/03/2022 00:18', 'bertholdt.hoover@attackontitn.pa', 'Marc Ribillet Records', 'Services', "Lot code: 1a\nAdded items: E.14 Catering equipment maintenance|E.15 Audio Visual (AV) equipment maintenance\nRemoved items: I.14 Cleaning of curtains and window blinds|J.7 Clocks"])
+      expect(generated_csv[5][1..]).to eq(['09/03/2022 12:00', 'bertholdt.hoover@attackontitn.pa', 'Marc Ribillet Records', 'Details', 'Supplier name - FROM: Abshire, Schumm and Farrell TO: Marc Ribillet Records'])
+      expect(generated_csv[6][1..]).to eq(['08/03/2022 10:00', 'bertholdt.hoover@attackontitn.pa', 'N/A', 'Data uploaded', "Upload: http://localhost:3000/facilities-management/RM6232/admin/uploads/#{new_upload.id}"])
+      expect(generated_csv[7][1..]).to eq(['07/03/2022 04:59', 'reiner.braun@attackontitn.pa', 'Skiles LLC', 'Regions', "Lot code: 1a\nRemoved items: UKC1 Tees Valley and Durham"])
+      expect(generated_csv[8][1..]).to eq(['06/03/2022 13:26', 'bertholdt.hoover@attackontitn.pa', 'Abshire, Schumm and Farrell', 'Details', 'Status - FROM: Active TO: Inactive'])
+      expect(generated_csv[9][1..]).to eq(['05/03/2022 01:11', 'reiner.braun@attackontitn.pa', 'Abshire, Schumm and Farrell', 'Services', "Lot code: 1a\nAdded items: F.12 Radon Gas Management Services"])
+      expect(generated_csv[10][1..]).to eq(['04/03/2022 12:55', 'During a deployment', 'N/A', 'Data uploaded', 'N/A'])
     end
     # rubocop:enable RSpec/MultipleExpectations
   end

--- a/spec/services/facilities_management/rm6232/suppliers_selector_spec.rb
+++ b/spec/services/facilities_management/rm6232/suppliers_selector_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
 
   let!(:my_supplier) do
     create(:facilities_management_rm6232_supplier) do |supplier|
-      supplier.lot_data = build_list(:facilities_management_rm6232_supplier_lot_data, 1, lot_code: lot_code, service_codes: supplier_services, region_codes: supplier_regions)
+      supplier.lot_data = build_list(:facilities_management_rm6232_supplier_lot_data, 1, lot_code: lot_code, service_codes: supplier_services, region_codes: supplier_regions, active: active)
     end
   end
 
+  let(:active) { true }
   let(:selection_one) { { total: false, hard: false, soft: false } }
   let(:selection_two) { { total: false, hard: false, soft: false } }
   let(:service_codes) { FacilitiesManagement::RM6232::Service.where(**selection_one).sample(5).pluck(:code) + FacilitiesManagement::RM6232::Service.where(**selection_two).sample(5).pluck(:code) }
@@ -39,6 +40,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
 
         context 'and my_supplier is not active' do
           before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and the lot is not active' do
+          let(:active) { false }
 
           it 'returns a list of suppliers that does not include my_supplier' do
             expect(supplier_names).not_to include my_supplier.supplier_name
@@ -74,6 +83,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
           end
         end
 
+        context 'and the lot is not active' do
+          let(:active) { false }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
+
         context 'and known_lot_number is 1b' do
           let(:known_lot_number) { '1b' }
 
@@ -97,6 +114,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
 
         context 'and my_supplier is not active' do
           before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and the lot is not active' do
+          let(:active) { false }
 
           it 'returns a list of suppliers that does not include my_supplier' do
             expect(supplier_names).not_to include my_supplier.supplier_name
@@ -136,6 +161,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
           end
         end
 
+        context 'and the lot is not active' do
+          let(:active) { false }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
+
         context 'and known_lot_number is 1a' do
           let(:known_lot_number) { '1a' }
 
@@ -165,6 +198,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
           end
         end
 
+        context 'and the lot is not active' do
+          let(:active) { false }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
+
         context 'and known_lot_number is 1b' do
           let(:known_lot_number) { '1b' }
 
@@ -188,6 +229,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
 
         context 'and my_supplier is not active' do
           before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and the lot is not active' do
+          let(:active) { false }
 
           it 'returns a list of suppliers that does not include my_supplier' do
             expect(supplier_names).not_to include my_supplier.supplier_name
@@ -227,6 +276,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
             expect(supplier_names).not_to include my_supplier.supplier_name
           end
         end
+
+        context 'and the lot is not active' do
+          let(:active) { false }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
       end
 
       context 'and the annual_contract_value is a more than 1,500,000 and less than 10,000,000' do
@@ -248,6 +305,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
             expect(supplier_names).not_to include my_supplier.supplier_name
           end
         end
+
+        context 'and the lot is not active' do
+          let(:active) { false }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
       end
 
       context 'and the annual_contract_value is more than 10,000,000' do
@@ -264,6 +329,14 @@ RSpec.describe FacilitiesManagement::RM6232::SuppliersSelector do
 
         context 'and my_supplier is not active' do
           before { my_supplier.update(active: false) }
+
+          it 'returns a list of suppliers that does not include my_supplier' do
+            expect(supplier_names).not_to include my_supplier.supplier_name
+          end
+        end
+
+        context 'and the lot is not active' do
+          let(:active) { false }
 
           it 'returns a list of suppliers that does not include my_supplier' do
             expect(supplier_names).not_to include my_supplier.supplier_name


### PR DESCRIPTION
Ticket: [FMFR-1269](https://crowncommercialservice.atlassian.net/browse/FMFR-1269)

We have been asked by the category team to add the ability to suspend a supplier in certain lots. There is a de facto way of doing this already where they can upload the lot data without that supplier's data in that lot.

This change adds a toggle on all the lot data which allows the status to be changed. As part of this there are also updates to the logging functionality for when an admin user makes changes.

I have added specs and feature tests for these changes as well.