### PR TITLE
FMFR-1314 - Add backend for managing users

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -41,19 +41,17 @@ class Ability
     can :manage, FacilitiesManagement::Admin
   end
 
+  def allow_list_specific_auth(user)
+    if user.has_role?(:ccs_user_admin)
+      can :manage, AllowedEmailDomain
+    elsif user.has_role?(:allow_list_access)
+      can :read, AllowedEmailDomain
+    end
+  end
+
   def super_admin_specific_auth(user)
     return unless user.has_role?(:ccs_developer)
 
     can :manage, FacilitiesManagement::Framework
-  end
-
-  def allow_list_specific_auth(user)
-    return unless user.has_role?(:allow_list_access)
-
-    if user.has_role?(:ccs_employee)
-      can :manage, AllowedEmailDomain
-    else
-      can :read, AllowedEmailDomain
-    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,7 +72,7 @@ class User < ApplicationRecord
 
   # declare the valid roles -- do not change the order if you add more
   # roles later, always append them at the end!
-  roles :buyer, :supplier, :ccs_employee, :ccs_admin, :st_access, :fm_access, :ls_access, :mc_access, :allow_list_access, :ccs_developer
+  roles :buyer, :supplier, :ccs_employee, :ccs_admin, :st_access, :fm_access, :ls_access, :mc_access, :allow_list_access, :ccs_developer, :ccs_user_admin
 
   attr_accessor :password, :password_confirmation
 

--- a/app/services/cognito/admin/roles.rb
+++ b/app/services/cognito/admin/roles.rb
@@ -1,0 +1,85 @@
+module Cognito
+  module Admin
+    class Roles
+      attr_reader :access, :available_roles
+
+      attr_writer :roles, :service_access
+
+      def initialize(access, roles, service_access)
+        @access = access
+        @roles = (roles || []).compact
+        @service_access = (service_access || []).compact
+        @available_roles = self.class.find_available_roles(access)
+      end
+
+      def role_selection_valid
+        return :role_selection_required if @roles.empty?
+
+        return :invalid_role_selection unless @roles.all? { |role| @available_roles.include?(role) }
+      end
+
+      def service_access_selection_valid
+        return :invalid_service_access_selection unless @service_access.all? { |service_access| SERVICE_ROLES_ACCESS.include?(service_access) }
+
+        return :service_access_selection_required if (@roles.include?('buyer') || @roles.include?('ccs_employee')) && @service_access.empty?
+      end
+
+      def combine_roles
+        @service_access + @roles
+      end
+
+      def admin_roles_present?
+        @roles.any? && @roles != ['buyer']
+      end
+
+      def application_role_locations
+        return %i[main] if @roles.exclude?('buyer') && @roles.exclude?('ccs_employee')
+
+        application_locations = []
+
+        application_locations << :main if MAIN_SERVICE_ROLE_ACCESS.any? { |role| @service_access.include?(role) }
+        application_locations << :legacy if LEGACY_SERVICE_ROLE_ACCESS.any? { |role| @service_access.include?(role) }
+
+        application_locations
+      end
+
+      def self.get_roles_and_service_access_from_cognito_roles(cognito_roles)
+        roles = SUPER_ADMIN_ROLE_ACCESS & cognito_roles
+        service_access = SERVICE_ROLES_ACCESS & cognito_roles
+
+        [roles, service_access]
+      end
+
+      def self.current_user_access(current_user_ability)
+        if current_user_ability.can? :manage, FacilitiesManagement::Framework
+          :super_admin
+        elsif current_user_ability.can? :manage, AllowedEmailDomain
+          :user_admin
+        elsif current_user_ability.can? :read, AllowedEmailDomain
+          :user_support
+        end
+      end
+
+      def self.find_available_roles(access)
+        case access
+        when :super_admin
+          SUPER_ADMIN_ROLE_ACCESS
+        when :user_admin
+          USER_ADMIN_ROLE_ACCESS
+        when :user_support
+          USER_SUPPORT_ROLE_ACCESS
+        else
+          []
+        end
+      end
+
+      MAIN_SERVICE_ROLE_ACCESS = %w[fm_access].freeze
+      LEGACY_SERVICE_ROLE_ACCESS = %w[st_access ls_access mc_access].freeze
+      SERVICE_ROLES_ACCESS = (MAIN_SERVICE_ROLE_ACCESS + LEGACY_SERVICE_ROLE_ACCESS).freeze
+
+      USER_SUPPORT_ROLE_ACCESS = %w[buyer].freeze
+      USER_ADMIN_ROLE_ACCESS = (USER_SUPPORT_ROLE_ACCESS + %w[ccs_employee allow_list_access]).freeze
+      SUPER_ADMIN_ROLE_ACCESS = (USER_ADMIN_ROLE_ACCESS + %w[ccs_user_admin]).freeze
+    end
+  end
+end

--- a/app/services/cognito/admin/user.rb
+++ b/app/services/cognito/admin/user.rb
@@ -1,0 +1,162 @@
+module Cognito
+  module Admin
+    class User < BaseService
+      include ActiveModel::Validations
+      include ActiveModel::Validations::Callbacks
+
+      attr_reader :email, :account_status, :confirmation_status, :mfa_enabled, :roles, :service_access, :cognito_roles, :telephone_number
+
+      private
+
+      attr_reader :origional_groups
+      attr_writer :email, :telephone_number, :account_status, :confirmation_status
+      attr_accessor :cognito_uuid
+
+      public
+
+      validates :email, presence: true, format: { with: /\A[^A-Z]*\z/ }, on: :create
+      validate :domain_in_allow_list, if: -> { @cognito_roles.access == :user_support && email.present? }, on: :create
+
+      validates :account_status, inclusion: { in: [true, false] }, on: :account_status
+
+      validates :telephone_number, format: { with: /\A07\d{9}\z/ }, if: :telephone_number_required?, on: %i[create telephone_number]
+
+      validates :roles, length: { is: 1 }, on: %i[select_role create]
+      validate :validate_role, on: %i[create roles select_role]
+      validate :can_set_admin_role, on: :roles
+
+      validates :service_access, length: { minimum: 1 }, on: :service_access
+      validate :validate_service_access, on: %i[create service_access]
+
+      with_options on: :mfa_enabled do
+        validate :can_set_mfa
+        validates :mfa_enabled, inclusion: { in: [true, false] }
+        validate :can_disable_mfa, unless: -> { mfa_enabled }
+      end
+
+      def self.find(current_user_access, cognito_uuid)
+        new(current_user_access, UserClientInterface.find_user_from_cognito_uuid(cognito_uuid))
+      end
+
+      def self.search(email)
+        return { users: [], error: 'You must enter an email address' } if email.blank?
+
+        UserClientInterface.find_users_from_email(email.squish.downcase)
+      end
+
+      def initialize(current_user_access, attributes = {})
+        assign_attributes(**attributes)
+
+        return unless @error.nil?
+
+        @cognito_roles = Roles.new(current_user_access, @roles, @service_access)
+        @origional_groups = @cognito_roles.combine_roles
+      end
+
+      def assign_attributes(**new_attributes)
+        raise ArgumentError, 'When assigning attributes, you must pass a hash as an argument.' unless new_attributes.respond_to?(:stringify_keys)
+        return if new_attributes.empty?
+
+        attributes = new_attributes.stringify_keys
+
+        attributes.each do |key, value|
+          setter = :"#{key}="
+
+          raise ActiveRecord::UnknownAttributeError.new(self, key) unless respond_to?(setter, true)
+
+          send(setter, value)
+        end
+      end
+
+      def create
+        return false unless valid?(:create)
+
+        error = UserClientInterface.create_user_and_return_errors(cognito_attributes, cognito_roles.admin_roles_present?)
+
+        errors.add(:base, error) if error
+
+        error.nil?
+      end
+
+      def update(method)
+        return false unless valid?(method)
+
+        error = UserClientInterface.update_user_and_return_errors(cognito_uuid, cognito_attributes, method)
+
+        errors.add(method, error) if error
+
+        error.nil?
+      end
+
+      def success?
+        errors.none?
+      end
+
+      private
+
+      # Methods for assigning values to certain attributes
+      %i[account_status mfa_enabled].each do |attribute|
+        define_method :"#{attribute}=" do |value|
+          instance_variable_set("@#{attribute}", ActiveModel::Type::Boolean.new.cast(value))
+        end
+      end
+
+      %i[roles service_access].each do |attribute|
+        define_method :"#{attribute}=" do |value|
+          value = (value || []).compact
+
+          @cognito_roles&.public_send("#{attribute}=", value)
+          instance_variable_set("@#{attribute}", value)
+        end
+      end
+
+      # Validations for the attributes
+      def domain_in_allow_list
+        return if AllowedEmailDomain.new(email_domain: email.split('@').last).domain_in_allow_list?
+
+        errors.add(:email, :not_on_allow_list)
+      end
+
+      def telephone_number_required?
+        return true if telephone_number.present? || validation_context == :telephone_number
+
+        cognito_roles.admin_roles_present?
+      end
+
+      def validate_role
+        role_error = cognito_roles.role_selection_valid
+
+        errors.add(:roles, role_error) if role_error
+      end
+
+      def validate_service_access
+        service_access_error = cognito_roles.service_access_selection_valid
+
+        errors.add(:service_access, service_access_error) if service_access_error
+      end
+
+      def can_set_mfa
+        errors.add(:mfa_enabled, :telephone_number_required) if telephone_number.blank?
+      end
+
+      def can_disable_mfa
+        errors.add(:mfa_enabled, :cannot_disable_mfa) if cognito_roles.admin_roles_present?
+      end
+
+      def can_set_admin_role
+        errors.add(:roles, :mfa_required) if !mfa_enabled && cognito_roles.admin_roles_present?
+      end
+
+      def cognito_attributes
+        {
+          email: email,
+          account_status: account_status,
+          telephone_number: telephone_number,
+          groups: cognito_roles.combine_roles,
+          origional_groups: origional_groups,
+          mfa_enabled: mfa_enabled
+        }
+      end
+    end
+  end
+end

--- a/app/services/cognito/admin/user_client_interface.rb
+++ b/app/services/cognito/admin/user_client_interface.rb
@@ -1,0 +1,267 @@
+# rubocop:disable Metrics/ModuleLength
+module Cognito
+  module Admin
+    module UserClientInterface
+      class << self
+        def find_user_from_cognito_uuid(cognito_uuid)
+          client = new_client
+
+          attributes = { cognito_uuid: cognito_uuid }
+
+          attributes.merge(find_user_in_cognito(client, cognito_uuid))
+        end
+
+        def create_user_and_return_errors(attributes, enable_mfa)
+          client = new_client
+
+          creat_user_resp = create_cognito_user(client, attributes, enable_mfa)
+          cognito_uuid = creat_user_resp.user['username']
+          add_user_mfa(client, cognito_uuid) if enable_mfa
+          add_user_to_groups(client, cognito_uuid, attributes)
+
+          nil
+        rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+          e.message
+        end
+
+        def find_users_from_email(email)
+          client = new_client
+
+          list_users_resp = client.list_users({
+                                                user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+                                                attributes_to_get: ['email'],
+                                                filter: "email ^= \"#{email}\""
+                                              })
+
+          { users: get_users_attributes_from_response(list_users_resp) }
+        rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+          { users: [], error: e.message }
+        end
+
+        def update_user_and_return_errors(cognito_uuid, attributes, method)
+          client = new_client
+
+          case method
+          when :account_status
+            update_enabled_status(client, cognito_uuid, attributes)
+          when :telephone_number
+            update_telephone_number(client, cognito_uuid, attributes)
+          when :mfa_enabled
+            update_mfa_status(client, cognito_uuid, attributes)
+          when :roles, :service_access
+            update_groups(client, cognito_uuid, attributes)
+          end
+
+          nil
+        rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+          e.message
+        end
+
+        private
+
+        def new_client
+          Aws::CognitoIdentityProvider::Client.new(region: ENV['COGNITO_AWS_REGION'])
+        end
+
+        # Methods relating to creating a user
+        def create_cognito_user(client, attributes, enable_mfa)
+          client.admin_create_user(**determine_user_attributes(attributes, enable_mfa))
+        end
+
+        def determine_user_attributes(attributes, enable_mfa)
+          user_attributes = {
+            user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+            username: attributes[:email],
+            user_attributes: [
+              {
+                name: 'email',
+                value: attributes[:email]
+              },
+              {
+                name: 'email_verified',
+                value: true
+              }
+            ],
+            desired_delivery_mediums: ['EMAIL']
+          }
+
+          if enable_mfa
+            user_attributes[:user_attributes] << {
+              name: 'phone_number',
+              value: formatted_phone_number(attributes[:telephone_number])
+            }
+          end
+
+          user_attributes
+        end
+
+        def add_user_mfa(client, cognito_uuid)
+          client.admin_set_user_mfa_preference(
+            sms_mfa_settings: {
+              enabled: true,
+              preferred_mfa: true,
+            },
+            user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+            username: cognito_uuid,
+          )
+        end
+
+        def add_user_to_groups(client, cognito_uuid, attributes)
+          attributes[:groups].each do |group|
+            client.admin_add_user_to_group(
+              user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+              username: cognito_uuid,
+              group_name: group.to_s
+            )
+          end
+        end
+
+        # Methods relating to finding users
+        def get_users_attributes_from_response(resp)
+          users = resp.users.map do |user|
+            {
+              cognito_uuid: user.username,
+              email: get_attribute_value_from_user_attributes(user.attributes, 'email'),
+              account_status: user.enabled
+            }
+          end
+
+          users.sort_by { |user| user[:email] }
+        end
+
+        # Methods relating to finding a user
+        def find_user_in_cognito(client, cognito_uuid)
+          get_user_resp = client.admin_get_user({
+                                                  user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+                                                  username: cognito_uuid
+                                                })
+
+          attributes = get_user_attributes_from_response(get_user_resp)
+
+          get_groups_resp = client.admin_list_groups_for_user({
+                                                                user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+                                                                username: cognito_uuid
+                                                              })
+
+          attributes[:roles], attributes[:service_access] = Roles.get_roles_and_service_access_from_cognito_roles(get_groups_resp.groups.map(&:group_name))
+
+          attributes
+        rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+          { error: e.message }
+        end
+
+        def get_user_attributes_from_response(resp)
+          attributes = {}
+
+          attributes[:email] = get_attribute_value_from_user_attributes(resp.user_attributes, 'email')
+          attributes[:telephone_number] = extract_telephone_number_from_response(get_attribute_value_from_user_attributes(resp.user_attributes, 'phone_number'))
+          attributes[:account_status] = resp.enabled
+          attributes[:confirmation_status] = resp.user_status
+          attributes[:mfa_enabled] = resp.user_mfa_setting_list&.include?('SMS_MFA') || false
+
+          attributes
+        end
+
+        def extract_telephone_number_from_response(telephone_number)
+          telephone_number ||= ''
+
+          if telephone_number.starts_with?('+44')
+            "0#{telephone_number[3..]}"
+          else
+            telephone_number
+          end
+        end
+
+        def find_user_in_cognito_debug
+          attributes = {}
+
+          attributes[:email] = 'tim.south@email.com'
+          # attributes[:telephone_number] = '07123456789'
+          attributes[:telephone_number] = ''
+          attributes[:account_status] = true
+          attributes[:confirmation_status] = 'CONFIRMED'
+          attributes[:mfa_enabled] = false
+          # attributes[:roles] = ['buyer', 'ccs_user_admin', 'ccs_employee']
+          attributes[:roles] = ['buyer']
+          attributes[:service_access] = ['fm_access', 'st_access']
+
+          attributes
+        end
+
+        # Methods relating to updating the user
+        def update_enabled_status(client, cognito_uuid, attributes)
+          if attributes[:account_status]
+            client.admin_enable_user(
+              user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+              username: cognito_uuid
+            )
+          else
+            client.admin_disable_user(
+              user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+              username: cognito_uuid
+            )
+          end
+        end
+
+        def update_telephone_number(client, cognito_uuid, attributes)
+          client.admin_update_user_attributes(
+            user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+            username: cognito_uuid,
+            user_attributes: [
+              {
+                name: 'phone_number',
+                value: formatted_phone_number(attributes[:telephone_number])
+              },
+              {
+                name: 'phone_number_verified',
+                value: 'true'
+              }
+            ]
+          )
+        end
+
+        def update_mfa_status(client, cognito_uuid, attributes)
+          client.admin_set_user_mfa_preference(
+            user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+            username: cognito_uuid,
+            sms_mfa_settings: {
+              enabled: attributes[:mfa_enabled],
+              preferred_mfa: attributes[:mfa_enabled],
+            }
+          )
+        end
+
+        def update_groups(client, cognito_uuid, attributes)
+          groups_to_add = attributes[:groups] - attributes[:origional_groups]
+          groups_to_remove = attributes[:origional_groups] - attributes[:groups]
+
+          groups_to_remove.each do |group|
+            client.admin_remove_user_from_group(
+              user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+              username: cognito_uuid,
+              group_name: group.to_s
+            )
+          end
+
+          groups_to_add.each do |group|
+            client.admin_add_user_to_group(
+              user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+              username: cognito_uuid,
+              group_name: group.to_s
+            )
+          end
+        end
+
+        # Shared methods
+        def formatted_phone_number(telephone_number)
+          "+44#{telephone_number[1..]}"
+        end
+
+        def get_attribute_value_from_user_attributes(user_attributes, attribute)
+          user_attributes.find { |user_attribute| user_attribute.name == attribute }&.value
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/ModuleLength

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,12 +3,6 @@ en:
   activemodel:
     errors:
       models:
-        allowed_email_domain:
-          attributes:
-            email_domain:
-              blank: Enter an email domain
-              invalid: The email domain can only contain letters, numbers, hyphens or full stops
-              taken: The email domain is already in the Allow list
         cognito/cog_forgot_password_request:
           attributes:
             please_enter_a_valid_email_address: You must provide your email address in the correct format, like name@example.com
@@ -346,45 +340,6 @@ en:
     unit:
       one: company
       other: companies
-  crown_marketplace:
-    allow_list:
-      allow_list_table:
-        email_domain: Email domain
-        no_email_domains_found: No email domains found
-        remove: Remove
-      delete:
-        are_you_sure: Are you sure you want to remove '%{email_domain}' from the Allow list?
-        page_title: Delete email domain
-        re_add: The email domain can be added again at a later date
-        remove: Remove
-        return_to_allow_list: Return to the allow list
-      index:
-        add_new_email_domain: Add a new email domain
-        added: Email domain added
-        enter_an_email_domain: Enter an email domain and click 'Search' to see if it is in the Allow list.
-        facilities_management: Facilities Management
-        find_an_email_domain: Find an email domain
-        heading_title: Allow list
-        in_order_to: In order to create an account for three of the Crown Marketplace services, the user must use an email which has a domain contained within this list.
-        legal_services: Legal Services
-        management_consultancy: Management Consultancy
-        not_in_allow_list: The email domain could not be found in the Allow list
-        removed: Email domain removed
-        search: Search
-        the_four_Services_are: 'The three Crown Marketplace services are:'
-        was_added: "'%{email_domain}' was added to the allow list"
-        was_removed: "'%{email_domain}' was removed from the allow list"
-        you_can_add: You can add a new email domain by clicking the 'Add a new email domain' button.
-      new:
-        email_domain_hint: For example, the email domain for 'example@crowncommercial.gov.uk' would be 'crowncommercial.gov.uk'
-        email_domain_label: Enter a new email domain for the Allow list
-        email_domain_must: 'The new email domain cannot already be in the allow list and it can only contain the following:'
-        email_domain_must_1: letters
-        email_domain_must_2: numbers
-        email_domain_must_3: hyphen (-) or full stop (.)
-        heading: Add an email domain
-        return_to_allow_list: Return to the allow list
-        save_and_continue: Save and continue
   errors:
     contact_ccs:
       contact_ccs_html: "%{link} if you believe you are seeing this message in error."

--- a/config/locales/views/crown_marketplace.en.yml
+++ b/config/locales/views/crown_marketplace.en.yml
@@ -1,0 +1,69 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        allowed_email_domain:
+          attributes:
+            email_domain:
+              blank: Enter an email domain
+              invalid: The email domain can only contain letters, numbers, hyphens or full stops
+              taken: The email domain is already in the Allow list
+        cognito/admin/user:
+          attributes:
+            email:
+              blank: Enter an email address in the correct format, like name@example.com
+              invalid: Email address cannot contain any capital letters
+              not_on_allow_list: Email domain is not in the allow list
+            mfa_enabled:
+              telephone_number_required: The telephone number of the user must be set to update the MFA configuration
+            roles:
+              invalid_role_selection: You do not have the ability to create users with these roles
+              mfa_required: You must enable MFA for this user to add these admin roles
+              role_selection_required: Select a role for the user
+              wrong_length: Select one role for the user
+            service_access:
+              invalid_service_access_selection: You must select the service access for the user from this list
+              service_access_selection_required: You must select the service access for the user if they have the buyer or service admin role
+              too_short: You must select the service access for the user from this list
+            telephone_number:
+              invalid: Enter a UK mobile telephone number, for example 07700900982
+  crown_marketplace:
+    allow_list:
+      allow_list_table:
+        email_domain: Email domain
+        no_email_domains_found: No email domains found
+        remove: Remove
+      delete:
+        are_you_sure: Are you sure you want to remove '%{email_domain}' from the Allow list?
+        page_title: Delete email domain
+        re_add: The email domain can be added again at a later date
+        remove: Remove
+        return_to_allow_list: Return to the allow list
+      index:
+        add_new_email_domain: Add a new email domain
+        added: Email domain added
+        enter_an_email_domain: Enter an email domain and click 'Search' to see if it is in the Allow list.
+        facilities_management: Facilities Management
+        find_an_email_domain: Find an email domain
+        heading_title: Allow list
+        in_order_to: In order to create an account for three of the Crown Marketplace services, the user must use an email which has a domain contained within this list.
+        legal_services: Legal Services
+        management_consultancy: Management Consultancy
+        not_in_allow_list: The email domain could not be found in the Allow list
+        removed: Email domain removed
+        search: Search
+        the_four_Services_are: 'The three Crown Marketplace services are:'
+        was_added: "'%{email_domain}' was added to the allow list"
+        was_removed: "'%{email_domain}' was removed from the allow list"
+        you_can_add: You can add a new email domain by clicking the 'Add a new email domain' button.
+      new:
+        email_domain_hint: For example, the email domain for 'example@crowncommercial.gov.uk' would be 'crowncommercial.gov.uk'
+        email_domain_label: Enter a new email domain for the Allow list
+        email_domain_must: 'The new email domain cannot already be in the allow list and it can only contain the following:'
+        email_domain_must_1: letters
+        email_domain_must_2: numbers
+        email_domain_must_3: hyphen (-) or full stop (.)
+        heading: Add an email domain
+        return_to_allow_list: Return to the allow list
+        save_and_continue: Save and continue

--- a/spec/services/cognito/admin/roles_spec.rb
+++ b/spec/services/cognito/admin/roles_spec.rb
@@ -1,0 +1,739 @@
+require 'rails_helper'
+
+RSpec.describe Cognito::Admin::Roles do
+  let(:cognito_roles) { described_class.new(user_access, roles, service_access) }
+
+  let(:user_access) { :super_admin }
+  let(:roles) { [] }
+  let(:service_access) { [] }
+
+  describe 'validations' do
+    # rubocop:disable RSpec/NestedGroups
+    context 'when validating the role selection' do
+      let(:result) { cognito_roles.role_selection_valid }
+
+      context 'and the current user is an user_support user' do
+        let(:user_access) { :user_support }
+
+        context 'and no roles are given' do
+          it 'returns :role_selection_required' do
+            expect(result).to eq :role_selection_required
+          end
+        end
+
+        context 'and only buyer is given' do
+          let(:roles) { %w[buyer] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and ccs_employee is given' do
+          let(:roles) { %w[ccs_employee] }
+
+          it 'returns :invalid_role_selection' do
+            expect(result).to eq :invalid_role_selection
+          end
+        end
+
+        context 'and ccs_user_admin is given' do
+          let(:roles) { %w[ccs_user_admin] }
+
+          it 'returns :invalid_role_selection' do
+            expect(result).to eq :invalid_role_selection
+          end
+        end
+
+        context 'and buyer is given with ccs_employee and allow_list_access' do
+          let(:roles) { %w[buyer ccs_employee allow_list_access] }
+
+          it 'returns :invalid_role_selection' do
+            expect(result).to eq :invalid_role_selection
+          end
+        end
+
+        context 'and all 4 roles are given' do
+          let(:roles) { %w[buyer ccs_employee allow_list_access ccs_user_admin] }
+
+          it 'returns :invalid_role_selection' do
+            expect(result).to eq :invalid_role_selection
+          end
+        end
+      end
+
+      context 'and the current user is a user_admin user' do
+        let(:user_access) { :user_admin }
+
+        context 'and no roles are given' do
+          it 'returns :role_selection_required' do
+            expect(result).to eq :role_selection_required
+          end
+        end
+
+        context 'and only buyer is given' do
+          let(:roles) { %w[buyer] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and ccs_employee is given' do
+          let(:roles) { %w[ccs_employee] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and ccs_user_admin is given' do
+          let(:roles) { %w[ccs_user_admin] }
+
+          it 'returns :invalid_role_selection' do
+            expect(result).to eq :invalid_role_selection
+          end
+        end
+
+        context 'and buyer is given with ccs_employee and allow_list_access' do
+          let(:roles) { %w[buyer ccs_employee allow_list_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and all 4 roles are given' do
+          let(:roles) { %w[buyer ccs_employee allow_list_access ccs_user_admin] }
+
+          it 'returns :invalid_role_selection' do
+            expect(result).to eq :invalid_role_selection
+          end
+        end
+      end
+
+      context 'and the current user is a super_admin user' do
+        let(:user_access) { :super_admin }
+
+        context 'and no roles are given' do
+          it 'returns :role_selection_required' do
+            expect(result).to eq :role_selection_required
+          end
+        end
+
+        context 'and only buyer is given' do
+          let(:roles) { %w[buyer] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and ccs_employee is given' do
+          let(:roles) { %w[ccs_employee] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and ccs_user_admin is given' do
+          let(:roles) { %w[ccs_user_admin] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and buyer is given with ccs_employee and allow_list_access' do
+          let(:roles) { %w[buyer ccs_employee allow_list_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and all 4 roles are given' do
+          let(:roles) { %w[buyer ccs_employee allow_list_access ccs_user_admin] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'when validating the service_access selection' do
+      let(:result) { cognito_roles.service_access_selection_valid }
+
+      context 'when there are no roles' do
+        context 'and the service access is empty' do
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has an item in the list' do
+          let(:service_access) { %w[st_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has items in the list' do
+          let(:service_access) { %w[st_access fm_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has an item that is not in the list' do
+          let(:service_access) { %w[st_access fm_access buyer] }
+
+          it 'returns :invalid_service_access_selection' do
+            expect(result).to eq :invalid_service_access_selection
+          end
+        end
+      end
+
+      context 'when the role is buyer' do
+        let(:roles) { %w[buyer] }
+
+        context 'and the service access is empty' do
+          it 'returns :service_access_selection_required' do
+            expect(result).to eq :service_access_selection_required
+          end
+        end
+
+        context 'and the service access has an item in the list' do
+          let(:service_access) { %w[fm_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has items in the list' do
+          let(:service_access) { %w[fm_access ls_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has an item that is not in the list' do
+          let(:service_access) { %w[fm_access ls_access ccs_employee] }
+
+          it 'returns :invalid_service_access_selection' do
+            expect(result).to eq :invalid_service_access_selection
+          end
+        end
+      end
+
+      context 'when the role is ccs_employee' do
+        let(:roles) { %w[ccs_employee] }
+
+        context 'and the service access is empty' do
+          it 'returns :service_access_selection_required' do
+            expect(result).to eq :service_access_selection_required
+          end
+        end
+
+        context 'and the service access has an item in the list' do
+          let(:service_access) { %w[ls_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has items in the list' do
+          let(:service_access) { %w[ls_access mc_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has an item that is not in the list' do
+          let(:service_access) { %w[ls_access mc_access allow_list_access] }
+
+          it 'returns :invalid_service_access_selection' do
+            expect(result).to eq :invalid_service_access_selection
+          end
+        end
+      end
+
+      context 'when the role is allow_list_access' do
+        let(:roles) { %w[allow_list_access] }
+
+        context 'and the service access is empty' do
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has an item in the list' do
+          let(:service_access) { %w[mc_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has items in the list' do
+          let(:service_access) { %w[mc_access st_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has an item that is not in the list' do
+          let(:service_access) { %w[mc_access st_access supplier] }
+
+          it 'returns :invalid_service_access_selection' do
+            expect(result).to eq :invalid_service_access_selection
+          end
+        end
+      end
+
+      context 'when the role is ccs_user_admin' do
+        let(:roles) { %w[ccs_user_admin] }
+
+        context 'and the service access is empty' do
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has an item in the list' do
+          let(:service_access) { %w[st_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has items in the list' do
+          let(:service_access) { %w[st_access ls_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has an item that is not in the list' do
+          let(:service_access) { %w[st_access ls_access ccs_developer] }
+
+          it 'returns :invalid_service_access_selection' do
+            expect(result).to eq :invalid_service_access_selection
+          end
+        end
+      end
+
+      context 'when the role is buyer with allow_list_access' do
+        let(:roles) { %w[buyer allow_list_access] }
+
+        context 'and the service access is empty' do
+          it 'returns :service_access_selection_required' do
+            expect(result).to eq :service_access_selection_required
+          end
+        end
+
+        context 'and the service access has an item in the list' do
+          let(:service_access) { %w[fm_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has items in the list' do
+          let(:service_access) { %w[fm_access mc_access] }
+
+          it 'returns nil' do
+            expect(result).to be_nil
+          end
+        end
+
+        context 'and the service access has an item that is not in the list' do
+          let(:service_access) { %w[fm_access mc_access supplier] }
+
+          it 'returns :invalid_service_access_selection' do
+            expect(result).to eq :invalid_service_access_selection
+          end
+        end
+      end
+    end
+    # rubocop:enable RSpec/NestedGroups
+  end
+
+  describe '.combine_roles' do
+    let(:result) { cognito_roles.combine_roles.sort }
+
+    context 'when the role is buyer with fm_access' do
+      let(:roles) { %w[buyer] }
+      let(:service_access) { %w[fm_access] }
+
+      it 'returns buyer and fm_access' do
+        expect(result).to eq %w[buyer fm_access]
+      end
+    end
+
+    context 'when the role is ccs_employee with st_access' do
+      let(:roles) { %w[ccs_employee] }
+      let(:service_access) { %w[st_access] }
+
+      it 'returns ccs_employee and st_access' do
+        expect(result).to eq %w[ccs_employee st_access]
+      end
+    end
+
+    context 'when the role is ccs_employee withouth any service_access' do
+      let(:roles) { %w[allow_list_access] }
+
+      it 'returns allow_list_access' do
+        expect(result).to eq %w[allow_list_access]
+      end
+    end
+
+    context 'when the role is ccs_user_admin withouth any service_access' do
+      let(:roles) { %w[ccs_user_admin] }
+
+      it 'returns ccs_user_admin' do
+        expect(result).to eq %w[ccs_user_admin]
+      end
+    end
+
+    context 'when the all roles and service_access are passed' do
+      let(:roles) { %w[buyer ccs_employee allow_list_access ccs_user_admin] }
+      let(:service_access) { %w[st_access fm_access ls_access mc_access] }
+
+      it 'returns allow_list_access, buyer, ccs_employee, ccs_user_admin, fm_access, ls_access, mc_access and st_access' do
+        expect(result).to eq %w[allow_list_access buyer ccs_employee ccs_user_admin fm_access ls_access mc_access st_access]
+      end
+    end
+  end
+
+  describe '.admin_roles_present?' do
+    let(:result) { cognito_roles.admin_roles_present? }
+
+    context 'when roles are empty' do
+      it 'returns false' do
+        expect(result).to be false
+      end
+    end
+
+    context 'when only buyer is present' do
+      let(:roles) { %w[buyer] }
+
+      it 'returns false' do
+        expect(result).to be false
+      end
+    end
+
+    context 'when only ccs_employee is present' do
+      let(:roles) { %w[ccs_employee] }
+
+      it 'returns true' do
+        expect(result).to be true
+      end
+    end
+
+    context 'when buyer and allow_list_access is present' do
+      let(:roles) { %w[buyer allow_list_access] }
+
+      it 'returns true' do
+        expect(result).to be true
+      end
+    end
+
+    context 'and all 4 roles are present' do
+      let(:roles) { %w[buyer ccs_employee allow_list_access ccs_user_admin] }
+
+      it 'returns true' do
+        expect(result).to be true
+      end
+    end
+  end
+
+  describe '.application_role_locations' do
+    let(:result) { cognito_roles.application_role_locations }
+
+    context 'when only buyer is present' do
+      let(:roles) { %w[buyer] }
+
+      context 'and fm_access is present' do
+        let(:service_access) { %w[fm_access] }
+
+        it 'returns main' do
+          expect(result).to eq %i[main]
+        end
+      end
+
+      context 'and st_access is present' do
+        let(:service_access) { %w[st_access] }
+
+        it 'returns legacy' do
+          expect(result).to eq %i[legacy]
+        end
+      end
+
+      context 'and fm_access and st_access are present' do
+        let(:service_access) { %w[fm_access st_access] }
+
+        it 'returns main and legacy' do
+          expect(result).to eq %i[main legacy]
+        end
+      end
+    end
+
+    context 'when only ccs_employee is present' do
+      let(:roles) { %w[ccs_employee] }
+
+      context 'and fm_access is present' do
+        let(:service_access) { %w[fm_access] }
+
+        it 'returns main' do
+          expect(result).to eq %i[main]
+        end
+      end
+
+      context 'and ls_access is present' do
+        let(:service_access) { %w[ls_access] }
+
+        it 'returns legacy' do
+          expect(result).to eq %i[legacy]
+        end
+      end
+
+      context 'and fm_access and ls_access are present' do
+        let(:service_access) { %w[fm_access ls_access] }
+
+        it 'returns main and legacy' do
+          expect(result).to eq %i[main legacy]
+        end
+      end
+    end
+
+    context 'when only allow_list_access is present' do
+      let(:roles) { %w[allow_list_access] }
+
+      context 'and fm_access is present' do
+        let(:service_access) { %w[fm_access] }
+
+        it 'returns main' do
+          expect(result).to eq %i[main]
+        end
+      end
+
+      context 'and mc_access is present' do
+        let(:service_access) { %w[mc_access] }
+
+        it 'returns main' do
+          expect(result).to eq %i[main]
+        end
+      end
+
+      context 'and fm_access and mc_access are present' do
+        let(:service_access) { %w[fm_access mc_access] }
+
+        it 'returns main' do
+          expect(result).to eq %i[main]
+        end
+      end
+    end
+
+    context 'when only ccs_user_admin is present' do
+      let(:roles) { %w[ccs_user_admin] }
+
+      context 'and fm_access is present' do
+        let(:service_access) { %w[fm_access] }
+
+        it 'returns main' do
+          expect(result).to eq %i[main]
+        end
+      end
+
+      context 'and st_access is present' do
+        let(:service_access) { %w[st_access] }
+
+        it 'returns main' do
+          expect(result).to eq %i[main]
+        end
+      end
+
+      context 'and fm_access and st_access are present' do
+        let(:service_access) { %w[fm_access st_access] }
+
+        it 'returns main' do
+          expect(result).to eq %i[main]
+        end
+      end
+    end
+
+    context 'when ccs_employee and ccs_user_admin is present' do
+      let(:roles) { %w[ccs_employee ccs_user_admin] }
+
+      context 'and fm_access is present' do
+        let(:service_access) { %w[fm_access] }
+
+        it 'returns main' do
+          expect(result).to eq %i[main]
+        end
+      end
+
+      context 'and st_access is present' do
+        let(:service_access) { %w[st_access] }
+
+        it 'returns legacy' do
+          expect(result).to eq %i[legacy]
+        end
+      end
+
+      context 'and fm_access and st_access are present' do
+        let(:service_access) { %w[fm_access st_access] }
+
+        it 'returns main and legacy' do
+          expect(result).to eq %i[main legacy]
+        end
+      end
+    end
+  end
+
+  describe '.get_roles_and_service_access_from_cognito_roles' do
+    let(:result) { described_class.get_roles_and_service_access_from_cognito_roles(cognio_roles) }
+
+    context 'when the cognio_roles are buyer with fm_access' do
+      let(:cognio_roles) { %w[buyer fm_access] }
+
+      it 'returns buyer for the roles and fm_access for the service_access' do
+        expect(result).to eq [%w[buyer], %w[fm_access]]
+      end
+    end
+
+    context 'when the cognio_roles is ccs_employee with st_access' do
+      let(:cognio_roles) { %w[ccs_employee st_access] }
+
+      it 'returns ccs_employee for the roles and st_access for the service_access' do
+        expect(result).to eq [%w[ccs_employee], %w[st_access]]
+      end
+    end
+
+    context 'when the cognio_roles is ccs_employee' do
+      let(:cognio_roles) { %w[allow_list_access] }
+
+      it 'returns allow_list_access for the roles and nothing for the service_access' do
+        expect(result).to eq [%w[allow_list_access], []]
+      end
+    end
+
+    context 'when the cognio_roles is ccs_user_admin and allow_list_access and the service_access is fm_access and mc_access' do
+      let(:cognio_roles) { %w[ccs_user_admin fm_access allow_list_access mc_access] }
+
+      it 'returns allow_list_access and ccs_user_admin for the roles and fm_access and mc_access for the service_access' do
+        expect(result).to eq [%w[allow_list_access ccs_user_admin], %w[fm_access mc_access]]
+      end
+    end
+
+    context 'when the cognio_roles is all the roles' do
+      let(:cognio_roles) { %w[buyer ccs_employee allow_list_access ccs_user_admin st_access fm_access ls_access mc_access] }
+
+      it 'returns buyer, ccs_employee, allow_list_access and ccs_user_admin for the roles and fm_access, st_access, ls_access and mc_access for the service_access' do
+        expect(result).to eq [%w[buyer ccs_employee allow_list_access ccs_user_admin], %w[fm_access st_access ls_access mc_access]]
+      end
+    end
+  end
+
+  describe '.current_user_access' do
+    let(:user) { create(:user, roles: user_roles) }
+    let(:result) { described_class.current_user_access(Ability.new(user)) }
+
+    context 'when the user has buyer access only' do
+      let(:user_roles) { %i[buyer] }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when the user has ccs_employee access only' do
+      let(:user_roles) { %i[ccs_employee] }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when the user has allow_list access only' do
+      let(:user_roles) { %i[allow_list_access] }
+
+      it 'returns user_support' do
+        expect(result).to eq :user_support
+      end
+    end
+
+    context 'when the user has ccs_user_admin access only' do
+      let(:user_roles) { %i[ccs_user_admin] }
+
+      it 'returns user_admin' do
+        expect(result).to eq :user_admin
+      end
+    end
+
+    context 'when the user has ccs_developer access only' do
+      let(:user_roles) { %i[ccs_developer] }
+
+      it 'returns super_admin' do
+        expect(result).to eq :super_admin
+      end
+    end
+
+    context 'when the user has buyer, ccs_developer, ccs_employee and allow_list access' do
+      let(:user_roles) { %i[ccs_employee allow_list_access ccs_developer] }
+
+      it 'returns super_admin' do
+        expect(result).to eq :super_admin
+      end
+    end
+  end
+
+  describe '.find_available_roles' do
+    let(:result) { described_class.find_available_roles(user_access) }
+
+    context 'when the user access is nil' do
+      let(:user_access) { nil }
+
+      it 'has no roles available' do
+        expect(result).to be_empty
+      end
+    end
+
+    context 'when the user access is user_support' do
+      let(:user_access) { :user_support }
+
+      it 'has buyer available' do
+        expect(result).to eq %w[buyer]
+      end
+    end
+
+    context 'when the user access is user_admin' do
+      let(:user_access) { :user_admin }
+
+      it 'has buyer, ccs_employee and allow_list_access available' do
+        expect(result).to eq %w[buyer ccs_employee allow_list_access]
+      end
+    end
+
+    context 'when the user access is super_admin' do
+      let(:user_access) { :super_admin }
+
+      it 'has buyer, ccs_employee, allow_list_access and ccs_user_admin available' do
+        expect(result).to eq %w[buyer ccs_employee allow_list_access ccs_user_admin]
+      end
+    end
+  end
+end

--- a/spec/services/cognito/admin/user_spec.rb
+++ b/spec/services/cognito/admin/user_spec.rb
@@ -1,0 +1,1397 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/NestedGroups
+RSpec.describe Cognito::Admin::User do
+  let(:cognito_admin_user) { described_class.new(current_user_access, attributes) }
+
+  let(:current_user_access) { :super_admin }
+  let(:cognito_uuid) { SecureRandom.uuid }
+  let(:email) { 'user@crowncommercial.gov.uk' }
+  let(:account_status) { true }
+  let(:roles) { %w[buyer] }
+  let(:telephone_number) { '07123456789' }
+  let(:service_access) { %w[fm_access] }
+  let(:mfa_enabled) { false }
+
+  let(:attributes) do
+    {
+      cognito_uuid: cognito_uuid,
+      email: email,
+      telephone_number: telephone_number,
+      roles: roles,
+      service_access: service_access,
+      account_status: account_status,
+      confirmation_status: 'CONFIRMED',
+      mfa_enabled: mfa_enabled
+    }
+  end
+
+  describe '#validations on select_role' do
+    let(:attributes) do
+      {
+        roles: roles,
+      }
+    end
+
+    context 'when no role is selected' do
+      let(:roles) { [] }
+
+      it 'is invalid and it has the correct error message' do
+        expect(cognito_admin_user).not_to be_valid(:select_role)
+        expect(cognito_admin_user.errors[:roles].first).to eq 'Select one role for the user'
+      end
+    end
+
+    context 'when multiple roles are selected' do
+      let(:roles) { %w[buyer ccs_employee] }
+
+      it 'is invalid and it has the correct error message' do
+        expect(cognito_admin_user).not_to be_valid(:select_role)
+        expect(cognito_admin_user.errors[:roles].first).to eq 'Select one role for the user'
+      end
+    end
+
+    context 'and the roles are not within the users scope' do
+      let(:roles) { %w[ccs_employee] }
+      let(:current_user_access) { :user_support }
+
+      it 'is invalid and it has the correct error message' do
+        expect(cognito_admin_user).not_to be_valid(:select_role)
+        expect(cognito_admin_user.errors[:roles].first).to eq 'You do not have the ability to create users with these roles'
+      end
+    end
+
+    context 'when one role is selected' do
+      let(:roles) { %w[allow_list_access] }
+
+      it 'is ivalid' do
+        expect(cognito_admin_user).to be_valid(:select_role)
+      end
+    end
+  end
+
+  describe '#validations on create' do
+    let(:attributes) do
+      {
+        email: email,
+        telephone_number: telephone_number,
+        roles: roles,
+        service_access: service_access
+      }
+    end
+    let(:allow_list_file) { Tempfile.new('allow_list.txt') }
+    let(:email_list) { ['email.com'] }
+    let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
+
+    before do
+      allow_list_file.write(email_list.join("\n"))
+      allow_list_file.close
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list_file_path).and_return(allow_list_file.path)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    after do
+      allow_list_file.unlink
+    end
+
+    context 'when validating the email' do
+      context 'and the email is nil' do
+        let(:email) { '' }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:email].first).to eq 'Enter an email address in the correct format, like name@example.com'
+        end
+      end
+
+      context 'and the email contains an uppercase character' do
+        let(:email) { 'uSer@cheemail.com' }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:email].first).to eq 'Email address cannot contain any capital letters'
+        end
+      end
+
+      context 'when the email is not on the allow list' do
+        context 'and the current user is super_admin' do
+          it 'is valid' do
+            expect(cognito_admin_user).to be_valid(:create)
+          end
+        end
+
+        context 'and the current user is user_admin' do
+          let(:current_user_access) { :user_admin }
+
+          it 'is valid' do
+            expect(cognito_admin_user).to be_valid(:create)
+          end
+        end
+
+        context 'and the current user is user_support' do
+          let(:current_user_access) { :user_support }
+
+          it 'is invalid and it has the correct error message' do
+            expect(cognito_admin_user).not_to be_valid(:create)
+            expect(cognito_admin_user.errors[:email].first).to eq 'Email domain is not in the allow list'
+          end
+        end
+      end
+    end
+
+    context 'when validating the roles' do
+      context 'and the roles empty' do
+        let(:roles) { [] }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:roles].first).to eq 'Select one role for the user'
+        end
+      end
+
+      context 'when multiple roles are selected' do
+        let(:roles) { %w[buyer ccs_user_admin] }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:roles].first).to eq 'Select one role for the user'
+        end
+      end
+
+      context 'and the roles are not within the users scope' do
+        let(:roles) { %w[ccs_employee] }
+        let(:current_user_access) { :user_support }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:roles].first).to eq 'You do not have the ability to create users with these roles'
+        end
+      end
+    end
+
+    context 'when validating the telephone number' do
+      context 'when the phone number is too short' do
+        let(:telephone_number) { '0712345678' }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:telephone_number].first).to eq 'Enter a UK mobile telephone number, for example 07700900982'
+        end
+      end
+
+      context 'when the phone number is too long' do
+        let(:telephone_number) { '071234567891' }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:telephone_number].first).to eq 'Enter a UK mobile telephone number, for example 07700900982'
+        end
+      end
+
+      context 'when the phone number does not start with 07' do
+        let(:telephone_number) { '12345678912' }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:telephone_number].first).to eq 'Enter a UK mobile telephone number, for example 07700900982'
+        end
+      end
+
+      context 'when the role requires the telephone number and it is blank' do
+        let(:telephone_number) { '' }
+        let(:roles) { %w[allow_list_access] }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:telephone_number].first).to eq 'Enter a UK mobile telephone number, for example 07700900982'
+        end
+      end
+
+      context 'when the role does not require the telephone number and it is blank' do
+        let(:telephone_number) { '' }
+
+        it 'is valid' do
+          expect(cognito_admin_user).to be_valid(:create)
+        end
+      end
+    end
+
+    context 'when validating the service_access' do
+      context 'and the service_access is empty when it required' do
+        let(:roles) { %w[ccs_employee] }
+        let(:service_access) { [] }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:service_access].first).to eq 'You must select the service access for the user if they have the buyer or service admin role'
+        end
+      end
+
+      context 'and the service_access are not within the list' do
+        let(:service_access) { %w[fake_service] }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:service_access].first).to eq 'You must select the service access for the user from this list'
+        end
+      end
+    end
+
+    context 'when eveything is present and correct' do
+      it 'is valid' do
+        expect(cognito_admin_user).to be_valid(:create)
+      end
+    end
+  end
+
+  describe 'validations on an existing user' do
+    before { cognito_admin_user.assign_attributes({ attribute => value }) }
+
+    context 'when validating the account status' do
+      let(:attribute) { :account_status }
+
+      context 'when it is nil' do
+        let(:value) { nil }
+
+        it 'is invalid' do
+          expect(cognito_admin_user).not_to be_valid(:account_status)
+        end
+      end
+
+      context 'when it is empty' do
+        let(:value) { '' }
+
+        it 'is invalid' do
+          expect(cognito_admin_user).not_to be_valid(:account_status)
+        end
+      end
+
+      context 'when it is true' do
+        let(:value) { 'true' }
+
+        it 'is valid' do
+          expect(cognito_admin_user).to be_valid(:account_status)
+        end
+      end
+
+      context 'when it is false' do
+        let(:value) { 'false' }
+
+        it 'is valid' do
+          expect(cognito_admin_user).to be_valid(:account_status)
+        end
+      end
+    end
+
+    context 'when validating the telephone number' do
+      let(:attribute) { :telephone_number }
+
+      context 'when the phone number is too short' do
+        let(:value) { '0712345678' }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:telephone_number)
+          expect(cognito_admin_user.errors[:telephone_number].first).to eq 'Enter a UK mobile telephone number, for example 07700900982'
+        end
+      end
+
+      context 'when the phone number is too long' do
+        let(:value) { '071234567891' }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:telephone_number)
+          expect(cognito_admin_user.errors[:telephone_number].first).to eq 'Enter a UK mobile telephone number, for example 07700900982'
+        end
+      end
+
+      context 'when the phone number does not start with 07' do
+        let(:value) { '12345678912' }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:telephone_number)
+          expect(cognito_admin_user.errors[:telephone_number].first).to eq 'Enter a UK mobile telephone number, for example 07700900982'
+        end
+      end
+
+      context 'when the phone number is a GB number' do
+        let(:value) { '07123456789' }
+
+        it 'is valid' do
+          expect(cognito_admin_user).to be_valid(:telephone_number)
+        end
+      end
+
+      context 'when the role requires the telephone number and it is blank' do
+        let(:value) { '' }
+        let(:roles) { %w[ccs_employee] }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:create)
+          expect(cognito_admin_user.errors[:telephone_number].first).to eq 'Enter a UK mobile telephone number, for example 07700900982'
+        end
+      end
+
+      context 'when the role does not require the telephone number and it is blank' do
+        let(:value) { '' }
+
+        it 'is valid' do
+          expect(cognito_admin_user).to be_valid(:create)
+        end
+      end
+    end
+
+    context 'when validating the mfa status' do
+      let(:attribute) { :mfa_enabled }
+
+      context 'when it is nil' do
+        let(:value) { nil }
+
+        it 'is invalid' do
+          expect(cognito_admin_user).not_to be_valid(:mfa_enabled)
+        end
+      end
+
+      context 'when it is empty' do
+        let(:value) { '' }
+
+        it 'is invalid' do
+          expect(cognito_admin_user).not_to be_valid(:mfa_enabled)
+        end
+      end
+
+      context 'when it is true' do
+        let(:value) { 'true' }
+
+        context 'and the telephone number is nil' do
+          let(:telephone_number) { nil }
+
+          it 'is invalid and it has the correct error message' do
+            expect(cognito_admin_user).not_to be_valid(:mfa_enabled)
+            expect(cognito_admin_user.errors[:mfa_enabled].first).to eq 'The telephone number of the user must be set to update the MFA configuration'
+          end
+        end
+
+        context 'and the telephone number is not nil' do
+          it 'is valid' do
+            expect(cognito_admin_user).to be_valid(:mfa_enabled)
+          end
+        end
+      end
+
+      context 'when it is false' do
+        let(:value) { 'false' }
+
+        context 'and the telephone number is nil' do
+          let(:telephone_number) { nil }
+
+          it 'is invalid and it has the correct error message' do
+            expect(cognito_admin_user).not_to be_valid(:mfa_enabled)
+            expect(cognito_admin_user.errors[:mfa_enabled].first).to eq 'The telephone number of the user must be set to update the MFA configuration'
+          end
+        end
+
+        context 'and one of the roles requires MFA' do
+          let(:roles) { %i[allow_list_access] }
+
+          it 'is invalid and it has the correct error message' do
+            expect(cognito_admin_user).not_to be_valid(:mfa_enabled)
+          end
+        end
+
+        context 'and the telephone number is not nil' do
+          it 'is valid' do
+            expect(cognito_admin_user).to be_valid(:mfa_enabled)
+          end
+        end
+      end
+    end
+
+    context 'when validating the roles' do
+      let(:attribute) { :roles }
+
+      context 'and roles is empty' do
+        let(:value) { [] }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:roles)
+          expect(cognito_admin_user.errors[:roles].first).to eq 'Select a role for the user'
+        end
+      end
+
+      context 'and the roles are not within the users scope' do
+        let(:current_user_access) { :user_support }
+        let(:value) { %w[ccs_employee] }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:roles)
+          expect(cognito_admin_user.errors[:roles].first).to eq 'You do not have the ability to create users with these roles'
+        end
+      end
+
+      context 'and MFA is not enabled when admin roles are present' do
+        let(:mfa_enabled) { 'false' }
+        let(:value) { %w[buyer ccs_employee] }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:roles)
+          expect(cognito_admin_user.errors[:roles].first).to eq 'You must enable MFA for this user to add these admin roles'
+        end
+      end
+
+      context 'and the roles are within the users scope' do
+        let(:current_user_access) { :user_support }
+        let(:value) { %w[buyer] }
+
+        it 'is valid' do
+          expect(cognito_admin_user).to be_valid(:roles)
+        end
+      end
+    end
+
+    context 'when validating the service_access' do
+      let(:attribute) { :service_access }
+
+      context 'and the service_access is empty when it required' do
+        let(:value) { [] }
+
+        context 'and the role requires a service' do
+          it 'is invalid and it has the correct error message' do
+            expect(cognito_admin_user).not_to be_valid(:service_access)
+            expect(cognito_admin_user.errors[:service_access].first).to eq 'You must select the service access for the user from this list'
+          end
+        end
+
+        context 'and the role does not require a service' do
+          let(:roles) { %w[user_admin] }
+
+          it 'is invalid and it has the correct error message' do
+            expect(cognito_admin_user).not_to be_valid(:service_access)
+            expect(cognito_admin_user.errors[:service_access].first).to eq 'You must select the service access for the user from this list'
+          end
+        end
+      end
+
+      context 'and the service_access are not within the list' do
+        let(:value) { %w[fake_service] }
+
+        it 'is invalid and it has the correct error message' do
+          expect(cognito_admin_user).not_to be_valid(:service_access)
+          expect(cognito_admin_user.errors[:service_access].first).to eq 'You must select the service access for the user from this list'
+        end
+      end
+
+      context 'when there is a service_access' do
+        let(:value) { %w[fm_access mc_access] }
+
+        context 'and the role requires it' do
+          it 'is valid' do
+            expect(cognito_admin_user).to be_valid(:service_access)
+          end
+        end
+
+        context 'and the role does not require it' do
+          let(:roles) { %w[allow_list_access] }
+
+          it 'is valid' do
+            expect(cognito_admin_user).to be_valid(:service_access)
+          end
+        end
+      end
+    end
+  end
+
+  describe '.create' do
+    let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
+
+    before { allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client) }
+
+    context 'when a cognito error is made' do
+      let(:error) { Aws::CognitoIdentityProvider::Errors::ServiceError }
+
+      before do
+        allow(aws_client).to receive(:admin_create_user).and_raise(error.new('Some context', 'Some message'))
+        cognito_admin_user.create
+      end
+
+      it 'does not return success' do
+        expect(cognito_admin_user.success?).to eq false
+      end
+
+      it 'returns an error' do
+        expect(cognito_admin_user.errors.empty?).to eq false
+      end
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    context 'when the user is successfully created' do
+      before do
+        allow(aws_client).to receive(:admin_create_user).and_return(OpenStruct.new(user: { 'username' => cognito_uuid }))
+        allow(aws_client).to receive(:admin_set_user_mfa_preference)
+        allow(aws_client).to receive(:admin_add_user_to_group)
+        cognito_admin_user.create
+      end
+
+      context 'and the user is a buyer with fm_access and st_access' do
+        let(:service_access) { %w[fm_access st_access] }
+
+        it 'calls admin_create_user with the correct arguments' do
+          expect(aws_client).to have_received(:admin_create_user).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: 'user@crowncommercial.gov.uk',
+              user_attributes: [
+                {
+                  name: 'email',
+                  value: 'user@crowncommercial.gov.uk'
+                },
+                {
+                  name: 'email_verified',
+                  value: true
+                }
+              ],
+              desired_delivery_mediums: ['EMAIL']
+            }
+          )
+        end
+
+        it 'does not call admin_set_user_mfa_preference' do
+          expect(aws_client).not_to have_received(:admin_set_user_mfa_preference)
+        end
+
+        it 'calls admin_add_user_to_group with the correct arguments' do
+          expect(aws_client).to have_received(:admin_add_user_to_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'buyer'
+            }
+          )
+          expect(aws_client).to have_received(:admin_add_user_to_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'fm_access'
+            }
+          )
+        end
+
+        it 'returns success' do
+          expect(cognito_admin_user.success?).to be true
+        end
+
+        it 'does not return an error' do
+          expect(cognito_admin_user.errors.empty?).to be true
+        end
+      end
+
+      context 'when the user created is an admin' do
+        let(:roles) { %w[ccs_employee] }
+
+        it 'calls admin_create_user with the correct arguments' do
+          expect(aws_client).to have_received(:admin_create_user).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: 'user@crowncommercial.gov.uk',
+              user_attributes: [
+                {
+                  name: 'email',
+                  value: 'user@crowncommercial.gov.uk'
+                },
+                {
+                  name: 'email_verified',
+                  value: true
+                },
+                {
+                  name: 'phone_number',
+                  value: '+447123456789'
+                }
+              ],
+              desired_delivery_mediums: ['EMAIL']
+            }
+          )
+        end
+
+        it 'calls admin_set_user_mfa_preference with the correct arguments' do
+          expect(aws_client).to have_received(:admin_set_user_mfa_preference).with(
+            sms_mfa_settings: {
+              enabled: true,
+              preferred_mfa: true,
+            },
+            user_pool_id: 'cognito-user-pool-id',
+            username: cognito_uuid,
+          )
+        end
+
+        it 'calls admin_add_user_to_group with the correct arguments' do
+          expect(aws_client).to have_received(:admin_add_user_to_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'ccs_employee'
+            }
+          )
+          expect(aws_client).to have_received(:admin_add_user_to_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'fm_access'
+            }
+          )
+        end
+
+        it 'does return success' do
+          expect(cognito_admin_user.success?).to be true
+        end
+
+        it 'does not return an error' do
+          expect(cognito_admin_user.errors.empty?).to be true
+        end
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
+  describe '.assign_attributes' do
+    let(:assign_attributes) { cognito_admin_user.assign_attributes(new_attributes) }
+
+    context 'when new_attributes is nil' do
+      let(:new_attributes) { nil }
+
+      it 'raises an argument error' do
+        expect { assign_attributes }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when new_attributes is empty' do
+      let(:new_attributes) { {} }
+
+      it 'raises does not change the cognito_admin_user' do
+        expect(assign_attributes).to be_nil
+      end
+    end
+
+    context 'when the attribute does not exist' do
+      let(:new_attributes) { { my_made_up_attribute: 'hello' } }
+
+      it 'raises an ActiveRecord::UnknownAttributeError error' do
+        expect { assign_attributes }.to raise_error(ActiveRecord::UnknownAttributeError)
+      end
+    end
+
+    context 'when the attribute does exist' do
+      let(:new_attributes) { { telephone_number: '07987654321' } }
+
+      it 'updates the cognito_admin_user' do
+        expect { assign_attributes }.to change(cognito_admin_user, :telephone_number).from('07123456789').to('07987654321')
+      end
+    end
+
+    context 'when multiple attributes are assigned' do
+      let(:new_attributes) { { telephone_number: '07987654321', mfa_enabled: 'true' } }
+
+      it 'updates the cognito_admin_user' do
+        expect { assign_attributes }.to change(cognito_admin_user, :telephone_number).from('07123456789').to('07987654321')
+                                    .and change(cognito_admin_user, :mfa_enabled).from(false).to(true)
+      end
+    end
+  end
+
+  describe '.find' do
+    let(:cognito_admin_user) { described_class.find(current_user_access, cognito_uuid) }
+
+    let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
+    let(:cognio_enabled) { true }
+    let(:cognito_telephone_number) { '+447123456789' }
+    let(:cognito_mfa_setting_list) { nil }
+    let(:cognito_groups) { %w[buyer fm_access] }
+
+    before do
+      allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+      allow(aws_client).to receive(:admin_get_user).and_return(
+        OpenStruct.new(
+          user_attributes: [
+            OpenStruct.new({ name: 'email', value: email }),
+            OpenStruct.new({ name: 'phone_number', value: cognito_telephone_number })
+          ],
+          enabled: cognio_enabled,
+          user_status: 'CONFIRMED',
+          user_mfa_setting_list: cognito_mfa_setting_list
+        )
+      )
+      allow(aws_client).to receive(:admin_list_groups_for_user).and_return(
+        OpenStruct.new(
+          groups: cognito_groups.map { |cognito_role| OpenStruct.new(group_name: cognito_role) }
+        )
+      )
+    end
+
+    context 'when considering the attributes' do
+      it 'sets the email' do
+        expect(cognito_admin_user.email).to eq email
+      end
+
+      context 'when looking at the telephone_number' do
+        context 'and the telephone number is nil' do
+          let(:cognito_telephone_number) { nil }
+
+          it 'sets the telephone number as an empty string' do
+            expect(cognito_admin_user.telephone_number).to eq ''
+          end
+        end
+
+        context 'and the telephone number is not a GB number' do
+          let(:cognito_telephone_number) { '+11234567891' }
+
+          it 'sets the telephone number as unchanged' do
+            expect(cognito_admin_user.telephone_number).to eq cognito_telephone_number
+          end
+        end
+
+        context 'and the telephone number is a GB number' do
+          it 'sets replaces the area code with 0' do
+            expect(cognito_admin_user.telephone_number).to eq '07123456789'
+          end
+        end
+      end
+
+      it 'sets the account status' do
+        expect(cognito_admin_user.account_status).to eq true
+      end
+
+      it 'sets the confirmation status' do
+        expect(cognito_admin_user.confirmation_status).to eq 'CONFIRMED'
+      end
+
+      context 'when looking at mfa_enabled' do
+        context 'and mfa_enabled telephone number is nil' do
+          let(:cognito_mfa_setting_list) { nil }
+
+          it 'sets mfa_enabled as false' do
+            expect(cognito_admin_user.mfa_enabled).to be false
+          end
+        end
+
+        context 'and mfa_enabled telephone number is an empty array' do
+          let(:cognito_mfa_setting_list) { [] }
+
+          it 'sets mfa_enabled as false' do
+            expect(cognito_admin_user.mfa_enabled).to be false
+          end
+        end
+
+        context 'and mfa_enabled telephone number is an array with EMAIL_MFA' do
+          let(:cognito_mfa_setting_list) { %w[EMAIL_MFA] }
+
+          it 'sets mfa_enabled as false' do
+            expect(cognito_admin_user.mfa_enabled).to be false
+          end
+        end
+
+        context 'and mfa_enabled telephone number is an array with SMS_MFA' do
+          let(:cognito_mfa_setting_list) { %w[SMS_MFA] }
+
+          it 'sets mfa_enabled as true' do
+            expect(cognito_admin_user.mfa_enabled).to be true
+          end
+        end
+      end
+
+      it 'seperates the groups into roles and service access' do
+        expect(cognito_admin_user.roles).to eq %w[buyer]
+        expect(cognito_admin_user.service_access).to eq %w[fm_access]
+      end
+
+      it 'sets the cognito_roles' do
+        expect(cognito_admin_user.cognito_roles).not_to be_nil
+      end
+    end
+
+    context 'when considering the client calls' do
+      before { cognito_admin_user }
+
+      it 'calls admin_get_user with correct arguments' do
+        expect(aws_client).to have_received(:admin_get_user).with(
+          {
+            user_pool_id: 'cognito-user-pool-id',
+            username: cognito_uuid,
+          }
+        )
+      end
+
+      it 'calls admin_list_groups_for_user with correct arguments' do
+        expect(aws_client).to have_received(:admin_list_groups_for_user).with(
+          {
+            user_pool_id: 'cognito-user-pool-id',
+            username: cognito_uuid,
+          }
+        )
+      end
+    end
+
+    context 'and there is an error' do
+      before { allow(aws_client).to receive(:admin_get_user).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('Some context', 'Some message')) }
+
+      it 'does not set any of the atributes' do
+        expect(%i[email telephone_number account_status confirmation_status mfa_enabled roles service_access cognito_roles].all? { |attribute| cognito_admin_user.send(attribute).nil? }).to be true
+      end
+
+      it 'sets the error' do
+        expect(cognito_admin_user.error).to eq 'Some message'
+      end
+    end
+  end
+
+  describe '.search' do
+    let(:search) { described_class.search(email) }
+    let(:search_users) { search[:users] }
+    let(:search_error) { search[:error] }
+
+    let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
+
+    let(:aa_user) { { email: 'aa_user@email.com', cognito_uuid: SecureRandom.uuid, account_status: true } }
+    let(:ab_user) { { email: 'ab_user@email.com', cognito_uuid: SecureRandom.uuid, account_status: false } }
+    let(:ac_user) { { email: 'ac_user@email.com', cognito_uuid: SecureRandom.uuid, account_status: true } }
+
+    before do
+      allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+      allow(aws_client).to receive(:list_users).and_return(
+        OpenStruct.new(
+          users: [ac_user, ab_user, aa_user].map do |user|
+            OpenStruct.new(
+              {
+                username: user[:cognito_uuid],
+                attributes: [OpenStruct.new({ name: 'email', value: user[:email] })],
+                enabled: user[:account_status]
+              }
+            )
+          end
+        )
+      )
+    end
+
+    context 'and the email is valid' do
+      let(:email) { ' A ' }
+
+      it 'calls the aws client with the right parameters' do
+        search
+
+        expect(aws_client).to have_received(:list_users).with(
+          {
+            user_pool_id: 'cognito-user-pool-id',
+            attributes_to_get: ['email'],
+            filter: 'email ^= "a"'
+          }
+        )
+      end
+
+      it 'gets the sorted users' do
+        expect(search_users).to eq([aa_user, ab_user, ac_user])
+      end
+
+      it 'returns no error' do
+        expect(search_error).to be_nil
+      end
+    end
+
+    context 'and the email is invalid because it is empty' do
+      let(:email) { '' }
+
+      it 'does not call the aws client with the right parameters' do
+        search
+
+        expect(aws_client).not_to have_received(:list_users)
+      end
+
+      it 'returns no users' do
+        expect(search_users).to be_empty
+      end
+
+      it 'returns the error' do
+        expect(search_error).to eq 'You must enter an email address'
+      end
+    end
+
+    context 'and the email is invalid because it is blank' do
+      let(:email) { '   ' }
+
+      it 'does not call the aws client with the right parameters' do
+        search
+
+        expect(aws_client).not_to have_received(:list_users)
+      end
+
+      it 'returns no users' do
+        expect(search_users).to be_empty
+      end
+
+      it 'returns the error' do
+        expect(search_error).to eq 'You must enter an email address'
+      end
+    end
+
+    context 'and an error is raised' do
+      let(:email) { 'a' }
+
+      before { allow(aws_client).to receive(:list_users).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('Some context', 'Some message')) }
+
+      it 'calls the aws client with the right parameters' do
+        search
+
+        expect(aws_client).to have_received(:list_users).with(
+          {
+            user_pool_id: 'cognito-user-pool-id',
+            attributes_to_get: ['email'],
+            filter: 'email ^= "a"'
+          }
+        )
+      end
+
+      it 'returns no users' do
+        expect(search_users).to be_empty
+      end
+
+      it 'returns the error' do
+        expect(search_error).to eq 'Some message'
+      end
+    end
+  end
+
+  # rubocop:disable RSpec/ExampleLength
+  describe 'update' do
+    let(:result) { cognito_admin_user.update(method) }
+
+    let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
+
+    before { allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client) }
+
+    context 'when updating the account status' do
+      let(:method) { :account_status }
+
+      before do
+        allow(aws_client).to receive(:admin_enable_user)
+        allow(aws_client).to receive(:admin_disable_user)
+      end
+
+      context 'and it is invalid' do
+        let(:account_status) { nil }
+
+        it 'returns false' do
+          expect(result).to be false
+        end
+
+        it 'does not call admin_enable_user' do
+          result
+
+          expect(aws_client).not_to have_received(:admin_enable_user)
+        end
+
+        it 'does not call admin_disable_user' do
+          result
+
+          expect(aws_client).not_to have_received(:admin_disable_user)
+        end
+      end
+
+      context 'and it raises an AWS error' do
+        before { allow(aws_client).to receive(:admin_enable_user).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('Some context', 'Some message')) }
+
+        it 'returns false it has the correct error message' do
+          expect(result).to be false
+          expect(cognito_admin_user.errors[:account_status].first).to eq 'Some message'
+        end
+
+        it 'calls admin_enable_user with correct arguments' do
+          result
+
+          expect(aws_client).to have_received(:admin_enable_user).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid
+            }
+          )
+        end
+
+        it 'does not call admin_disable_user' do
+          result
+
+          expect(aws_client).not_to have_received(:admin_disable_user)
+        end
+      end
+
+      context 'and it is valid and does not raise an AWS error' do
+        context 'and the account status is enabled' do
+          let(:account_status) { 'true' }
+
+          it 'returns true' do
+            expect(result).to be true
+          end
+
+          it 'calls admin_enable_user with correct arguments' do
+            result
+
+            expect(aws_client).to have_received(:admin_enable_user).with(
+              {
+                user_pool_id: 'cognito-user-pool-id',
+                username: cognito_uuid
+              }
+            )
+          end
+
+          it 'does not call admin_disable_user' do
+            result
+
+            expect(aws_client).not_to have_received(:admin_disable_user)
+          end
+        end
+
+        context 'and the account status is disabled' do
+          let(:account_status) { 'false' }
+
+          it 'returns true' do
+            expect(result).to be true
+          end
+
+          it 'does not call admin_enable_user' do
+            result
+
+            expect(aws_client).not_to have_received(:admin_enable_user)
+          end
+
+          it 'does not call admin_disable_user' do
+            result
+
+            expect(aws_client).to have_received(:admin_disable_user).with(
+              {
+                user_pool_id: 'cognito-user-pool-id',
+                username: cognito_uuid
+              }
+            )
+          end
+        end
+      end
+    end
+
+    context 'when updating the telephone number' do
+      let(:method) { :telephone_number }
+
+      before { allow(aws_client).to receive(:admin_update_user_attributes) }
+
+      context 'and it is invalid' do
+        let(:telephone_number) { '' }
+
+        it 'returns false it has the correct error message' do
+          expect(result).to be false
+          expect(cognito_admin_user.errors[:telephone_number].first).to eq 'Enter a UK mobile telephone number, for example 07700900982'
+        end
+
+        it 'does not call admin_update_user_attributes' do
+          result
+
+          expect(aws_client).not_to have_received(:admin_update_user_attributes)
+        end
+      end
+
+      context 'and it raises an AWS error' do
+        before { allow(aws_client).to receive(:admin_update_user_attributes).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('Some context', 'Some message')) }
+
+        it 'returns false it has the correct error message' do
+          expect(result).to be false
+          expect(cognito_admin_user.errors[:telephone_number].first).to eq 'Some message'
+        end
+
+        it 'calls admin_update_user_attributes with correct arguments' do
+          result
+
+          expect(aws_client).to have_received(:admin_update_user_attributes).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              user_attributes: [
+                {
+                  name: 'phone_number',
+                  value: '+447123456789'
+                },
+                {
+                  name: 'phone_number_verified',
+                  value: 'true'
+                }
+              ]
+            }
+          )
+        end
+      end
+
+      context 'and it is valid and does not raise an AWS error' do
+        it 'returns true' do
+          expect(result).to be true
+        end
+
+        it 'calls admin_update_user_attributes with correct arguments' do
+          result
+
+          expect(aws_client).to have_received(:admin_update_user_attributes).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              user_attributes: [
+                {
+                  name: 'phone_number',
+                  value: '+447123456789'
+                },
+                {
+                  name: 'phone_number_verified',
+                  value: 'true'
+                }
+              ]
+            }
+          )
+        end
+      end
+    end
+
+    context 'when updating the mfa status' do
+      let(:method) { :mfa_enabled }
+
+      before { allow(aws_client).to receive(:admin_set_user_mfa_preference) }
+
+      context 'and it is invalid' do
+        let(:mfa_enabled) { nil }
+
+        it 'returns false' do
+          expect(result).to be false
+        end
+
+        it 'does not call admin_set_user_mfa_preference' do
+          result
+
+          expect(aws_client).not_to have_received(:admin_set_user_mfa_preference)
+        end
+      end
+
+      context 'and it raises an AWS error' do
+        before { allow(aws_client).to receive(:admin_set_user_mfa_preference).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('Some context', 'Some message')) }
+
+        it 'returns false it has the correct error message' do
+          expect(result).to be false
+          expect(cognito_admin_user.errors[:mfa_enabled].first).to eq 'Some message'
+        end
+
+        it 'calls admin_set_user_mfa_preference with correct arguments' do
+          result
+
+          expect(aws_client).to have_received(:admin_set_user_mfa_preference).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              sms_mfa_settings: {
+                enabled: false,
+                preferred_mfa: false,
+              }
+            }
+          )
+        end
+      end
+
+      context 'and it is valid and does not raise an AWS error' do
+        let(:mfa_enabled) { 'true' }
+
+        it 'returns true' do
+          expect(result).to be true
+        end
+
+        it 'calls admin_set_user_mfa_preference with correct arguments' do
+          result
+
+          expect(aws_client).to have_received(:admin_set_user_mfa_preference).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              sms_mfa_settings: {
+                enabled: true,
+                preferred_mfa: true,
+              }
+            }
+          )
+        end
+      end
+    end
+
+    context 'when updating the roles' do
+      let(:method) { :roles }
+      let(:mfa_enabled) { true }
+      let(:roles) { %w[buyer allow_list_access ccs_employee] }
+      let(:new_roles) { %w[buyer ccs_user_admin] }
+
+      before do
+        cognito_admin_user.assign_attributes(roles: new_roles)
+        allow(aws_client).to receive(:admin_remove_user_from_group)
+        allow(aws_client).to receive(:admin_add_user_to_group)
+      end
+
+      context 'and it is invalid' do
+        let(:new_roles) { [] }
+
+        it 'returns false it has the correct error message' do
+          expect(result).to be false
+          expect(cognito_admin_user.errors[:roles].first).to eq 'Select a role for the user'
+        end
+
+        it 'does not call admin_remove_user_from_group or admin_add_user_to_group' do
+          result
+
+          expect(aws_client).not_to have_received(:admin_remove_user_from_group)
+          expect(aws_client).not_to have_received(:admin_add_user_to_group)
+        end
+      end
+
+      context 'and it raises an AWS error' do
+        before { allow(aws_client).to receive(:admin_remove_user_from_group).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('Some context', 'Some message')) }
+
+        it 'returns false it has the correct error message' do
+          expect(result).to be false
+          expect(cognito_admin_user.errors[:roles].first).to eq 'Some message'
+        end
+
+        it 'calls admin_remove_user_from_group with correct arguments' do
+          result
+
+          expect(aws_client).to have_received(:admin_remove_user_from_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'allow_list_access'
+            }
+          )
+        end
+      end
+
+      context 'and it is valid and does not raise an AWS error' do
+        it 'returns true' do
+          expect(result).to be true
+        end
+
+        it 'calls admin_remove_user_from_group with correct arguments' do
+          result
+
+          expect(aws_client).to have_received(:admin_remove_user_from_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'allow_list_access'
+            }
+          )
+
+          expect(aws_client).to have_received(:admin_remove_user_from_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'ccs_employee'
+            }
+          )
+        end
+
+        it 'calls admin_add_user_to_group with correct arguments' do
+          result
+
+          expect(aws_client).to have_received(:admin_add_user_to_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'ccs_user_admin'
+            }
+          )
+        end
+      end
+    end
+
+    context 'when updating the service_access' do
+      let(:method) { :service_access }
+      let(:service_access) { %w[fm_access st_access] }
+      let(:new_service_access) { %w[fm_access mc_access ls_access] }
+
+      before do
+        cognito_admin_user.assign_attributes(service_access: new_service_access)
+        allow(aws_client).to receive(:admin_remove_user_from_group)
+        allow(aws_client).to receive(:admin_add_user_to_group)
+      end
+
+      context 'and it is invalid' do
+        let(:new_service_access) { [] }
+
+        it 'returns false it has the correct error message' do
+          expect(result).to be false
+          expect(cognito_admin_user.errors[:service_access].first).to eq 'You must select the service access for the user from this list'
+        end
+
+        it 'does not call admin_remove_user_from_group or admin_add_user_to_group' do
+          result
+
+          expect(aws_client).not_to have_received(:admin_remove_user_from_group)
+          expect(aws_client).not_to have_received(:admin_add_user_to_group)
+        end
+      end
+
+      context 'and it raises an AWS error' do
+        before { allow(aws_client).to receive(:admin_remove_user_from_group).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('Some context', 'Some message')) }
+
+        it 'returns false it has the correct error message' do
+          expect(result).to be false
+          expect(cognito_admin_user.errors[:service_access].first).to eq 'Some message'
+        end
+
+        it 'calls admin_remove_user_from_group with correct arguments' do
+          result
+
+          expect(aws_client).to have_received(:admin_remove_user_from_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'st_access'
+            }
+          )
+        end
+      end
+
+      context 'and it is valid and does not raise an AWS error' do
+        it 'returns true' do
+          expect(result).to be true
+        end
+
+        it 'calls admin_remove_user_from_group with correct arguments' do
+          result
+
+          expect(aws_client).to have_received(:admin_remove_user_from_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'st_access'
+            }
+          )
+        end
+
+        it 'calls admin_add_user_to_group with correct arguments' do
+          result
+
+          expect(aws_client).to have_received(:admin_add_user_to_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'mc_access'
+            }
+          )
+
+          expect(aws_client).to have_received(:admin_add_user_to_group).with(
+            {
+              user_pool_id: 'cognito-user-pool-id',
+              username: cognito_uuid,
+              group_name: 'ls_access'
+            }
+          )
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
+end
+# rubocop:enable RSpec/NestedGroups

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -45,7 +45,7 @@ module ControllerMacros
   def login_crown_marketplace_admin
     before do
       @request.env['devise.mapping'] = Devise.mappings[:user]
-      user = FactoryBot.create(:user, :without_detail, confirmed_at: Time.zone.now, roles: %i[ccs_employee allow_list_access])
+      user = FactoryBot.create(:user, :without_detail, confirmed_at: Time.zone.now, roles: %i[ccs_user_admin])
       sign_in user
     end
   end


### PR DESCRIPTION
Ticket: [FMFR-1314](https://crowncommercialservice.atlassian.net/browse/FMFR-1314)

We are adding the ability for the CSC team to manage users through the application rather than in cognito. This commit contains the code that, once the frontend has been developed, will allow them to do so.

I have created the `Cognito::Admin::User` model to handle the users we find in a more rails way. I have created the `Cognito::Admin::UserClientInterface` as an interface to handle the Cognito API, and keep some of the complexity out of the `Cognito::Admin::User` model. This interface allows us to:
- Create users
- Search users
- Find a single user
- Update the users attributes

In addition to these, I have created the  `Cognito::Admin::Roles` class which handles the logic for the roles that can be assigned to users by users. This is because we need to limit the ability of who can edit who based on their permissions. For example, most CSC users will only need to manage buyers so they do not need to be able to create Service admins.

As usual, I have added tests to make sure the changes I have implemented work.