### PR TITLE
FMFR-1194 - Address username enumeration concerns

### DIFF
--- a/app/services/cognito/confirm_sign_up.rb
+++ b/app/services/cognito/confirm_sign_up.rb
@@ -21,6 +21,9 @@ module Cognito
         confirm_sign_up
         confirm_user
       end
+    rescue Aws::CognitoIdentityProvider::Errors::NotAuthorizedException
+      # We do nothing as we don't want people to be able enumerate users
+      errors.add(:confirmation_code, :invalid)
     rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
       errors.add(:confirmation_code, e.message)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
           attributes:
             confirmation_code:
               blank: Enter your verification code
+              invalid: Invalid verification code provided, please try again
               invalid_format: Confirmation code must contain numeric characters only
               invalid_length: Confirmation code must be 6 characters
         cognito/respond_to_challenge:
@@ -248,7 +249,7 @@ en:
         lead1: If the email address you’ve entered belongs to a Crown Commercial Service account, we’ll send instructions to reset the password.
         new_password: New password
         password: Your password must have
-        text_html: If you don’t receive this, email <a href="mailto:support@crowncommercial.gov.uk">support@crowncommercial.gov.uk</a>
+        text_html: If you don’t receive this, email <a href="mailto:support@crowncommercial.gov.uk" class="govuk-link govuk-link--no-visited-state">support@crowncommercial.gov.uk</a>
         verify_code: Verification code
       new:
         email: Email address

--- a/features/helpers/facilities_management/logging_in_helper.rb
+++ b/features/helpers/facilities_management/logging_in_helper.rb
@@ -2,6 +2,7 @@ def stub_login
   aws_client = instance_double(Aws::CognitoIdentityProvider::Client)
   allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
   allow(aws_client).to receive(:initiate_auth).and_return(OpenStruct.new)
+  allow_any_instance_of(Cognito::SignInUser).to receive(:sleep)
 end
 
 def create_user_with_details

--- a/spec/controllers/crown_marketplace/passwords_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/passwords_controller_spec.rb
@@ -12,35 +12,70 @@ RSpec.describe CrownMarketplace::PasswordsController, type: :controller do
   end
 
   describe 'POST create' do
-    before do
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
-      # rubocop:enable RSpec/AnyInstance
-      post :create, params: { email: email }
-      cookies.update(response.cookies)
+    context 'when no exception is raised' do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+        # rubocop:enable RSpec/AnyInstance
+        post :create, params: { email: email }
+        cookies.update(response.cookies)
+      end
+
+      context 'when the email is invalid' do
+        let(:email) { 'testtest.com' }
+
+        it 'redirects to the crown_marketplace_new_user_password_path' do
+          expect(response).to redirect_to crown_marketplace_new_user_password_path
+        end
+
+        it 'does not set the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to be nil
+        end
+      end
+
+      context 'when the email is valid' do
+        let(:email) { 'test@test.com' }
+
+        it 'redirects to crown_marketplace_edit_user_password_path' do
+          expect(response).to redirect_to crown_marketplace_edit_user_password_path
+        end
+
+        it 'sets the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+        end
+      end
     end
 
-    context 'when the email is invalid' do
-      let(:email) { 'testtest.com' }
-
-      it 'redirects to the crown_marketplace_new_user_password_path' do
-        expect(response).to redirect_to crown_marketplace_new_user_password_path
+    context 'when the email is valid but an exception is raised' do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+        # rubocop:enable RSpec/AnyInstance
+        post :create, params: { email: 'test@test.com' }
       end
 
-      it 'does not set the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to be nil
-      end
-    end
+      context 'and the error is UserNotFoundException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
 
-    context 'when the email is valid' do
-      let(:email) { 'test@test.com' }
-
-      it 'redirects to crown_marketplace_edit_user_password_path' do
-        expect(response).to redirect_to crown_marketplace_edit_user_password_path
+        it 'redirects to the edit password page' do
+          expect(response).to redirect_to crown_marketplace_edit_user_password_path
+        end
       end
 
-      it 'sets the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+      context 'and the error is InvalidParameterException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+        it 'redirects to the new password page' do
+          expect(response).to redirect_to crown_marketplace_new_user_password_path
+        end
+      end
+
+      context 'and the error is ServiceError' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+        it 'redirects to the new password page' do
+          expect(response).to redirect_to crown_marketplace_new_user_password_path
+        end
       end
     end
   end

--- a/spec/controllers/crown_marketplace/sessions_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/sessions_controller_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe CrownMarketplace::SessionsController, type: :controller do
     before do
       cookies['test_marketplace_session'] = 'I AM THE SESSION COOKIE'
       allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::SignInUser).to receive(:sleep)
+      # rubocop:enable RSpec/AnyInstance
     end
 
     context 'when the log in attempt is unsuccessful' do

--- a/spec/controllers/facilities_management/rm3830/admin/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/passwords_controller_spec.rb
@@ -12,35 +12,70 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::PasswordsController, type: :
   end
 
   describe 'POST create' do
-    before do
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
-      # rubocop:enable RSpec/AnyInstance
-      post :create, params: { email: email }
-      cookies.update(response.cookies)
+    context 'when no exception is raised' do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+        # rubocop:enable RSpec/AnyInstance
+        post :create, params: { email: email }
+        cookies.update(response.cookies)
+      end
+
+      context 'when the email is invalid' do
+        let(:email) { 'testtest.com' }
+
+        it 'redirects to the facilities_management_rm3830_admin_new_user_password_path' do
+          expect(response).to redirect_to facilities_management_rm3830_admin_new_user_password_path
+        end
+
+        it 'does not set the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to be nil
+        end
+      end
+
+      context 'when the email is valid' do
+        let(:email) { 'test@test.com' }
+
+        it 'redirects to facilities_management_rm3830_admin_edit_user_password_path' do
+          expect(response).to redirect_to facilities_management_rm3830_admin_edit_user_password_path
+        end
+
+        it 'sets the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+        end
+      end
     end
 
-    context 'when the email is invalid' do
-      let(:email) { 'testtest.com' }
-
-      it 'redirects to the facilities_management_rm3830_admin_new_user_password_path' do
-        expect(response).to redirect_to facilities_management_rm3830_admin_new_user_password_path
+    context 'when the email is valid but an exception is raised' do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+        # rubocop:enable RSpec/AnyInstance
+        post :create, params: { email: 'test@test.com' }
       end
 
-      it 'does not set the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to be nil
-      end
-    end
+      context 'and the error is UserNotFoundException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
 
-    context 'when the email is valid' do
-      let(:email) { 'test@test.com' }
-
-      it 'redirects to facilities_management_rm3830_admin_edit_user_password_path' do
-        expect(response).to redirect_to facilities_management_rm3830_admin_edit_user_password_path
+        it 'redirects to the edit password page' do
+          expect(response).to redirect_to facilities_management_rm3830_admin_edit_user_password_path
+        end
       end
 
-      it 'sets the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+      context 'and the error is InvalidParameterException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+        it 'redirects to the new password page' do
+          expect(response).to redirect_to facilities_management_rm3830_admin_new_user_password_path
+        end
+      end
+
+      context 'and the error is ServiceError' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+        it 'redirects to the new password page' do
+          expect(response).to redirect_to facilities_management_rm3830_admin_new_user_password_path
+        end
       end
     end
   end

--- a/spec/controllers/facilities_management/rm3830/admin/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/sessions_controller_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController, type: :c
     before do
       cookies['test_marketplace_session'] = 'I AM THE SESSION COOKIE'
       allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::SignInUser).to receive(:sleep)
+      # rubocop:enable RSpec/AnyInstance
     end
 
     context 'when the log in attempt is unsuccessful' do

--- a/spec/controllers/facilities_management/rm3830/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/passwords_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe FacilitiesManagement::RM3830::PasswordsController, type: :control
   end
 
   describe 'POST create' do
-    context 'when the framework is live' do
+    context 'when no exception is raised' do
       before do
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
@@ -59,14 +59,36 @@ RSpec.describe FacilitiesManagement::RM3830::PasswordsController, type: :control
       end
     end
 
-    context 'when the framework is not live' do
-      include_context 'and RM3830 is not live'
-
-      it 'renders the unrecognised framework page with the right http status' do
+    context 'when the email is valid but an exception is raised' do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+        # rubocop:enable RSpec/AnyInstance
         post :create, params: { email: 'test@test.com' }
+      end
 
-        expect(response).to render_template('home/unrecognised_framework')
-        expect(response).to have_http_status(:bad_request)
+      context 'and the error is UserNotFoundException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
+
+        it 'redirects to the edit password page' do
+          expect(response).to redirect_to facilities_management_rm3830_edit_user_password_path
+        end
+      end
+
+      context 'and the error is InvalidParameterException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+        it 'redirects to the new password page' do
+          expect(response).to redirect_to facilities_management_rm3830_new_user_password_path
+        end
+      end
+
+      context 'and the error is ServiceError' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+        it 'redirects to the new password page' do
+          expect(response).to redirect_to facilities_management_rm3830_new_user_password_path
+        end
       end
     end
   end

--- a/spec/controllers/facilities_management/rm3830/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/sessions_controller_spec.rb
@@ -34,6 +34,9 @@ RSpec.describe FacilitiesManagement::RM3830::SessionsController, type: :controll
     before do
       cookies['test_marketplace_session'] = 'I AM THE SESSION COOKIE'
       allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::SignInUser).to receive(:sleep)
+      # rubocop:enable RSpec/AnyInstance
     end
 
     context 'when the log in attempt is unsuccessful' do

--- a/spec/controllers/facilities_management/rm3830/supplier/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/supplier/passwords_controller_spec.rb
@@ -12,35 +12,70 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::PasswordsController, type
   end
 
   describe 'POST create' do
-    before do
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
-      # rubocop:enable RSpec/AnyInstance
-      post :create, params: { email: email }
-      cookies.update(response.cookies)
+    context 'when no exception is raised' do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
+        # rubocop:enable RSpec/AnyInstance
+        post :create, params: { email: email }
+        cookies.update(response.cookies)
+      end
+
+      context 'when the email is invalid' do
+        let(:email) { 'testtest.com' }
+
+        it 'redirects to the facilities_management_rm3830_supplier_new_user_password_path' do
+          expect(response).to redirect_to facilities_management_rm3830_supplier_new_user_password_path
+        end
+
+        it 'does not set the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to be nil
+        end
+      end
+
+      context 'when the email is valid' do
+        let(:email) { 'test@test.com' }
+
+        it 'redirects to facilities_management_rm3830_supplier_edit_user_password_path' do
+          expect(response).to redirect_to facilities_management_rm3830_supplier_edit_user_password_path
+        end
+
+        it 'sets the crown_marketplace_reset_email cookie' do
+          expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+        end
+      end
     end
 
-    context 'when the email is invalid' do
-      let(:email) { 'testtest.com' }
-
-      it 'redirects to the facilities_management_rm3830_supplier_new_user_password_path' do
-        expect(response).to redirect_to facilities_management_rm3830_supplier_new_user_password_path
+    context 'when the email is valid but an exception is raised' do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_raise(error.new('Some context', 'Some message'))
+        # rubocop:enable RSpec/AnyInstance
+        post :create, params: { email: 'test@test.com' }
       end
 
-      it 'does not set the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to be nil
-      end
-    end
+      context 'and the error is UserNotFoundException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::UserNotFoundException }
 
-    context 'when the email is valid' do
-      let(:email) { 'test@test.com' }
-
-      it 'redirects to facilities_management_rm3830_supplier_edit_user_password_path' do
-        expect(response).to redirect_to facilities_management_rm3830_supplier_edit_user_password_path
+        it 'redirects to the edit password page' do
+          expect(response).to redirect_to facilities_management_rm3830_supplier_edit_user_password_path
+        end
       end
 
-      it 'sets the crown_marketplace_reset_email cookie' do
-        expect(cookies[:crown_marketplace_reset_email]).to eq 'test@test.com'
+      context 'and the error is InvalidParameterException' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+        it 'redirects to the new password page' do
+          expect(response).to redirect_to facilities_management_rm3830_supplier_new_user_password_path
+        end
+      end
+
+      context 'and the error is ServiceError' do
+        let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+        it 'redirects to the new password page' do
+          expect(response).to redirect_to facilities_management_rm3830_supplier_new_user_password_path
+        end
       end
     end
   end

--- a/spec/controllers/facilities_management/rm3830/supplier/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/supplier/sessions_controller_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::SessionsController, type:
     before do
       cookies['test_marketplace_session'] = 'I AM THE SESSION COOKIE'
       allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::SignInUser).to receive(:sleep)
+      # rubocop:enable RSpec/AnyInstance
     end
 
     context 'when the log in attempt is unsuccessful' do

--- a/spec/controllers/facilities_management/rm3830/users_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/users_controller_spec.rb
@@ -27,41 +27,79 @@ RSpec.describe FacilitiesManagement::RM3830::UsersController, type: :controller 
   describe 'POST confirm' do
     let(:user) { create(:user) }
     let(:user_email) { user.email }
+    let(:confirmation_code) { '123456' }
 
+    # rubocop:disable RSpec/NestedGroups
     context 'when the framework is live' do
-      before do
-        cookies[:crown_marketplace_confirmation_email] = user_email
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_return(true)
-        # rubocop:enable RSpec/AnyInstance
-        post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
-        cookies.update(response.cookies)
+      context 'and there is no exception' do
+        before do
+          cookies[:crown_marketplace_confirmation_email] = user_email
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_return(true)
+          # rubocop:enable RSpec/AnyInstance
+          post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
+          cookies.update(response.cookies)
+        end
+
+        context 'when the information is invalid' do
+          let(:confirmation_code) { '' }
+
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
+
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
+        end
+
+        context 'when the information is valid' do
+          it 'redirects to facilities_management_rm3830_path' do
+            expect(response).to redirect_to facilities_management_rm3830_path
+          end
+
+          it 'deletes the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to be nil
+          end
+        end
       end
 
-      context 'when the information is invalid' do
-        let(:confirmation_code) { '' }
-
-        it 'renders confirm_new' do
-          expect(response).to render_template(:confirm_new)
+      context 'and there is an exception' do
+        before do
+          cookies[:crown_marketplace_confirmation_email] = user_email
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::ConfirmSignUp).to receive(:confirm_sign_up).and_raise(error.new('Some context', 'Some message'))
+          # rubocop:enable RSpec/AnyInstance
+          post :confirm, params: { email: user_email, confirmation_code: confirmation_code }
+          cookies.update(response.cookies)
         end
 
-        it 'does not delete the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+        context 'when the exception is generic' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
+
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
         end
-      end
 
-      context 'when the information is valid' do
-        let(:confirmation_code) { '123456' }
+        context 'when the exception is NotAuthorizedException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::NotAuthorizedException }
 
-        it 'redirects to facilities_management_rm3830_path' do
-          expect(response).to redirect_to facilities_management_rm3830_path
-        end
+          it 'renders confirm_new' do
+            expect(response).to render_template(:confirm_new)
+          end
 
-        it 'deletes the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to be nil
+          it 'does not delete the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq user_email
+          end
         end
       end
     end
+    # rubocop:enable RSpec/NestedGroups
 
     context 'when the framework is not live' do
       include_context 'and RM3830 is not live'

--- a/spec/controllers/facilities_management/rm6232/admin/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/sessions_controller_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SessionsController, type: :c
     before do
       cookies['test_marketplace_session'] = 'I AM THE SESSION COOKIE'
       allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::SignInUser).to receive(:sleep)
+      # rubocop:enable RSpec/AnyInstance
     end
 
     context 'when the log in attempt is unsuccessful' do

--- a/spec/controllers/facilities_management/rm6232/registrations_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/registrations_controller_spec.rb
@@ -30,45 +30,80 @@ RSpec.describe FacilitiesManagement::RM6232::RegistrationsController, type: :con
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   describe 'POST create' do
     let(:email) { 'test@testemail.com' }
     let(:password) { 'Password890!' }
     let(:password_confirmation) { password }
 
     context 'when the framework is live' do
-      before do
-        # rubocop:disable RSpec/AnyInstance
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_return({ 'user_sub': '1234567890' })
-        allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
-        allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
-        # rubocop:enable RSpec/AnyInstance
-        post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
-        cookies.update(response.cookies)
-      end
+      context 'when no exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_return({ 'user_sub': '1234567890' })
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
+          allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          cookies.update(response.cookies)
+        end
 
-      context 'when the emaildomain is not on the allow list' do
-        let(:email) { 'test@fake-testemail.com' }
+        context 'when the emaildomain is not on the allow list' do
+          let(:email) { 'test@fake-testemail.com' }
 
-        it 'redirects to facilities_management_rm6232_domain_not_on_safelist_path' do
-          expect(response).to redirect_to facilities_management_rm6232_domain_not_on_safelist_path
+          it 'redirects to facilities_management_rm6232_domain_not_on_safelist_path' do
+            expect(response).to redirect_to facilities_management_rm6232_domain_not_on_safelist_path
+          end
+        end
+
+        context 'when some of the information is invalid' do
+          let(:password_confirmation) { 'I do not match the password' }
+
+          it 'renders the new page' do
+            expect(response).to render_template(:new)
+          end
+        end
+
+        context 'when all the information is valid' do
+          it 'redirects to facilities_management_rm6232_users_confirm_path' do
+            expect(response).to redirect_to facilities_management_rm6232_users_confirm_path
+          end
+
+          it 'sets the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+          end
         end
       end
 
-      context 'when some of the information is invalid' do
-        let(:password_confirmation) { 'I do not match the password' }
-
-        it 'renders the new page' do
-          expect(response).to render_template(:new)
-        end
-      end
-
-      context 'when all the information is valid' do
-        it 'redirects to facilities_management_rm6232_users_confirm_path' do
-          expect(response).to redirect_to facilities_management_rm6232_users_confirm_path
+      context 'when an exception is raised' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:create_cognito_user).and_raise(error.new('Some context', 'Some message'))
+          allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
+          allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
+          # rubocop:enable RSpec/AnyInstance
+          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          cookies.update(response.cookies)
         end
 
-        it 'sets the crown_marketplace_confirmation_email cookie' do
-          expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+        context 'and the error is UsernameExistsException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::UsernameExistsException }
+
+          it 'redirects to facilities_management_rm6232_users_confirm_path' do
+            expect(response).to redirect_to facilities_management_rm6232_users_confirm_path
+          end
+
+          it 'sets the crown_marketplace_confirmation_email cookie' do
+            expect(cookies[:crown_marketplace_confirmation_email]).to eq email
+          end
+        end
+
+        context 'and the error is InvalidParameterException' do
+          let(:error) { Aws::CognitoIdentityProvider::Errors::InvalidParameterException }
+
+          it 'renders the new page' do
+            expect(response).to render_template(:new)
+          end
         end
       end
     end
@@ -84,6 +119,7 @@ RSpec.describe FacilitiesManagement::RM6232::RegistrationsController, type: :con
       end
     end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   describe 'GET domain_not_on_safelist' do
     context 'when the framework is live' do

--- a/spec/controllers/facilities_management/rm6232/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/sessions_controller_spec.rb
@@ -34,6 +34,9 @@ RSpec.describe FacilitiesManagement::RM6232::SessionsController, type: :controll
     before do
       cookies['test_marketplace_session'] = 'I AM THE SESSION COOKIE'
       allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Cognito::SignInUser).to receive(:sleep)
+      # rubocop:enable RSpec/AnyInstance
     end
 
     context 'when the log in attempt is unsuccessful' do

--- a/spec/features/authentication.feature_spec.rb
+++ b/spec/features/authentication.feature_spec.rb
@@ -13,6 +13,9 @@ RSpec.feature 'Authentication', type: :feature do
     allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
     allow(aws_client).to receive(:initiate_auth).and_return(OpenStruct.new(session: '1234667'))
     allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Cognito::SignInUser).to receive(:sleep)
+    # rubocop:enable RSpec/AnyInstance
     create_cookie('foo', 'bar')
   end
 

--- a/spec/services/cognito/sign_in_user_spec.rb
+++ b/spec/services/cognito/sign_in_user_spec.rb
@@ -11,32 +11,35 @@ RSpec.describe Cognito::SignInUser do
 
     let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
 
-    context 'when success' do
-      let(:response) { described_class.call(email, password, cookies_disabled) }
+    let(:sign_in_user) { described_class.new(email, password, cookies_disabled) }
 
+    before { allow(sign_in_user).to receive(:sleep) }
+
+    context 'when success' do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_return(OpenStruct.new(challenge_name: challenge_name, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => user_id_for_srp }))
+        sign_in_user.call
       end
 
       it 'returns success' do
-        expect(response.success?).to eq true
+        expect(sign_in_user.success?).to eq true
       end
 
       it 'returns no error' do
-        expect(response.error).to eq nil
+        expect(sign_in_user.error).to eq nil
       end
 
       it 'returns challenge name' do
-        expect(response.challenge_name).to eq challenge_name
+        expect(sign_in_user.challenge_name).to eq challenge_name
       end
 
       it 'returns challenge?' do
-        expect(response.challenge?).to eq true
+        expect(sign_in_user.challenge?).to eq true
       end
 
       it 'returns session' do
-        expect(response.session).to eq session
+        expect(sign_in_user.session).to eq session
       end
     end
 
@@ -44,16 +47,15 @@ RSpec.describe Cognito::SignInUser do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops'))
+        sign_in_user.call
       end
 
       it 'does not return success' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.success?).to eq false
+        expect(sign_in_user.success?).to eq false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.error).to eq I18n.t('facilities_management.users.sign_in_error')
+        expect(sign_in_user.error).to eq I18n.t('facilities_management.users.sign_in_error')
       end
     end
 
@@ -61,21 +63,19 @@ RSpec.describe Cognito::SignInUser do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotConfirmedException.new('oops', 'Oops'))
+        sign_in_user.call
       end
 
       it 'does not return success' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.success?).to eq false
+        expect(sign_in_user.success?).to eq false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.error).to eq 'Oops'
+        expect(sign_in_user.error).to eq 'Oops'
       end
 
       it 'returns needs_confirmation true' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.needs_confirmation).to eq true
+        expect(sign_in_user.needs_confirmation).to eq true
       end
     end
 
@@ -83,21 +83,19 @@ RSpec.describe Cognito::SignInUser do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_raise(Aws::CognitoIdentityProvider::Errors::PasswordResetRequiredException.new('oops', 'Oops'))
+        sign_in_user.call
       end
 
       it 'does not return success' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.success?).to eq false
+        expect(sign_in_user.success?).to eq false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.error).to eq 'Oops'
+        expect(sign_in_user.error).to eq 'Oops'
       end
 
       it 'returns need_password_reset true' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.needs_password_reset).to eq true
+        expect(sign_in_user.needs_password_reset).to eq true
       end
     end
 
@@ -105,21 +103,19 @@ RSpec.describe Cognito::SignInUser do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('oops', 'Oops'))
+        sign_in_user.call
       end
 
       it 'does not return success' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.success?).to eq false
+        expect(sign_in_user.success?).to eq false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.error).to eq I18n.t('facilities_management.users.sign_in_error')
+        expect(sign_in_user.error).to eq I18n.t('facilities_management.users.sign_in_error')
       end
 
       it 'returns need_password_reset false' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.needs_password_reset).to eq false
+        expect(sign_in_user.needs_password_reset).to eq false
       end
     end
 
@@ -129,16 +125,15 @@ RSpec.describe Cognito::SignInUser do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_return(OpenStruct.new(challenge_name: challenge_name, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => user_id_for_srp }))
+        sign_in_user.call
       end
 
       it 'does not return success' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.success?).to eq false
+        expect(sign_in_user.success?).to eq false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(email, password, cookies_disabled)
-        expect(response.errors.any?).to eq true
+        expect(sign_in_user.errors.any?).to eq true
       end
     end
   end


### PR DESCRIPTION
Ticket: [FMFR-1194](https://crowncommercialservice.atlassian.net/browse/FMFR-1194)

I have made updates to the code to prevent user enumeration which were raised in a recent IT Health Check. The changes I have made address the following issues:

- Make response times for sign in identical
- Allow users with accounts already to pass through sign up
- Make sure error message on the next page (confirm sign up)  does not inform of users existence

I have then updated the tests to make sure we are testing these changes and they don’t have any negative effects.