### PR TITLE
Split up date addition to account for months with shorter lengths

### DIFF
--- a/spec/helpers/facilities_management/contract_dates_helper_spec.rb
+++ b/spec/helpers/facilities_management/contract_dates_helper_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe FacilitiesManagement::ContractDatesHelper, type: :helper do
       let(:initial_call_off_period_years) { 1 }
 
       it 'returns one year after the icontract start date' do
-        expect(result).to eq (Time.zone.now + 18.months).strftime '%e %B %Y'
+        expect(result).to eq (Time.zone.now + 6.months + 1.year).strftime '%e %B %Y'
       end
     end
   end


### PR DESCRIPTION
Because the date we are adding adds the 18 months as 6 months plus one year, we need to do the same to prevent the following issue.

If the date is 30 August 2022, if we add 18 months we will get to 29th Feb 2024. However, if we add 6 months we will get the 28th Feb 2023 and then add a year we will get the 28th of Feb 2024.

By adding the date in this way for the result of this test, we can prevent this potential issue.