### PR TITLE
Add some feature tests for allow list

### DIFF
--- a/app/controllers/crown_marketplace/allow_list_controller.rb
+++ b/app/controllers/crown_marketplace/allow_list_controller.rb
@@ -8,7 +8,9 @@ class CrownMarketplace::AllowListController < CrownMarketplace::FrameworkControl
 
   def create
     if @allowed_email_domain.save
-      redirect_to crown_marketplace_allow_list_index_path(email_domain_added: @allowed_email_domain.email_domain)
+      flash[:email_domain_added] = @allowed_email_domain.email_domain
+
+      redirect_to crown_marketplace_allow_list_index_path
     else
       render :new
     end
@@ -20,7 +22,10 @@ class CrownMarketplace::AllowListController < CrownMarketplace::FrameworkControl
 
   def destroy
     @allowed_email_domain.remove_email_domain
-    redirect_to crown_marketplace_allow_list_index_path(email_domain_removed: @allowed_email_domain.email_domain)
+
+    flash[:email_domain_removed] = @allowed_email_domain.email_domain
+
+    redirect_to crown_marketplace_allow_list_index_path
   end
 
   def search_allow_list

--- a/app/helpers/crown_marketplace/framework_helper.rb
+++ b/app/helpers/crown_marketplace/framework_helper.rb
@@ -1,0 +1,7 @@
+module CrownMarketplace::FrameworkHelper
+  def crown_marketplace_breadcrumbs(*breadcrumbs)
+    breadcrumbs.prepend({ text: 'Home', link: crown_marketplace_path })
+
+    govuk_breadcrumbs(*breadcrumbs)
+  end
+end

--- a/app/helpers/header_navigation_links_helper.rb
+++ b/app/helpers/header_navigation_links_helper.rb
@@ -32,7 +32,7 @@ module HeaderNavigationLinksHelper
   end
 
   def crown_marketplace_navigation_link
-    { link_text: t('header_navigation_links_helper.back_to_start'), link_url: crown_marketplace_path } if user_signed_in? && request.path != crown_marketplace_allow_list_index_path
+    { link_text: crown_marketplace_back_to_start_text, link_url: crown_marketplace_path } unless sign_in_or_dashboard?('home')
   end
 
   def facilites_management_admin_navigation_link
@@ -63,6 +63,10 @@ module HeaderNavigationLinksHelper
 
   def page_with_back_to_start?
     fm_back_to_start_page? || fm_activate_account_landing_page?
+  end
+
+  def crown_marketplace_back_to_start_text
+    passwords_page? || !user_signed_in? ? t('header_navigation_links_helper.back_to_start') : t('header_navigation_links_helper.crown_marketplace')
   end
 
   def supplier_back_to_start_text

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -39,10 +39,11 @@ class Ability
 
     can :read, :all
     can :manage, FacilitiesManagement::Admin
+    cannot :read, AllowedEmailDomain
   end
 
   def allow_list_specific_auth(user)
-    if user.has_role?(:ccs_user_admin)
+    if user.has_role?(:ccs_user_admin) || user.has_role?(:ccs_developer)
       can :manage, AllowedEmailDomain
     elsif user.has_role?(:allow_list_access)
       can :read, AllowedEmailDomain

--- a/app/views/crown_marketplace/allow_list/_allow_list_table.html.erb
+++ b/app/views/crown_marketplace/allow_list/_allow_list_table.html.erb
@@ -13,10 +13,10 @@
       </tr>
     <% elsif can? :manage, AllowedEmailDomain %>
       <% paginated_allow_list.each do |domain| %>
-        <tr class="govuk-table__row" style="<%= 'background: #F0FFF1' if domain == email_domain_added %>">
+        <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-padding-right-2"><%= domain %></td>
           <td class="govuk-table__cell govuk-!-padding-right-2">
-            <%= link_to t('.remove'), crown_marketplace_allow_list_delete_path(email_domain: domain), class: 'govuk-link--no-visited-state' %>
+            <%= link_to t('.remove'), delete_crown_marketplace_allow_list_index_path(email_domain: domain), class: 'govuk-link--no-visited-state' %>
           </td>
         </tr>
       <% end %>

--- a/app/views/crown_marketplace/allow_list/delete.html.erb
+++ b/app/views/crown_marketplace/allow_list/delete.html.erb
@@ -1,4 +1,8 @@
 <%= content_for :page_title, t('.page_title') %>
+<%= crown_marketplace_breadcrumbs(
+  { text: t('crown_marketplace.allow_list.index.heading_title'), link: crown_marketplace_allow_list_index_path },
+  { text: t('.page_title') }
+)%>
 
 <h1 class="govuk-heading-m">
   <%= t('.are_you_sure', email_domain: params[:email_domain])%>
@@ -8,7 +12,7 @@
   <%= t('.re_add') %>
 </p>
 
-<%= form_with url: crown_marketplace_allow_list_destroy_path, model: @allowed_email_domain, method: :delete, local: true, html: { specialvalidation: true } do |f| %>
+<%= form_with url: destroy_crown_marketplace_allow_list_index_path, model: @allowed_email_domain, method: :delete, local: true, html: { specialvalidation: true } do |f| %>
   <%= f.hidden_field :email_domain, value: params[:email_domain] %>
 
   <%= f.submit t('.remove'), class: 'govuk-button govuk-button--warning govuk-!-margin-right-4' %>

--- a/app/views/crown_marketplace/allow_list/index.html.erb
+++ b/app/views/crown_marketplace/allow_list/index.html.erb
@@ -1,10 +1,10 @@
 <%= content_for :page_title, t('.heading_title') %>
-
-<%= govuk_notification_banner(:success, t('.added')) { t('.was_added', email_domain: params[:email_domain_added]) } unless params[:email_domain_added].blank? %>
-<%= govuk_notification_banner(:success, t('.removed')) { t('.was_removed', email_domain: params[:email_domain_removed]) } unless params[:email_domain_removed].blank? %>
+<%= crown_marketplace_breadcrumbs({ text: t('.heading_title') })%>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= govuk_notification_banner(:success, t('.added')) { t('.was_added', email_domain: flash[:email_domain_added]) } unless flash[:email_domain_added].blank? %>
+    <%= govuk_notification_banner(:success, t('.removed')) { t('.was_removed', email_domain: flash[:email_domain_removed]) } unless flash[:email_domain_removed].blank? %>
     <h1 class="govuk-heading-xl"><%= t('.heading_title') %></h1>
     <p>
       <%= t('.in_order_to') %>
@@ -30,17 +30,12 @@
 
 <div class="govuk-grid-row" id="allow-list-search-container">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: crown_marketplace_allow_list_search_allow_list_path, model: @allowed_email_domain, method: :get, remote: true, html: { specialvalidation: true } do |f| %>
+    <%= form_with url: search_allow_list_crown_marketplace_allow_list_index_path, model: @allowed_email_domain, method: :get, remote: true, html: { specialvalidation: true } do |f| %>
       <%= hidden_field_tag :email_domain_added, params[:email_domain_added] %>
       <%= f.label :email_domain, t('.find_an_email_domain'), class: 'govuk-label--m' %>
       <p class="govuk-hint" id="allow-list-search-hint">
         <%= t('.enter_an_email_domain') %>
       </p>
-      <div id="domain-not-found" hidden>
-        <span class="govuk-error-message">
-          <%= t('.not_in_allow_list') %>
-        </span>
-      </div>
       <%= f.text_field  :email_domain, class: 'govuk-input govuk-!-width-three-quarters govuk-!-margin-right-2', type: 'search', aria: { describedby: 'allow-list-search-hint' } %>
       <%= f.submit t('.search'), class: 'govuk-button govuk-button--secondary' %>
     <% end %>
@@ -49,6 +44,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="allow-list-table">
-    <%= render(partial: 'allow_list_table', locals: { paginated_allow_list: @paginated_allow_list, email_domain_added: params[:email_domain_added] }) %>
+    <%= render(partial: 'allow_list_table', locals: { paginated_allow_list: @paginated_allow_list }) %>
   </div>
 </div>

--- a/app/views/crown_marketplace/allow_list/new.html.erb
+++ b/app/views/crown_marketplace/allow_list/new.html.erb
@@ -1,4 +1,8 @@
 <%= content_for :page_title, t('.heading') %>
+<%= crown_marketplace_breadcrumbs(
+  { text: t('crown_marketplace.allow_list.index.heading_title'), link: crown_marketplace_allow_list_index_path },
+  { text: t('.heading') }
+)%>
 
 <%= render partial: 'shared/error_summary', locals: { errors: @allowed_email_domain.errors } %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -360,6 +360,13 @@ en:
     unacceptable:
       changes_rejected: Sorry, the change you wanted was rejected
       explanation: Maybe you tried to change something you didn’t have access to.
+  header_navigation_links_helper:
+    admin_dashboard: Admin dashboard
+    back_to_start: Back to start
+    crown_marketplace: Crown Marketplace dashboard
+    my_account: My account
+    my_dashboard: My dashboard
+    sign_out: Sign out
   home:
     accessibility_statement:
       CCS_is_committed: Crown Commercial Service is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.

--- a/config/locales/views/crown_marketplace.en.yml
+++ b/config/locales/views/crown_marketplace.en.yml
@@ -50,7 +50,6 @@ en:
         in_order_to: In order to create an account for three of the Crown Marketplace services, the user must use an email which has a domain contained within this list.
         legal_services: Legal Services
         management_consultancy: Management Consultancy
-        not_in_allow_list: The email domain could not be found in the Allow list
         removed: Email domain removed
         search: Search
         the_four_Services_are: 'The three Crown Marketplace services are:'

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -544,9 +544,3 @@ en:
           tupe: TUPE
     users:
       sign_in_error: You must provide a correct username or password
-  header_navigation_links_helper:
-    admin_dashboard: Admin dashboard
-    back_to_start: Back to start
-    my_account: My account
-    my_dashboard: My dashboard
-    sign_out: Sign out

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -231,10 +231,13 @@ Rails.application.routes.draw do
     concerns :shared_pages
 
     get '/', to: 'home#index'
-    resources :allow_list, path: 'allow-list', only: %i[index new create]
-    delete '/allow-list/destroy', to: 'allow_list#destroy'
-    get '/allow-list/delete', to: 'allow_list#delete'
-    get '/allow-list/search_allow_list', to: 'allow_list#search_allow_list'
+    resources :allow_list, path: 'allow-list', only: %i[index new create] do
+      collection do
+        delete '/destroy', action: :destroy
+        get '/delete', action: :delete
+        get '/search_allow_list', action: :search_allow_list
+      end
+    end
   end
 
   get '/404', to: 'errors#not_found', as: :errors_404

--- a/features/accessibility/crown_marketplace/user_admin/allow_list_accessibility.feature
+++ b/features/accessibility/crown_marketplace/user_admin/allow_list_accessibility.feature
@@ -1,0 +1,20 @@
+@allow_list @javascript @accessibility
+Feature: Allow list - User admin - accessibility
+
+  Background: Sign in and navigate to the allow list page
+    Given I sign in as an 'user admin' user go to the crown marketplace dashboard
+    # When I click on 'Allow list'
+    # Then I am on the 'Allow list' page
+
+  Scenario: Allow list page
+    And the page should be axe clean
+
+  Scenario: Add email domain page
+    And I click on 'Add a new email domain'
+    Then I am on the 'Add an email domain' page
+    And the page should be axe clean
+
+  Scenario: Remove email domain page
+    And I click on remove for 'example.com'
+    Then I am on the "Are you sure you want to remove 'example.com' from the Allow list?" page
+    And the page should be axe clean

--- a/features/accessibility/crown_marketplace/user_support/allow_list_accessibility.feature
+++ b/features/accessibility/crown_marketplace/user_support/allow_list_accessibility.feature
@@ -1,0 +1,8 @@
+@allow_list @javascript @accessibility
+Feature: Allow list - User support - accessibility
+
+  Scenario: Allow list page
+    Given I sign in as an 'user support' user go to the crown marketplace dashboard
+    # When I click on 'Allow list'
+    # Then I am on the 'Allow list' page
+    And the page should be axe clean

--- a/features/crown_marketplace/allow_list/user_admin/add_email_domain.feature
+++ b/features/crown_marketplace/allow_list/user_admin/add_email_domain.feature
@@ -1,0 +1,34 @@
+@allow_list
+Feature: Allow list - User admin - Add email domain
+
+  Background: Sign in and navigate to the allow list page
+    Given I sign in as an 'user admin' user go to the crown marketplace dashboard
+    # When I click on 'Allow list'
+    # Then I am on the 'Allow list' page
+    And the following email domains are in the list:
+      | email.com   |
+      | example.com |
+      | test.com    |
+    And I click on 'Add a new email domain'
+    Then I am on the 'Add an email domain' page
+
+  @pipeline
+  Scenario: Add email domain
+    And I enter 'new.emai.com' for the email domain
+    And I click on 'Save and continue'
+    Then I am on the 'Allow list' page
+    And the email domian 'new.emai.com' has been succesffuly added
+    And the following email domains are in the list:
+      | email.com     |
+      | example.com   |
+      | new.emai.com  |
+      | test.com      |
+
+  Scenario: Return links work
+    Given I click on '<text>'
+    Then I am on the 'Allow list' page
+
+    Examples:
+      | text                      |
+      | Return to the allow list  |
+      | Allow list                |

--- a/features/crown_marketplace/allow_list/user_admin/remove_email_domain.feature
+++ b/features/crown_marketplace/allow_list/user_admin/remove_email_domain.feature
@@ -1,0 +1,31 @@
+@allow_list
+Feature: Allow list - User admin - Remove email domain
+
+  Background: Sign in and navigate to the allow list page
+    Given I sign in as an 'user admin' user go to the crown marketplace dashboard
+    # When I click on 'Allow list'
+    # Then I am on the 'Allow list' page
+    And the following email domains are in the list:
+      | email.com   |
+      | example.com |
+      | test.com    |
+    And I click on remove for 'example.com'
+    Then I am on the "Are you sure you want to remove 'example.com' from the Allow list?" page
+
+  @pipeline
+  Scenario: Remove email domain
+    And I click on 'Remove'
+    Then I am on the 'Allow list' page
+    And the email domian 'example.com' has been succesffuly removed
+    And the following email domains are in the list:
+      | email.com     |
+      | test.com      |
+
+  Scenario: Return links work
+    Given I click on '<text>'
+    Then I am on the 'Allow list' page
+
+    Examples:
+      | text                      |
+      | Return to the allow list  |
+      | Allow list                |

--- a/features/crown_marketplace/allow_list/user_admin/search_allow_list.feature
+++ b/features/crown_marketplace/allow_list/user_admin/search_allow_list.feature
@@ -1,0 +1,24 @@
+@allow_list @javascript @pipeline
+Feature: Allow list - User admin - Search allow list
+
+  Scenario: Serach allow list
+    Given I sign in as an 'user admin' user go to the crown marketplace dashboard
+    # When I click on 'Allow list'
+    # Then I am on the 'Allow list' page
+    And the following email domains are in the list:
+      | email.com   |
+      | example.com |
+      | test.com    |
+    And I enter 'te' into the email domain search
+    And the following email domains are in the list:
+      | test.com    |
+    And I enter 'test.co.uk' into the email domain search
+    And the following email domains are in the list:
+      | No email domains found  |
+    And I enter '' into the email domain search
+    And the following email domains are in the list:
+      | email.com   |
+      | example.com |
+      | test.com    |
+    # And I click on 'Home'
+    # Then I am on the 'Crown Marketplace dashboard' page

--- a/features/crown_marketplace/allow_list/user_admin/validations/add_email_domain_validations.feature
+++ b/features/crown_marketplace/allow_list/user_admin/validations/add_email_domain_validations.feature
@@ -1,0 +1,19 @@
+@allow_list @pipeline
+Feature: Allow list - User admin - Add email domain - Validations
+
+  Scenario Outline: Add email domain
+    Given I sign in as an 'user admin' user go to the crown marketplace dashboard
+    # When I click on 'Allow list'
+    # Then I am on the 'Allow list' page
+    And I click on 'Add a new email domain'
+    Then I am on the 'Add an email domain' page
+    And I enter '<email_domain>' for the email domain
+    And I click on 'Save and continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | email_domain    | error_message                                                             |
+      |                 | Enter an email domain                                                     |
+      | !nvalid.d()ma!n | The email domain can only contain letters, numbers, hyphens or full stops |
+      | test.com        | The email domain is already in the Allow list                             |

--- a/features/crown_marketplace/allow_list/user_support/add_email_domain.feature
+++ b/features/crown_marketplace/allow_list/user_support/add_email_domain.feature
@@ -1,0 +1,12 @@
+@allow_list @pipeline
+Feature: Allow list - User support - Add email domain
+
+  Scenario: I cannot add an email domain
+    Given I sign in as an 'user support' user go to the crown marketplace dashboard
+    # When I click on 'Allow list'
+    # Then I am on the 'Allow list' page
+    And the following email domains are in the list:
+      | email.com   |
+      | example.com |
+      | test.com    |
+    And I cannot add an email domain

--- a/features/crown_marketplace/allow_list/user_support/remove_email_domain.feature
+++ b/features/crown_marketplace/allow_list/user_support/remove_email_domain.feature
@@ -1,0 +1,12 @@
+@allow_list @pipeline
+Feature: Allow list - User support - Remove email domain
+
+  Scenario: I cannot remove an email domain
+    Given I sign in as an 'user support' user go to the crown marketplace dashboard
+    # When I click on 'Allow list'
+    # Then I am on the 'Allow list' page
+    And the following email domains are in the list:
+      | email.com   |
+      | example.com |
+      | test.com    |
+    And I cannot remove an email domain

--- a/features/crown_marketplace/allow_list/user_support/search_allow_list.feature
+++ b/features/crown_marketplace/allow_list/user_support/search_allow_list.feature
@@ -1,0 +1,24 @@
+@allow_list @javascript @pipeline
+Feature: Allow list - User support - Search allow list
+
+  Scenario: Serach allow list
+    Given I sign in as an 'user support' user go to the crown marketplace dashboard
+    # When I click on 'Allow list'
+    # Then I am on the 'Allow list' page
+    And the following email domains are in the list:
+      | email.com   |
+      | example.com |
+      | test.com    |
+    And I enter 'te' into the email domain search
+    And the following email domains are in the list:
+      | test.com    |
+    And I enter 'test.co.uk' into the email domain search
+    And the following email domains are in the list:
+      | No email domains found  |
+    And I enter '' into the email domain search
+    And the following email domains are in the list:
+      | email.com   |
+      | example.com |
+      | test.com    |
+    # And I click on 'Home'
+    # Then I am on the 'Crown Marketplace dashboard' page

--- a/features/crown_marketplace/home/footer/footer_signed_in.feature
+++ b/features/crown_marketplace/home/footer/footer_signed_in.feature
@@ -1,0 +1,26 @@
+@allow_list
+Feature: Crown Marketplace admin footer links - signed in
+
+  Background: Crown Marketplace admin signs in
+    Given I sign in as an 'super admin' user go to the crown marketplace dashboard
+
+  Scenario: Cookies policy
+    When I click on 'Cookie policy'
+    Then I am on the 'Details about cookies on Crown Marketplace' page
+    And I click on 'Crown Marketplace dashboard'
+    # Then I am on the 'Crown Marketplace dashboard' page
+    Then I am on the 'Allow list' page
+
+  Scenario: Cookies settings
+    When I click on 'Cookie settings'
+    Then I am on the 'Cookies on Crown Marketplace' page
+    And I click on 'Crown Marketplace dashboard'
+    # Then I am on the 'Crown Marketplace dashboard' page
+    Then I am on the 'Allow list' page
+
+  Scenario: Accessibility statement
+    When I click on 'Accessibility statement'
+    Then I am on the 'Facilities Management (FM) Accessibility statement' page
+    And I click on 'Crown Marketplace dashboard'
+    # Then I am on the 'Crown Marketplace dashboard' page
+    Then I am on the 'Allow list' page

--- a/features/crown_marketplace/home/footer/footer_signed_out.feature
+++ b/features/crown_marketplace/home/footer/footer_signed_out.feature
@@ -1,0 +1,16 @@
+Feature: Crown Marketplace admin footer links - signed out
+
+  Background: Crown Marketplace admin on sign in page
+    Given I go to the crown marketplace start page
+
+  Scenario: Cookies policy
+    When I click on 'Cookie policy'
+    Then I am on the 'Details about cookies on Crown Marketplace' page
+
+  Scenario: Cookies settings
+    When I click on 'Cookie settings'
+    Then I am on the 'Cookies on Crown Marketplace' page
+
+  Scenario: Accessibility statement
+    When I click on 'Accessibility statement'
+    Then I am on the 'Facilities Management (FM) Accessibility statement' page

--- a/features/crown_marketplace/home/navigation_links/navigation_links_signed_in.feature
+++ b/features/crown_marketplace/home/navigation_links/navigation_links_signed_in.feature
@@ -1,0 +1,108 @@
+@allow_list
+Feature: Navigation links when signed in
+
+  Background: Crown Marketplace admin signs in
+    Given I sign in as an 'super admin' user go to the crown marketplace dashboard
+
+  Scenario: Cookies policy - Crown Marketplace dashboard
+    When I click on 'Cookie policy'
+    Then I am on the 'Details about cookies on Crown Marketplace' page
+    And I should see the following navigation links:
+      | Crown Marketplace dashboard |
+      | Sign out                    |
+    And I click on 'Crown Marketplace dashboard'
+    # Then I am on the 'Crown Marketplace dashboard' page
+    Then I am on the 'Allow list' page
+
+  Scenario: Cookies policy - Sign out
+    When I click on 'Cookie policy'
+    Then I am on the 'Details about cookies on Crown Marketplace' page
+    And I should see the following navigation links:
+      | Crown Marketplace dashboard |
+      | Sign out                    |
+    And I click on 'Sign out'
+    And I am on the 'Sign in to manage Crown Marketplace' page
+
+  Scenario: Cookies settings - Crown Marketplace dashboard
+    When I click on 'Cookie settings'
+    Then I am on the 'Cookies on Crown Marketplace' page
+    And I should see the following navigation links:
+      | Crown Marketplace dashboard |
+      | Sign out                    |
+    And I click on 'Crown Marketplace dashboard'
+    # Then I am on the 'Crown Marketplace dashboard' page
+    Then I am on the 'Allow list' page
+
+  Scenario: Cookies settings - Sign out
+    When I click on 'Cookie settings'
+    Then I am on the 'Cookies on Crown Marketplace' page
+    And I should see the following navigation links:
+      | Crown Marketplace dashboard |
+      | Sign out                    |
+    And I click on 'Sign out'
+    And I am on the 'Sign in to manage Crown Marketplace' page
+
+  Scenario: Accessibility statement - Crown Marketplace dashboard
+    When I click on 'Accessibility statement'
+    Then I am on the 'Facilities Management (FM) Accessibility statement' page
+    And I should see the following navigation links:
+      | Crown Marketplace dashboard |
+      | Sign out                    |
+    And I click on 'Crown Marketplace dashboard'
+    # Then I am on the 'Crown Marketplace dashboard' page
+    Then I am on the 'Allow list' page
+
+  Scenario: Accessibility statement - Sign out
+    When I click on 'Accessibility statement'
+    Then I am on the 'Facilities Management (FM) Accessibility statement' page
+    And I should see the following navigation links:
+      | Crown Marketplace dashboard |
+      | Sign out                    |
+    And I click on 'Sign out'
+    And I am on the 'Sign in to manage Crown Marketplace' page
+
+  # Scenario: Crown Marketplace dashboard - Sign out
+  #   And I should see the following navigation links:
+  #     | Sign out                    |
+  #   And I click on 'Sign out'
+  #   And I am on the 'Sign in to manage Crown Marketplace' page
+
+  Scenario: Accessibility statement - Crown Marketplace dashboard
+    When I click on 'Accessibility statement'
+    Then I am on the 'Facilities Management (FM) Accessibility statement' page
+    And I should see the following navigation links:
+      | Crown Marketplace dashboard |
+      | Sign out                    |
+    And I click on 'Crown Marketplace dashboard'
+    # Then I am on the 'Crown Marketplace dashboard' page
+    Then I am on the 'Allow list' page
+
+  Scenario: Accessibility statement - Sign out
+    When I click on 'Accessibility statement'
+    Then I am on the 'Facilities Management (FM) Accessibility statement' page
+    And I should see the following navigation links:
+      | Crown Marketplace dashboard |
+      | Sign out                    |
+    And I click on 'Sign out'
+    And I am on the 'Sign in to manage Crown Marketplace' page
+
+  @allow_list
+  Scenario: Crown Marketplace admin page - Crown Marketplace dashboard
+    # When I click on 'Allow list'
+    # Then I am on the 'Allow list' page
+    And I should see the following navigation links:
+      | Crown Marketplace dashboard |
+      | Sign out                    |
+    And I click on 'Crown Marketplace dashboard'
+    # Then I am on the 'Crown Marketplace dashboard' page
+    Then I am on the 'Allow list' page
+
+  @allow_list
+  Scenario: Crown Marketplace admin page - Accessibility statement - Sign out
+    # When I click on 'Allow list'
+    # Then I am on the 'Allow list' page
+    And I should see the following navigation links:
+      | Crown Marketplace dashboard |
+      | Sign out                    |
+    And I click on 'Sign out'
+    And I am on the 'Sign in to manage Crown Marketplace' page

--- a/features/crown_marketplace/home/navigation_links/navigation_links_signed_out.feature
+++ b/features/crown_marketplace/home/navigation_links/navigation_links_signed_out.feature
@@ -1,0 +1,36 @@
+Feature: Navigation links when signed out
+
+  Background: Crown Marketplace admin on sign in page
+    Given I go to the crown marketplace start page
+
+  Scenario: Sign in page 
+    Then there are no header navigation links
+
+  Scenario: Not permitted page
+    And I go to the crown marketplace not permitted page
+    And I should see the following navigation links:
+      | Back to start |
+
+  Scenario: Cookies policy
+    When I click on 'Cookie policy'
+    Then I am on the 'Details about cookies on Crown Marketplace' page
+    And I should see the following navigation links:
+      | Back to start |
+    And I click on 'Back to start'
+    And I am on the 'Sign in to manage Crown Marketplace' page
+
+  Scenario: Cookies settings
+    When I click on 'Cookie settings'
+    Then I am on the 'Cookies on Crown Marketplace' page
+    And I should see the following navigation links:
+      | Back to start |
+    And I click on 'Back to start'
+    And I am on the 'Sign in to manage Crown Marketplace' page
+
+  Scenario: Accessibility statement
+    When I click on 'Accessibility statement'
+    Then I am on the 'Facilities Management (FM) Accessibility statement' page
+    And I should see the following navigation links:
+      | Back to start |
+    And I click on 'Back to start'
+    And I am on the 'Sign in to manage Crown Marketplace' page

--- a/features/helpers/facilities_management/allow_list_helper.rb
+++ b/features/helpers/facilities_management/allow_list_helper.rb
@@ -1,6 +1,6 @@
 def stub_allow_list
   @allow_list_file = Tempfile.new('allow_list.txt')
-  @allow_list_file.write(['test.com'].join("\n"))
+  @allow_list_file.write(['email.com', 'example.com', 'test.com'].join("\n"))
   @allow_list_file.close
   allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list_file_path).and_return(@allow_list_file.path)
 end

--- a/features/helpers/facilities_management/logging_in_helper.rb
+++ b/features/helpers/facilities_management/logging_in_helper.rb
@@ -42,3 +42,16 @@ def create_user(option)
   allow_any_instance_of(Cognito::UpdateUser).to receive(:call).with(anything).and_return(true)
   stub_login
 end
+
+def create_admin_user(user_type)
+  @user = create(:user, confirmed_at: Time.zone.now, roles: [USER_TYPE_TO_ROLE[user_type]])
+  allow_any_instance_of(Cognito::UpdateUser).to receive(:call).and_return(true)
+  allow_any_instance_of(Cognito::UpdateUser).to receive(:call).with(anything).and_return(true)
+  stub_login
+end
+
+USER_TYPE_TO_ROLE = {
+  'user support' => :allow_list_access,
+  'user admin' => :ccs_user_admin,
+  'super admin' => :ccs_developer
+}.freeze

--- a/features/step_definitions/crown_marketplace/allow_list_steps.rb
+++ b/features/step_definitions/crown_marketplace/allow_list_steps.rb
@@ -1,0 +1,41 @@
+Then('I enter {string} for the email domain') do |email_domain|
+  allow_list_page.add_email_domain_form.email_domain.set(email_domain)
+end
+
+Then('the following email domains are in the list:') do |email_domains_table|
+  expected_email_domains = email_domains_table.raw.flatten
+  actual_email_domains = allow_list_page.email_domains_table.rows.map(&:email_domain)
+
+  expect(expected_email_domains.length).to eq actual_email_domains.length
+
+  actual_email_domains.zip(expected_email_domains).each do |element, value|
+    expect(element).to have_content(value)
+  end
+end
+
+Then('I click on remove for {string}') do |email_domain|
+  allow_list_page.email_domains_table.rows.find { |row| row.email_domain.text == email_domain }.remove_link.click
+end
+
+Then('the email domian {string} has been succesffuly added') do |email_domain|
+  expect(allow_list_page.notification_banner.heading).to have_content('Email domain added')
+  expect(allow_list_page.notification_banner.message).to have_content("'#{email_domain}' was added to the allow list")
+end
+
+Then('the email domian {string} has been succesffuly removed') do |email_domain|
+  expect(allow_list_page.notification_banner.heading).to have_content('Email domain removed')
+  expect(allow_list_page.notification_banner.message).to have_content("'#{email_domain}' was removed from the allow list")
+end
+
+Then('I enter {string} into the email domain search') do |email_domain|
+  allow_list_page.email_domain_search.input.fill_in with: email_domain
+  allow_list_page.email_domain_search.button.click
+end
+
+Then('I cannot add an email domain') do
+  expect(allow_list_page).not_to have_selector 'a[href="/crown-marketplace/allow-list/new"]'
+end
+
+Then('I cannot remove an email domain') do
+  expect(allow_list_page.email_domains_table.rows.map { |row| row.all('a') }.all?(&:empty?)).to be true
+end

--- a/features/step_definitions/crown_marketplace/home_steps.rb
+++ b/features/step_definitions/crown_marketplace/home_steps.rb
@@ -1,0 +1,19 @@
+Given('I sign in as an {string} user go to the crown marketplace dashboard') do |user|
+  visit '/crown-marketplace/sign-in'
+  update_banner_cookie(true) if @javascript
+  create_admin_user(user)
+  fill_in 'email', with: @user.email
+  fill_in 'password', with: 'ValidPassword'
+  click_on 'Sign in'
+  # expect(page.find('h1')).to have_content('Crown Marketplace dashboard')
+  expect(page.find('h1')).to have_content('Allow list')
+end
+
+Given('I go to the crown marketplace start page') do
+  visit '/crown-marketplace/sign-in'
+  update_banner_cookie(true) if @javascript
+end
+
+Given('I go to the crown marketplace not permitted page') do
+  visit 'crown-marketplace/not-permitted'
+end

--- a/features/support/pages.rb
+++ b/features/support/pages.rb
@@ -1,4 +1,8 @@
 module Pages
+  def allow_list_page
+    @allow_list_page ||= AllowList.new
+  end
+
   def admin_page
     @admin_page ||= case @framework
                     when 'RM3830'

--- a/features/support/pages/allow_list.rb
+++ b/features/support/pages/allow_list.rb
@@ -1,0 +1,26 @@
+module Pages
+  class EmailDomainRowSection < SitePrism::Section
+    element :email_domain, 'td:nth-of-type(1)'
+    element :remove_link, 'td:nth-of-type(2) > a'
+  end
+
+  class AllowList < SitePrism::Page
+    section :email_domains_table, '#allow-list-table > table' do
+      sections :rows, EmailDomainRowSection, 'tbody > tr'
+    end
+
+    section :email_domain_search, '#allow-list-search-container > div > form' do
+      element :input, '#allowed_email_domain_email_domain'
+      element :button, 'input.govuk-button.govuk-button--secondary'
+    end
+
+    section :add_email_domain_form, '#email_domain-form-group' do
+      element :email_domain, '#allowed_email_domain_email_domain'
+    end
+
+    section :notification_banner, '#main-content > div:nth-child(3) > div > div.govuk-notification-banner.govuk-notification-banner--success' do
+      element :heading, 'div.govuk-notification-banner__content > p.govuk-notification-banner__heading'
+      element :message, 'div.govuk-notification-banner__content > p.govuk-body'
+    end
+  end
+end

--- a/spec/controllers/crown_marketplace/allow_list_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/allow_list_controller_spec.rb
@@ -87,8 +87,9 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
     context 'when the email domain is valid' do
       let(:email_domain) { 'email-domain.com' }
 
-      it 'redirects to the index page' do
-        expect(response).to redirect_to crown_marketplace_allow_list_index_path(email_domain_added: email_domain)
+      it 'redirects to the allow list index page with the flash message' do
+        expect(response).to redirect_to crown_marketplace_allow_list_index_path
+        expect(flash[:email_domain_added]).to eq email_domain
       end
     end
   end
@@ -148,10 +149,11 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
   describe 'DESTROY destroy' do
     login_crown_marketplace_admin
 
-    it 'redirects to the allow list page' do
+    it 'redirects to the allow list index page with the flash message' do
       delete :destroy, params: { allowed_email_domain: { email_domain: 'email.com' } }
 
-      expect(response).to redirect_to crown_marketplace_allow_list_index_path(email_domain_removed: 'email.com')
+      expect(response).to redirect_to crown_marketplace_allow_list_index_path
+      expect(flash[:email_domain_removed]).to eq 'email.com'
     end
   end
 end

--- a/spec/controllers/crown_marketplace/home_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/home_controller_spec.rb
@@ -176,4 +176,64 @@ RSpec.describe CrownMarketplace::HomeController, type: :controller do
       expect(response).to render_template('home/not_permitted')
     end
   end
+
+  describe 'GET #index' do
+    context 'when not logged in' do
+      before { get :index }
+
+      it 'redirects to the sign in page' do
+        expect(response).to redirect_to crown_marketplace_new_user_session_path
+      end
+    end
+
+    context 'when logged in as a user support user' do
+      login_crown_marketplace_read_only
+
+      before { get :index }
+
+      it 'renders the index page' do
+        expect(response).to redirect_to crown_marketplace_allow_list_index_path
+      end
+    end
+
+    context 'when logged in as a user admin user' do
+      login_crown_marketplace_admin
+
+      before { get :index }
+
+      it 'renders the index page' do
+        expect(response).to redirect_to crown_marketplace_allow_list_index_path
+      end
+    end
+
+    context 'when logged in as a super admin user' do
+      login_ccs_developer
+
+      before { get :index }
+
+      it 'renders the index page' do
+        expect(response).to redirect_to crown_marketplace_allow_list_index_path
+      end
+    end
+
+    context 'when not logged in as an fm admin' do
+      login_fm_admin
+
+      before { get :index }
+
+      it 'redirects to the not permitted page' do
+        expect(response).to redirect_to '/crown-marketplace/not-permitted'
+      end
+    end
+
+    context 'when not logged in a non-admin' do
+      login_fm_buyer
+
+      before { get :index }
+
+      it 'redirects to the not permitted page' do
+        expect(response).to redirect_to '/crown-marketplace/not-permitted'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Setup for ticket: [FMFR-1315](https://crowncommercialservice.atlassian.net/browse/FMFR-1315)

We are going to be adding the ability for CSC to manage user accounts through the application.

Before we do this, I am going to make a few updates to the allow list section (adding breadcrumbs).

I’ve also added feature tests as I want to add them for the rest of the sections that we will add to crown marketplace later.