### PR TITLE
FMFR-1270 - Add 'User procurements' to admin dashboard

### DIFF
--- a/app/controllers/facilities_management/rm6232/admin/procurements_controller.rb
+++ b/app/controllers/facilities_management/rm6232/admin/procurements_controller.rb
@@ -1,0 +1,35 @@
+module FacilitiesManagement
+  module RM6232
+    module Admin
+      class ProcurementsController < FacilitiesManagement::Admin::FrameworkController
+        before_action :set_paginated_procurements, only: %i[index search_procurements]
+
+        def index; end
+
+        def show; end
+
+        def search_procurements
+          respond_to do |format|
+            format.js
+          end
+        end
+
+        private
+
+        def set_paginated_procurements
+          search_value = "%#{search_params[:search_value]}%".downcase
+
+          @paginated_procurements = Procurement.select(:id, :contract_name, :updated_at, :aasm_state, :contract_number)
+                                               .where('lower(contract_name) like ? or lower(contract_number) like ?', search_value, search_value)
+                                               .order(updated_at: :desc)
+                                               .page(params[:page])
+                                               .per(50)
+        end
+
+        def search_params
+          params.permit(:search_value)
+        end
+      end
+    end
+  end
+end

--- a/app/models/facilities_management/rm6232/procurement.rb
+++ b/app/models/facilities_management/rm6232/procurement.rb
@@ -34,6 +34,14 @@ module FacilitiesManagement
         @regions ||= Region.where(code: region_codes)
       end
 
+      def award_status
+        if what_happens_next?
+          [:grey, 'search only']
+        else
+          [:blue, 'awarded']
+        end
+      end
+
       aasm do
         state :what_happens_next, initial: true
       end

--- a/app/views/facilities_management/rm6232/admin/home/index.html.erb
+++ b/app/views/facilities_management/rm6232/admin/home/index.html.erb
@@ -6,29 +6,40 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-heading-m govuk-!-margin-top-5 govuk-!-margin-bottom-1"><%= t('.supplier_data') %></span>
+    <div class="govuk-grid-column-one-third">
+      <span class="govuk-heading-m govuk-!-margin-0"><%= t('.user_procurements.title') %></span>
     </div>
   </div>
   <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
   <%= ccs_account_panel_row do %>
-    <%= ccs_account_panel(t('.supplier_data'), facilities_management_rm6232_admin_supplier_data_path) do %>
-      <%= t('.manage_supplier_data') %>
+    <%= ccs_account_panel(t('.user_procurements.title'), facilities_management_rm6232_admin_procurements_path) do %>
+      <%= t('.user_procurements.details') %>
+    <% end %>
+  <% end %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <span class="govuk-heading-m govuk-!-margin-top-5 govuk-!-margin-bottom-1"><%= t('.supplier_data.title') %></span>
+    </div>
+  </div>
+  <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
+  <%= ccs_account_panel_row do %>
+    <%= ccs_account_panel(t('.supplier_data.title'), facilities_management_rm6232_admin_supplier_data_path) do %>
+      <%= t('.supplier_data.details') %>
     <% end %>
 
-    <%= ccs_account_panel(t('.audit_logs'), facilities_management_rm6232_admin_change_logs_path) do %>
-      <%= t('.view_logs') %>
+    <%= ccs_account_panel(t('.audit_logs.title'), facilities_management_rm6232_admin_change_logs_path) do %>
+      <%= t('.audit_logs.details') %>
     <% end %>
   <% end %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
-      <span class="govuk-heading-m govuk-!-margin-0"><%= t('.management_report') %></span>
+      <span class="govuk-heading-m govuk-!-margin-0"><%= t('.management_report.title') %></span>
     </div>
   </div>
   <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
   <%= ccs_account_panel_row do %>
-    <%= ccs_account_panel(t('.management_report'), facilities_management_rm6232_admin_management_reports_path) do %>
-      <%= t('.management_report_detail') %>
+    <%= ccs_account_panel(t('.management_report.title'), facilities_management_rm6232_admin_management_reports_path) do %>
+      <%= t('.management_report.details') %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/facilities_management/rm6232/admin/procurements/_procurements_table.html.erb
+++ b/app/views/facilities_management/rm6232/admin/procurements/_procurements_table.html.erb
@@ -1,0 +1,37 @@
+<% if paginated_procurements.length > 0 %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header" style="width: 25%"><%= t('.name') %></th>
+        <th scope="col" class="govuk-table__header" style="width: 25%"><%= t('.ref_number') %></th>
+        <th scope="col" class="govuk-table__header" style="width: 25%"><%= t('.date_saved') %></th>
+        <th scope="col" class="govuk-table__header" style="width: 25%"><%= t('.award_status') %></th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% paginated_procurements.each do |procurement| %>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__cell">
+            <%= link_to procurement.contract_name, '#', class: ' govuk-link--no-visited-state' %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= procurement.contract_number %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= format_date_time(procurement.updated_at) %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= govuk_tag_with_text(*procurement.award_status) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <%= paginate paginated_procurements, views_prefix: 'shared', params: { controller: 'procurements', action: 'index' } %>
+<% else %>
+  <hr class="govuk-section-break govuk-section-break--visible">
+  <p class="govuk-!-margin-top-4">
+    <%= t('.there_are_not_any') %>
+  </p>
+  <hr class="govuk-section-break govuk-section-break--visible">
+<% end %>

--- a/app/views/facilities_management/rm6232/admin/procurements/index.html.erb
+++ b/app/views/facilities_management/rm6232/admin/procurements/index.html.erb
@@ -1,0 +1,34 @@
+<% if @paginated_procurements.length > 0 %>
+  <% content_for :page_title, t('.page_title', page_number: params[:page] || 1, total_pages: @paginated_procurements.total_pages) %>
+<% else %>
+  <% content_for :page_title, t('.page_title_none') %>
+<% end %>
+
+<%= admin_breadcrumbs({ text: t('.heading') })%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t('.heading') %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row" id="procurements-search-container">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: search_procurements_facilities_management_rm6232_admin_procurements_path, method: :get, remote: true, html: { specialvalidation: true } do |f| %>
+      <%= f.label :search_value, t('.find_a_procurement'), class: 'govuk-label govuk-label--m' %>
+      <div class="govuk-hint" id="procurements-search-hint">
+        <%= t('.enter_a_value') %>
+      </div>
+      <%= f.text_field :search_value, class: 'govuk-input govuk-!-width-three-quarters govuk-!-margin-right-2', type: 'search', aria: { describedby: 'procurements-search-hint' } %>
+      <%= f.submit t('.search'), class: 'govuk-button govuk-button--secondary', id: 'procurements-search-button' %>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full" id="procurements-table">
+    <%= render partial: 'procurements_table', locals: { paginated_procurements: @paginated_procurements } %>
+  </div>
+</div>

--- a/app/views/facilities_management/rm6232/admin/procurements/search_procurements.js.erb
+++ b/app/views/facilities_management/rm6232/admin/procurements/search_procurements.js.erb
@@ -1,0 +1,1 @@
+$("#procurements-table").html("<%= escape_javascript(render(partial: 'procurements_table', locals: { paginated_procurements: @paginated_procurements })) %>"); 

--- a/app/views/facilities_management/rm6232/procurements/index.html.erb
+++ b/app/views/facilities_management/rm6232/procurements/index.html.erb
@@ -1,12 +1,14 @@
 <% content_for :page_title, t('.heading') %>
 
-<div class="govuk-grid-column-full">
-  <h1 class="govuk-heading-xl">
-    <%= t('.heading') %>
-  </h1>
-  <p class="govuk-body">
-    <%= t('.description') %>
-  </p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t('.heading') %>
+    </h1>
+    <p class="govuk-body">
+      <%= t('.description') %>
+    </p>
+  </div>
 </div>
 
 <div class="govuk-grid-row">

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -260,13 +260,33 @@ en:
             you_can_view_upload_html: You can view the %{link_url} in the 'Manage supplier data' section of the portal.
         home:
           index:
-            audit_logs: Supplier data change log
+            audit_logs:
+              details: View logs of all changes made to the supplier data by the admin team
+              title: Supplier data change log
             header: RM6232 administration dashboard
-            manage_supplier_data: Manage the supplier's details and their lot data
-            management_report: Management reports
-            management_report_detail: Download the management data in CSV format
-            supplier_data: Supplier data
-            view_logs: View logs of all changes made to the supplier data by the admin team
+            management_report:
+              details: Download the management data in CSV format
+              title: Management reports
+            supplier_data:
+              details: Manage the supplier's details and their lot data
+              title: Supplier data
+            user_procurements:
+              details: View and update user's procurements to add details of award
+              title: User procurements
+        procurements:
+          index:
+            enter_a_value: Enter a name or reference number to find a procurement
+            find_a_procurement: Find a procurement
+            heading: User procurements
+            page_title: User procurements (Page %{page_number} of %{total_pages})
+            page_title_none: User procurements
+            search: Search
+          procurements_table:
+            award_status: Award status
+            date_saved: Date saved
+            name: Procurement name
+            ref_number: Ref number
+            there_are_not_any: There are no procurements that match your search
         supplier_data:
           index:
             by_going_to_html: You can bulk upload the supplier data by going to '%{manage_data_link}'.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -211,6 +211,11 @@ Rails.application.routes.draw do
           get '/:change_type', action: :show, as: :show
         end
         resources :supplier_data_snapshots, path: 'supplier-data-snapshots', only: %i[new create]
+        resources :procurements, only: %i[index show] do
+          collection do
+            get :search_procurements, action: :search_procurements
+          end
+        end
       end
     end
 

--- a/db/migrate/20220914142228_add_index_on_searched_values.rb
+++ b/db/migrate/20220914142228_add_index_on_searched_values.rb
@@ -1,0 +1,6 @@
+class AddIndexOnSearchedValues < ActiveRecord::Migration[6.0]
+  def change
+    add_index :facilities_management_rm6232_procurements, 'lower(contract_name)', using: :btree, name: 'index_fm_rm6232_procurements_on_lower_contract_name'
+    add_index :facilities_management_rm6232_procurements, 'lower(contract_number)', using: :btree, name: 'index_fm_rm6232_procurements_on_lower_contract_number'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_14_120005) do
+ActiveRecord::Schema.define(version: 2022_09_14_142228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -418,6 +418,8 @@ ActiveRecord::Schema.define(version: 2022_09_14_120005) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "contract_number"
+    t.index "lower((contract_name)::text)", name: "index_fm_rm6232_procurements_on_lower_contract_name"
+    t.index "lower((contract_number)::text)", name: "index_fm_rm6232_procurements_on_lower_contract_number"
     t.index ["user_id", "contract_name"], name: "index_rm6232_procurement_name_and_user_id", unique: true
     t.index ["user_id"], name: "index_fm_rm6232_procurements_on_user_id"
   end

--- a/features/accessibility/facilities_management/rm6232/admin/users_procurements.feature
+++ b/features/accessibility/facilities_management/rm6232/admin/users_procurements.feature
@@ -1,0 +1,16 @@
+@accessibility @javascript
+Feature: User procurements - accessibility
+
+  Background: Admin signs in
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+
+  Scenario: User procurements page - no procurements
+    And I click on 'User procurements'
+    Then I am on the 'User procurements' page
+    Then the page should be axe clean
+
+  Scenario: User procurements page - multiple procurements
+    Given there are 100 procurements
+    And I click on 'User procurements'
+    Then I am on the 'User procurements' page
+    Then the page should be axe clean

--- a/features/facilities_management/rm6232/admin/user_procurements/user_procurements.feature
+++ b/features/facilities_management/rm6232/admin/user_procurements/user_procurements.feature
@@ -1,0 +1,53 @@
+@pipeline @javascript
+Feature: User procurements - index page
+
+  Background: Admin signs in and navigates to the user procurements page
+    Given I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I have a procurement with the name 'Procurement number 1'
+    And I have a procurement with the name 'Procurement number 2'
+    And I have a procurement with the name 'Procurement number 3'
+    And I have a procurement with the name 'Procurement number 4'
+    And I have a procurement with the name 'Procurement number 5'
+    And I have a procurement with the name 'Procurement number 6'
+    And I have a procurement with the name 'Procurement number 7'
+    And I have a procurement with the name 'Procurement number 8'
+    And I have a procurement with the name 'Procurement number 9'
+    And I have a procurement with the name 'Procurement number 10'
+    And I click on 'User procurements'
+    Then I am on the 'User procurements' page
+
+  Scenario: User procurements search
+    And I should see the following user procurements listed:
+      | Procurement number 10 |
+      | Procurement number 9  |
+      | Procurement number 8  |
+      | Procurement number 7  |
+      | Procurement number 6  |
+      | Procurement number 5  |
+      | Procurement number 4  |
+      | Procurement number 3  |
+      | Procurement number 2  |
+      | Procurement number 1  |
+    Then I enter "Procurement number 1" for the procurement search
+    And I should see the following user procurements listed:
+      | Procurement number 10 |
+      | Procurement number 1  |
+    Then I enter "a random string" for the procurement search
+    And the following content should be displayed on the page:
+      | There are no procurements that match your search  |
+    Then I enter "" for the procurement search
+    And I should see the following user procurements listed:
+      | Procurement number 10 |
+      | Procurement number 9  |
+      | Procurement number 8  |
+      | Procurement number 7  |
+      | Procurement number 6  |
+      | Procurement number 5  |
+      | Procurement number 4  |
+      | Procurement number 3  |
+      | Procurement number 2  |
+      | Procurement number 1  |
+
+  Scenario: Return links work user procurements page
+    Given I click on 'Home'
+    Then I am on the 'RM6232 administration dashboard' page

--- a/features/step_definitions/facilities_management/procurement_steps.rb
+++ b/features/step_definitions/facilities_management/procurement_steps.rb
@@ -66,6 +66,10 @@ Given('I have a completed procurement for further information named {string}') d
   create(FRMAEOWRK_AND_STATE_TO_FACTORY[@framework][:further_information], user: @user, contract_name: contract_name)
 end
 
+Given('there are {int} procurements') do |number_of_procurements|
+  create_list(FRMAEOWRK_AND_STATE_TO_FACTORY[@framework][:initial], number_of_procurements)
+end
+
 FRMAEOWRK_AND_STATE_TO_FACTORY = {
   'RM3830' => {
     initial: :facilities_management_rm3830_procurement,

--- a/features/step_definitions/facilities_management/rm6232/admin_steps.rb
+++ b/features/step_definitions/facilities_management/rm6232/admin_steps.rb
@@ -208,6 +208,19 @@ Then('the upload was done by {string}') do |email|
   expect(admin_page.uploaded_by_email).to have_content(email)
 end
 
+Then('I enter {string} for the procurement search') do |procurement_name|
+  admin_page.user_procurements.input.fill_in with: "#{procurement_name}\n"
+  admin_page.user_procurements.search.click
+end
+
+Then('I should see the following user procurements listed:') do |procurement_names|
+  expect(admin_page.user_procurements.names.length).to eq(procurement_names.raw.flatten.length)
+
+  admin_page.user_procurements.names.zip(procurement_names.raw.flatten).each do |element, value|
+    expect(element).to have_content(value)
+  end
+end
+
 def core_services(lot_number)
   FacilitiesManagement::RM6232::WorkPackage.selectable.map { |work_package| work_package.supplier_services.where(**LOT_NUMBER_TO_QUERY_PARAMS[lot_number]).select(&:core) }.flatten
 end

--- a/features/support/pages/rm6232/admin.rb
+++ b/features/support/pages/rm6232/admin.rb
@@ -90,5 +90,11 @@ module Pages::RM6232
       element :'To month', '#facilities_management_rm6232_admin_management_report_end_date_mm'
       element :'To year', '#facilities_management_rm6232_admin_management_report_end_date_yyyy'
     end
+
+    section :user_procurements, '#main-content' do
+      element :input, '#search_value'
+      element :search, '#procurements-search-button'
+      elements :names, '#procurements-table > table > tbody > tr > th'
+    end
   end
 end

--- a/spec/controllers/facilities_management/rm6232/admin/procurements_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/procurements_controller_spec.rb
@@ -1,0 +1,148 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::RM6232::Admin::ProcurementsController, type: :controller do
+  let(:default_params) { { service: 'facilities_management/admin', framework: 'RM6232' } }
+
+  login_fm_admin
+
+  describe 'GET index' do
+    context 'when not logged in as fm admin' do
+      login_fm_buyer
+
+      it 'redirects to the not permitted page' do
+        get :index
+
+        expect(response).to redirect_to '/facilities-management/RM6232/admin/not-permitted'
+      end
+    end
+
+    context 'when the framework is not recognised' do
+      let(:default_params) { { service: 'facilities_management/admin', framework: 'RM007' } }
+
+      before { get :index }
+
+      it 'renders the unrecognised framework page with the right http status' do
+        expect(response).to render_template('home/unrecognised_framework')
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'sets the framework variables' do
+        expect(assigns(:unrecognised_framework)).to eq 'RM007'
+        expect(controller.params[:framework]).to eq FacilitiesManagement::Framework.default_framework
+      end
+    end
+
+    context 'when logged in as fm admin' do
+      before do
+        create_list(:facilities_management_rm6232_procurement_what_happens_next, 75)
+
+        get :index, params: { page: page }
+      end
+
+      context 'and the page is nil' do
+        let(:page) { nil }
+
+        it 'renders the new page and sets the paginated procurements to be the first 50' do
+          expect(response).to render_template(:index)
+
+          expect(assigns(:paginated_procurements).length).to eq(50)
+        end
+      end
+
+      context 'and the page is 1' do
+        let(:page) { 1 }
+
+        it 'renders the new page and sets the paginated procurements to be the first 50' do
+          expect(response).to render_template(:index)
+
+          expect(assigns(:paginated_procurements).length).to eq(50)
+        end
+      end
+
+      context 'and the page is 2' do
+        let(:page) { 2 }
+
+        it 'renders the new page and sets the paginated procurements to be the last 25' do
+          expect(response).to render_template(:index)
+
+          expect(assigns(:paginated_procurements).length).to eq(25)
+        end
+      end
+
+      context 'and the page is 3' do
+        let(:page) { 3 }
+
+        it 'renders the new page and sets 0 paginated procurements' do
+          expect(response).to render_template(:index)
+
+          expect(assigns(:paginated_procurements).length).to be_zero
+        end
+      end
+    end
+  end
+
+  describe 'GET search_procurements' do
+    let(:contract_name) { Faker::Name.unique.name }
+    let(:contract_number) { 'RM6232-999999-2022' }
+    let(:paginated_procurements) { assigns(:paginated_procurements) }
+
+    before do
+      create_list(:facilities_management_rm6232_procurement_what_happens_next, 10)
+      create(:facilities_management_rm6232_procurement_what_happens_next, contract_name: contract_name, contract_number: contract_number)
+
+      get :search_procurements, params: { search_value: search_value }, xhr: true
+    end
+
+    context 'when the search_value param is empty' do
+      let(:search_value) { nil }
+
+      it 'renders the search_procurements page' do
+        expect(response).to render_template(:search_procurements)
+      end
+
+      it 'has the full list' do
+        expect(paginated_procurements.length).to eq(11)
+      end
+    end
+
+    context 'when the search_value param is my procurements name' do
+      let(:search_value) { contract_name }
+
+      it 'renders the search_procurements page' do
+        expect(response).to render_template(:search_procurements)
+      end
+
+      it 'has a shortened list with my procurement' do
+        expect(paginated_procurements.length).to eq(1)
+
+        expect(paginated_procurements.first.contract_name).to eq contract_name
+      end
+    end
+
+    context 'when the search_value param is my contracts reference number' do
+      let(:search_value) { contract_number }
+
+      it 'renders the search_procurements page' do
+        expect(response).to render_template(:search_procurements)
+      end
+
+      it 'has a shortened list with my procurement' do
+        expect(paginated_procurements.length).to eq(1)
+
+        expect(paginated_procurements.first.contract_name).to eq contract_name
+      end
+    end
+
+    context 'when the search_value param is a random string' do
+      let(:search_value) { Faker::Name.unique.name }
+
+      it 'renders the search_procurements page' do
+        expect(response).to render_template(:search_procurements)
+      end
+
+      it 'has no procurements' do
+        expect(assigns(:paginated_procurements).length).to be_zero
+      end
+    end
+  end
+end

--- a/spec/models/facilities_management/rm6232/procurement_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_spec.rb
@@ -409,4 +409,24 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement, type: :model do
       end
     end
   end
+
+  describe 'award_status' do
+    let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, aasm_state: state) }
+
+    context 'when the state is what_happens_next' do
+      let(:state) { 'what_happens_next' }
+
+      it 'returns grey and search only' do
+        expect(procurement.award_status).to eq [:grey, 'search only']
+      end
+    end
+
+    context 'when the state is not what_happens_next' do
+      let(:state) { 'not_what_happens_next' }
+
+      it 'returns blue and awarded' do
+        expect(procurement.award_status).to eq [:blue, 'awarded']
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: [FMFR-1270](https://crowncommercialservice.atlassian.net/browse/FMFR-1270)

We are adding a new admin section to the tool to allow for the FM category team to update procurement award states. This PR pertains to the first part of that which is to create an area where the admin team can see and access the procurements, the ‘User procurements’ section.

I have also added specs and features for these changes.