### PR TITLE
FMFR-1318 - Add ability to add users

### DIFF
--- a/app/controllers/crown_marketplace/manage_users_controller.rb
+++ b/app/controllers/crown_marketplace/manage_users_controller.rb
@@ -1,0 +1,119 @@
+class CrownMarketplace::ManageUsersController < CrownMarketplace::FrameworkController
+  before_action :authorize_user, :set_current_user_access
+  before_action :redirect_if_unrecognised_add_user_section, :continue_if_user_support, only: %i[add_user create_add_user]
+  before_action :continue_if_role_does_not_require_service_access, only: :add_user
+  before_action :set_new_user, only: %i[add_user new]
+
+  helper_method :section, :available_roles, :role_requires_service_access?
+
+  def add_user; end
+
+  def create_add_user
+    @user = Cognito::Admin::User.new(@current_user_access, add_user_params)
+
+    if @user.valid?(section)
+      next_section = ADD_USER_SECTIONS[ADD_USER_SECTIONS.index(section) + 1]
+
+      if next_section
+        redirect_to add_user_crown_marketplace_manage_users_path(section: next_section.to_s.dasherize, **add_user_params.to_h)
+      else
+        redirect_to new_crown_marketplace_manage_user_path(**add_user_params.to_h)
+      end
+    else
+      render :add_user
+    end
+  end
+
+  def new; end
+
+  def create
+    @user = Cognito::Admin::User.new(@current_user_access, create_user_params)
+
+    if @user.create
+      flash[:account_added] = @user.email
+
+      redirect_to crown_marketplace_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def section
+    @section ||= params[:section]&.underscore&.to_sym
+  end
+
+  def available_roles
+    @available_roles ||= @user&.cognito_roles&.available_roles || Cognito::Admin::Roles.find_available_roles(@current_user_access)
+  end
+
+  def redirect_if_unrecognised_add_user_section
+    redirect_to crown_marketplace_path unless ADD_USER_SECTIONS.include?(section)
+  end
+
+  def continue_if_user_support
+    redirect_to add_user_crown_marketplace_manage_users_path(section: 'select-service-access', roles: ['buyer']) if section == :select_role && @current_user_access == :user_support
+  end
+
+  def continue_if_role_does_not_require_service_access
+    return unless section == :select_service_access && !role_requires_service_access?(params[:roles])
+
+    redirect_to add_user_crown_marketplace_manage_users_path(section: 'enter-user-details', **filter_user_params)
+  end
+
+  def add_user_params
+    if params[:cognito_admin_user]
+      params.require(:cognito_admin_user).permit(ADD_USER_PERMITTED_PARAMS)
+    else
+      {}
+    end
+  end
+
+  def create_user_params
+    if params[:cognito_admin_user]
+      params.require(:cognito_admin_user).permit(CREATE_PERMITTED_PARAMS)
+    else
+      {}
+    end
+  end
+
+  def role_requires_service_access?(roles)
+    [['buyer'], ['ccs_employee']].include?(roles)
+  end
+
+  def authorize_user
+    authorize! :read, AllowedEmailDomain
+  end
+
+  def set_current_user_access
+    @current_user_access = Cognito::Admin::Roles.current_user_access(current_ability)
+  end
+
+  def set_new_user
+    @user = Cognito::Admin::User.new(@current_user_access, filter_user_params)
+  end
+
+  def filter_user_params
+    {
+      roles: params[:roles],
+      service_access: params[:service_access],
+      email: params[:email],
+      telephone_number: params[:telephone_number]
+    }.select { |_, value| value.present? }
+  end
+
+  ADD_USER_SECTIONS = %i[select_role select_service_access enter_user_details].freeze
+  ADD_USER_PERMITTED_PARAMS = [
+    :email,
+    :telephone_number,
+    { roles: [] },
+    { service_access: [] }
+  ].freeze
+  CREATE_PERMITTED_PARAMS = [
+    :email,
+    :telephone_number,
+    { roles: [] },
+    { service_access: [] }
+  ].freeze
+end

--- a/app/helpers/crown_marketplace/manage_users_helper.rb
+++ b/app/helpers/crown_marketplace/manage_users_helper.rb
@@ -1,0 +1,12 @@
+module CrownMarketplace::ManageUsersHelper
+  def add_users_back_link(user, section_name)
+    link_params = {
+      roles: user.roles,
+      service_access: user.service_access,
+      email: user.email,
+      telephone_number: user.telephone_number
+    }
+
+    add_user_crown_marketplace_manage_users_path(section: section_name, **link_params.select { |_, value| value.present? })
+  end
+end

--- a/app/services/cognito/admin/user_client_interface.rb
+++ b/app/services/cognito/admin/user_client_interface.rb
@@ -38,6 +38,22 @@ module Cognito
           { users: [], error: e.message }
         end
 
+        def user_with_email_exists(email)
+          client = new_client
+
+          list_users_resp = client.list_users(
+            {
+              user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+              attributes_to_get: ['email'],
+              filter: "email = \"#{email}\""
+            }
+          )
+
+          { result: list_users_resp.users.any? }
+        rescue Aws::CognitoIdentityProvider::Errors::ServiceError => e
+          { error: e.message }
+        end
+
         def update_user_and_return_errors(cognito_uuid, attributes, method)
           client = new_client
 
@@ -79,7 +95,7 @@ module Cognito
               },
               {
                 name: 'email_verified',
-                value: true
+                value: 'true'
               }
             ],
             desired_delivery_mediums: ['EMAIL']

--- a/app/views/crown_marketplace/home/index.html.erb
+++ b/app/views/crown_marketplace/home/index.html.erb
@@ -2,6 +2,25 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if flash[:account_added] %>
+      <%= govuk_notification_banner(:success, t('.user_account_created_banner.title')) do %>
+        <%= t('.user_account_created_banner.message', user_email: flash[:account_added]) %>
+      <% end %>
+    <% end %>
+    <% if flash[:error_message] %>
+      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
+        <h2 class="govuk-error-summary__title" id="error-summary-title">
+          <%= t('.something_went_wrong_banner.title') %>
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <li>
+              <%= t('.something_went_wrong_banner.message', error_message: flash[:error_message]) %>
+            </li>
+          </ul>
+        </div>
+      </div>
+    <% end %>
     <h1 class="govuk-heading-xl"><%= t('.admin_page_heading') %></h1>
     <p class="govuk-body"><%= t('.support_users_blurb') %></p>
     <ul class="govuk-list govuk-list--bullet">
@@ -18,24 +37,25 @@
     <span class="govuk-heading-m govuk-!-margin-top-5 govuk-!-margin-bottom-1"><%= t('.user_support_heading') %></span>
   </div>
 </div>
+
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
+
 <%= ccs_account_panel_row do %>
-  <%= ccs_account_panel(t('.new_user_invite_title'), '#') do %>
+  <%= ccs_account_panel(t('.new_user_invite_title'), add_user_crown_marketplace_manage_users_path(section: 'select-role')) do %>
     <%= t('.new_user_body') %>
   <% end %>
 
   <%= ccs_account_panel(t('.manage_users_title'),  '#') do %>
     <%= t('.manage_users_body') %>
   <% end %>
-
 <% end %>
-
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <span class="govuk-heading-m govuk-!-margin-top-5 govuk-!-margin-bottom-1"><%= t('.allow_list_heading') %></span>
   </div>
 </div>
+
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
 
 <%= ccs_account_panel_row do %>

--- a/app/views/crown_marketplace/manage_users/_hidden_answers.html.erb
+++ b/app/views/crown_marketplace/manage_users/_hidden_answers.html.erb
@@ -1,0 +1,23 @@
+<% unless section == :select_role %>
+  <% @user.roles.each do |role| %> 
+    <%= f.hidden_field :roles, multiple: true, value: role %>
+  <% end %>
+<% end %>
+
+<% unless section == :select_service_access %>
+  <% if @user.service_access && (allow_anyway || role_requires_service_access?(@user.roles)) %>
+    <% @user.service_access.each do |service_access| %> 
+      <%= f.hidden_field :service_access, multiple: true, value: service_access %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<% unless section == :enter_user_details %>
+  <%= f.hidden_field :email, value: @user.email %>
+<% end %>
+
+<% unless section == :enter_user_details %>
+  <% if (allow_anyway || @user.roles != ['buyer']) %>
+    <%= f.hidden_field :telephone_number, value: @user.telephone_number %>
+  <% end %>
+<% end %>

--- a/app/views/crown_marketplace/manage_users/_user_details_summary.html.erb
+++ b/app/views/crown_marketplace/manage_users/_user_details_summary.html.erb
@@ -1,0 +1,73 @@
+<h2 class="govuk-heading-m">
+  <%= t('.user_details_summary') %>
+</h2>
+<dl id="add-user-details-summary" class="govuk-summary-list">
+  <% if allowed_attributes.include?(:roles) %>
+    <div id="add-user-details-summary--roles" class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= t('.role') %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= t("crown_marketplace.role_map.#{@user.roles.first}.text") %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <% if @current_user_access != :user_support %>
+          <%= link_to add_users_back_link(@user, 'select-role'), class: 'govuk-link govuk-link--no-visited-state' do %>
+            <%= t('.change') %><span class="govuk-visually-hidden"> <%= t('.role') %></span>
+          <% end %>
+        <% end %>
+      </dd>
+    </div>
+  <% end %>
+  <% if allowed_attributes.include?(:service_access) && role_requires_service_access?(@user.roles) %>
+    <div id="add-user-details-summary--service-access" class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= t('.service_access') %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <ul class="govuk-list govuk-list--bullet">
+          <% @user.service_access.each do |service_access| %>
+            <li>
+              <%= t("crown_marketplace.service_access_map.#{service_access}.text") %>
+            </li>
+          <% end %>
+        </ul>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <%= link_to add_users_back_link(@user, 'select-service-access'), class: 'govuk-link govuk-link--no-visited-state' do %>
+          <%= t('.change') %><span class="govuk-visually-hidden"> <%= t('.service_access') %></span>
+        <% end %>
+      </dd>
+    </div>
+  <% end %>
+  <% if allowed_attributes.include?(:user_details) %>
+    <div id="add-user-details-summary--email" class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= t('.email_address') %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= @user.email %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <%= link_to add_users_back_link(@user, 'enter-user-details'), class: 'govuk-link govuk-link--no-visited-state' do %>
+          <%= t('.change') %><span class="govuk-visually-hidden"> <%= t('.email_address') %></span>
+        <% end %>
+      </dd>
+    </div>
+  <% end %>
+  <% if allowed_attributes.include?(:user_details) && @user.roles != ['buyer'] %>
+    <div id="add-user-details-summary--telephone-number" class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= t('.telephone_number') %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= @user.telephone_number %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <%= link_to add_users_back_link(@user, 'enter-user-details'), class: 'govuk-link govuk-link--no-visited-state' do %>
+          <%= t('.change') %><span class="govuk-visually-hidden"> <%= t('.telephone_number') %></span>
+        <% end %>
+      </dd>
+    </div>
+  <% end %>
+</dl>

--- a/app/views/crown_marketplace/manage_users/add_user.html.erb
+++ b/app/views/crown_marketplace/manage_users/add_user.html.erb
@@ -1,0 +1,24 @@
+<%= content_for :page_title, t('.heading') %>
+<%= crown_marketplace_breadcrumbs(
+  { text: t('.heading') }
+)%>
+
+<%= render partial: 'shared/error_summary', locals: { errors: @user.errors } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('.heading') %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @user, url: create_add_user_crown_marketplace_manage_users_path(section: section), method: :post, local: 'false', html: { novalidate: true } do |f| %>
+      <%= render partial: "crown_marketplace/manage_users/add_user_partials/#{section}", locals: { f: f } %>
+
+      <%= f.submit t('.submit'), class: 'govuk-button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/crown_marketplace/manage_users/add_user_partials/_enter_user_details.html.erb
+++ b/app/views/crown_marketplace/manage_users/add_user_partials/_enter_user_details.html.erb
@@ -1,0 +1,45 @@
+<%= render partial: 'user_details_summary', locals: { allowed_attributes: %i[roles service_access] } %>
+<%= render partial: 'hidden_answers', locals: { f: f, allow_anyway: true } %>
+
+<%= govuk_text_input(
+  f,
+  :email,
+  {
+    label: {
+      classes: 'govuk-label--m',
+      text: t('.email_address')
+    },
+    input: {
+      classes: 'govuk-input--width-20',
+      attributes: {
+        autocomplete: 'off',
+        spellcheck: false,
+        required: true
+      }
+    }
+  }
+) %>
+
+<%= govuk_text_input(
+  f,
+  :telephone_number,
+  {
+    label: {
+      classes: 'govuk-label--m',
+      text: t('.telephone_number.label')
+    },
+    hint: {
+      text: t('.telephone_number.hint')
+    },
+    input: {
+      classes: 'govuk-input--width-10 ccs-integer-field',
+      attributes: {
+        autocomplete: 'off',
+        spellcheck: false,
+        required: true,
+        type: 'number',
+        maxlength: 11
+      }
+    }
+  }
+) if @user.roles != ['buyer'] %>

--- a/app/views/crown_marketplace/manage_users/add_user_partials/_select_role.html.erb
+++ b/app/views/crown_marketplace/manage_users/add_user_partials/_select_role.html.erb
@@ -1,0 +1,24 @@
+<%= render partial: 'hidden_answers', locals: { f: f, allow_anyway: true } %>
+
+<%= form_group_with_error(@user, :roles) do |displayed_error| %>
+  <fieldset class="govuk-fieldset" aria-describedby="roles-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      <%= t('.legend') %>
+    </legend>
+    <div id="roles-hint" class="govuk-hint">
+      <%= t('.hint') %>
+    </div>
+    <%= displayed_error %>
+    <div class="govuk-radios" data-module="govuk-radios">
+      <% available_roles.each do |role| %>
+        <div class="govuk-radios__item">
+          <%= f.radio_button :roles, role, multiple: true, class: 'govuk-radios__input', checked: @user.roles&.first == role %>
+          <%= f.label :roles, t("crown_marketplace.role_map.#{role}.text"), value: role, class: 'govuk-label govuk-radios__label' %>
+          <div class="govuk-hint govuk-radios__hint">
+            <%= t("crown_marketplace.role_map.#{role}.hint") %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/crown_marketplace/manage_users/add_user_partials/_select_service_access.html.erb
+++ b/app/views/crown_marketplace/manage_users/add_user_partials/_select_service_access.html.erb
@@ -1,0 +1,22 @@
+<%= render partial: 'user_details_summary', locals: { allowed_attributes: %i[roles] } %>
+<%= render partial: 'hidden_answers', locals: { f: f, allow_anyway: true } %>
+
+<%= form_group_with_error(@user, :service_access) do |displayed_error| %>
+  <fieldset class="govuk-fieldset" aria-describedby="roles-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      <%= t('.legend') %>
+    </legend>
+    <div id="roles-hint" class="govuk-hint">
+      <%= t('.hint') %>
+    </div>
+    <%= displayed_error %>
+    <div class="govuk-checkboxes", data-module="govuk-checkboxes">
+      <% Cognito::Admin::Roles::SERVICE_ROLES_ACCESS.each do |service_access| %>
+        <div class="govuk-checkboxes__item">
+          <%= f.check_box(:service_access, { class: 'govuk-checkboxes__input', multiple: true, include_hidden: false }, service_access) %>
+          <%= f.label(:service_access, t("crown_marketplace.service_access_map.#{service_access}.text"), value: service_access, class: 'govuk-label govuk-checkboxes__label') %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/crown_marketplace/manage_users/new.html.erb
+++ b/app/views/crown_marketplace/manage_users/new.html.erb
@@ -1,0 +1,25 @@
+<%= content_for :page_title, t('.heading') %>
+<%= crown_marketplace_breadcrumbs(
+  { text: t('.heading') }
+)%>
+
+<%= render partial: 'shared/error_summary', locals: { errors: @user.errors } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('.heading') %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @user, url: crown_marketplace_manage_users_path, method: :post, local: 'false', html: { novalidate: true } do |f| %>
+      <%= render partial: 'user_details_summary', locals: { allowed_attributes: %i[roles service_access user_details] } %>
+      <%= render partial: 'hidden_answers', locals: { f: f, allow_anyway: false } %>
+
+      <%= f.submit t('.submit'), class: 'govuk-button' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/views/crown_marketplace.en.yml
+++ b/config/locales/views/crown_marketplace.en.yml
@@ -15,6 +15,7 @@ en:
               blank: Enter an email address in the correct format, like name@example.com
               invalid: Email address cannot contain any capital letters
               not_on_allow_list: Email domain is not in the allow list
+              user_already_exist: An account with this email already exists
             mfa_enabled:
               telephone_number_required: The telephone number of the user must be set to update the MFA configuration
             roles:
@@ -78,6 +79,60 @@ en:
         management_consultancy: Management Consultancy
         new_user_body: Add a new user onto the Crown Marketplace platform
         new_user_invite_title: Invite a new user
+        something_went_wrong_banner:
+          message: 'The following error occured: "%{error_message}"'
+          title: There is a problem
         supply_teachers: Supply Teachers
         support_users_blurb: 'Support users on the following four services:'
+        user_account_created_banner:
+          message: An email has been sent to %{user_email} with the details for them to sign in.
+          title: User account created
         user_support_heading: User support
+    manage_users:
+      add_user:
+        heading: Add a user
+        submit: Continue
+      add_user_partials:
+        enter_user_details:
+          email_address: Email address
+          telephone_number:
+            hint: Admin users require Multi-Factor Authentication (MFA) when signing in, otherwise this can be left blank
+            label: Mobile telephone number
+        select_role:
+          hint: The user will have different access depending on the role selected. If the user needs additional access, this can be added once they have been created.
+          legend: Select the role for the user
+        select_service_access:
+          hint: Buyer and service admin users need to be assigned access to at least one service
+          legend: Select the service access for the user
+      new:
+        heading: Add a user
+        submit: Create user account
+      user_details_summary:
+        change: Change
+        email_address: Email address
+        role: Role
+        service_access: Service access
+        telephone_number: Mobile telephone number
+        user_details_summary: User details summary
+    role_map:
+      allow_list_access:
+        hint: Abile to view the allow list and manage buyer users
+        text: User support
+      buyer:
+        hint: Able to use the portal as a buyer to search for services
+        text: Buyer
+      ccs_employee:
+        hint: Able to manage one of the services on the portal
+        text: Service admin
+      ccs_user_admin:
+        hint: Able to manage the allow list and manage buyer, service admin and user support users
+        text: User admin
+    service_access_map:
+      fm_access:
+        text: Facilities Management
+      ls_access:
+        text: Legal Services
+      mc_access:
+        text: Management Consultancy
+      st_access:
+        text: Supply Teachers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -238,6 +238,12 @@ Rails.application.routes.draw do
         get '/search_allow_list', action: :search_allow_list
       end
     end
+    resources :manage_users, path: 'manage-users', param: :cognito_uuid, only: %i[new create] do
+      collection do
+        get '/:section/add-user', action: :add_user, as: :add_user
+        post '/:section/add-user', action: :create_add_user, as: :create_add_user
+      end
+    end
   end
 
   get '/404', to: 'errors#not_found', as: :errors_404

--- a/features/accessibility/crown_marketplace/user_admin/add_user_accessibility.feature
+++ b/features/accessibility/crown_marketplace/user_admin/add_user_accessibility.feature
@@ -1,0 +1,53 @@
+@javascript @accessibility
+Feature: Manage users - User admin - Add user - accessibility
+
+  Background: Navigate to add user page
+    Given I sign in as an 'user admin' user go to the crown marketplace dashboard
+    When I click on 'Invite a new user'
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the role for the user'
+
+  Scenario: Select a role page
+    And the page should be axe clean
+
+  Scenario: Select service access page
+    Given I choose the 'Service admin' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    And the page should be axe clean
+  
+  Scenario: Enter user details page - without telephone number
+    Given I choose the 'Buyer' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the page should be axe clean
+
+  Scenario: Enter user details page - with telephone number
+    Given I choose the 'Service admin' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the page should be axe clean
+
+  Scenario: Add user page
+    Given I choose the 'Service admin' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address | name@example.com    |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the page should be axe clean

--- a/features/crown_marketplace/manage_users/super_admin/add_user.feature
+++ b/features/crown_marketplace/manage_users/super_admin/add_user.feature
@@ -1,0 +1,293 @@
+@pipeline
+Feature: Manage users - Super admin - Add user
+
+  Background: Navigate to add user page
+    Given I sign in as an 'super admin' user go to the crown marketplace dashboard
+    When I click on 'Invite a new user'
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the role for the user'
+
+  Scenario: Create a Buyer user
+    Given I choose the 'Buyer' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the legend is 'Select the service access for the user'
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And I am able to create a user account with:
+      | role            | Buyer                 |
+      | service access  | Facilities Management |
+      | email           | name@example.com      |
+    Then I click on 'Create user account'
+    And I am on the 'Crown Marketplace dashboard' page
+    And the account 'name@example.com' has been added
+
+  Scenario: Create a Service Admin user
+    Given I choose the 'Service admin' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the legend is 'Select the service access for the user'
+    And I select 'Legal Services'
+    And I select 'Management Consultancy'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+      | Mobile telephone number | 07123456789         |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I am able to create a user account with:
+      | role              | Service admin                         |
+      | service access    | Legal Services,Management Consultancy |
+      | email             | name@example.com                      |
+      | telephone number  | +447123456789                         |
+    Then I click on 'Create user account'
+    And I am on the 'Crown Marketplace dashboard' page
+    And the account 'name@example.com' has been added
+
+  Scenario: Create a User Support user
+    Given I choose the 'User support' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+      | Mobile telephone number | 07123456789         |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I am able to create a user account with:
+      | role              | User support      |
+      | email             | name@example.com  |
+      | telephone number  | +447123456789     |
+    Then I click on 'Create user account'
+    And I am on the 'Crown Marketplace dashboard' page
+    And the account 'name@example.com' has been added
+
+  Scenario: Create a User Admin user
+    Given I choose the 'User admin' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User admin  |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+      | Mobile telephone number | 07123456789         |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User admin  |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I am able to create a user account with:
+      | role              | User admin        |
+      | email             | name@example.com  |
+      | telephone number  | +447123456789     |
+    Then I click on 'Create user account'
+    And I am on the 'Crown Marketplace dashboard' page
+    And the account 'name@example.com' has been added
+
+  Scenario: Change the role
+    Given I choose the 'Buyer' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the legend is 'Select the service access for the user'
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And I change the 'role' from the user summary
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the role for the user'
+    Given I choose the 'User support' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support |
+    And I enter the following details into the form:
+      | Mobile telephone number | 07123456789         |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I change the 'role' from the user summary
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the role for the user'
+    Given I choose the 'Service admin' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    And the 'role' in the summary is:
+      | Service admin |
+    Then I click on 'Continue'    
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+
+  Scenario: Change the service access
+    Given I choose the 'Service admin' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the legend is 'Select the service access for the user'
+    And I select 'Legal Services'
+    And I select 'Management Consultancy'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+      | Mobile telephone number | 07123456789         |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I change the 'service access' from the user summary
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    Then I click on 'Continue'
+    And the 'role' in the summary is:
+      | Service admin |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And I change the 'service access' from the user summary
+    And I select 'Supply Teachers'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+      | Supply Teachers         |
+
+  Scenario: Change the user detail access
+    Given I choose the 'User support' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+      | Mobile telephone number | 07123456789         |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I change the 'email' from the user summary
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And I enter the following details into the form:
+      | Email address | name@test.com |
+    And I do not have an existing user in cognito with email 'name@test.com'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And the 'email' in the summary is:
+      | name@test.com |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I change the 'telephone number' from the user summary
+    And the 'role' in the summary is:
+      | User support  |
+    And I enter the following details into the form:
+      | Mobile telephone number | 07987654321 |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And the 'email' in the summary is:
+      | name@test.com |
+    And the 'telephone number' in the summary is:
+      | 07987654321 |

--- a/features/crown_marketplace/manage_users/super_admin/validations/add_user_validation.feature
+++ b/features/crown_marketplace/manage_users/super_admin/validations/add_user_validation.feature
@@ -1,0 +1,85 @@
+@pipeline
+Feature: Manage users - Super admin - Add user - Validations
+
+  Background: Navigate to add user page
+    Given I sign in as an 'super admin' user go to the crown marketplace dashboard
+    When I click on 'Invite a new user'
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the role for the user'
+
+  Scenario: Select the role for the user - no role selected
+    Given I click on 'Continue'
+    Then I should see the following error messages:
+      | Select one role for the user |
+
+  Scenario: Select the service access for the user - no service access selected
+    Given I choose the 'Buyer' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    Then I click on 'Continue'
+    Then I should see the following error messages:
+      | You must select the service access for the user from this list  |
+
+  Scenario Outline: Email address - invalid
+    Given I choose the 'Buyer' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And I have an existing user in cognito with email '<email>'
+    And I enter the following details into the form:
+      | Email address | <email> |
+    Then I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | email             | error_message                                                       |
+      |                   | Enter an email address in the correct format, like name@example.com |
+      | name@Example.com  | Email address cannot contain any capital letters                    |
+      | name@example.com  | An account with this email already exists                           |
+
+  Scenario Outline: Telephone number - invalid
+    Given I choose the 'User support' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+      | Mobile telephone number | <telephone_number>  |
+    Then I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | telephone_number  | error_message                                               |
+      |                   | Enter a UK mobile telephone number, for example 07700900982 |
+      | 0712345678        | Enter a UK mobile telephone number, for example 07700900982 |
+      | 01702123456       | Enter a UK mobile telephone number, for example 07700900982 |
+
+  Scenario: Create user - service error
+    Given I choose the 'Buyer' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address | name@example.com  |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And I cannot create a user account because of the 'service' error
+    Then I click on 'Create user account'
+    Then I should see the following error messages:
+      | An error occured: service |

--- a/features/crown_marketplace/manage_users/user_admin/add_user.feature
+++ b/features/crown_marketplace/manage_users/user_admin/add_user.feature
@@ -1,0 +1,266 @@
+Feature: Manage users - User admin - Add user
+
+  Background: Navigate to add user page
+    Given I sign in as an 'user admin' user go to the crown marketplace dashboard
+    When I click on 'Invite a new user'
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the role for the user'
+
+  Scenario: Create a Buyer user
+    Given I choose the 'Buyer' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the legend is 'Select the service access for the user'
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And I am able to create a user account with:
+      | role              | Buyer                 |
+      | service access    | Facilities Management |
+      | email             | name@example.com      |
+    Then I click on 'Create user account'
+    And I am on the 'Crown Marketplace dashboard' page
+    And the account 'name@example.com' has been added
+
+  Scenario: Create a Service Admin user
+    Given I choose the 'Service admin' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the legend is 'Select the service access for the user'
+    And I select 'Legal Services'
+    And I select 'Management Consultancy'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+      | Mobile telephone number | 07123456789         |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I am able to create a user account with:
+      | role              | Service admin                         |
+      | service access    | Legal Services,Management Consultancy |
+      | email             | name@example.com                      |
+      | telephone number  | +447123456789                         |
+    Then I click on 'Create user account'
+    And I am on the 'Crown Marketplace dashboard' page
+    And the account 'name@example.com' has been added
+
+  Scenario: Create a User Support user
+    Given I choose the 'User support' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+      | Mobile telephone number | 07123456789         |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I am able to create a user account with:
+      | role              | User support      |
+      | email             | name@example.com  |
+      | telephone number  | +447123456789     |
+    Then I click on 'Create user account'
+    And I am on the 'Crown Marketplace dashboard' page
+    And the account 'name@example.com' has been added
+
+  Scenario: Change the role
+    Given I choose the 'Buyer' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the legend is 'Select the service access for the user'
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And I change the 'role' from the user summary
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the role for the user'
+    Given I choose the 'User support' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support |
+    And I enter the following details into the form:
+      | Mobile telephone number | 07123456789         |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I change the 'role' from the user summary
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the role for the user'
+    Given I choose the 'Service admin' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    And the 'role' in the summary is:
+      | Service admin |
+    Then I click on 'Continue'    
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+
+  Scenario: Change the service access
+    Given I choose the 'Service admin' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the legend is 'Select the service access for the user'
+    And I select 'Legal Services'
+    And I select 'Management Consultancy'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+      | Mobile telephone number | 07123456789         |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I change the 'service access' from the user summary
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    Then I click on 'Continue'
+    And the 'role' in the summary is:
+      | Service admin |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And I change the 'service access' from the user summary
+    And I select 'Supply Teachers'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Service admin |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+      | Supply Teachers         |
+
+  Scenario: Change the user detail access
+    Given I choose the 'User support' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+      | Mobile telephone number | 07123456789         |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I change the 'email' from the user summary
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And I enter the following details into the form:
+      | Email address | name@test.com |
+    And I do not have an existing user in cognito with email 'name@test.com'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And the 'email' in the summary is:
+      | name@test.com |
+    And the 'telephone number' in the summary is:
+      | 07123456789 |
+    And I change the 'telephone number' from the user summary
+    And the 'role' in the summary is:
+      | User support  |
+    And I enter the following details into the form:
+      | Mobile telephone number | 07987654321 |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | User support  |
+    And the 'email' in the summary is:
+      | name@test.com |
+    And the 'telephone number' in the summary is:
+      | 07987654321 |

--- a/features/crown_marketplace/manage_users/user_admin/validations/add_user_validation.feature
+++ b/features/crown_marketplace/manage_users/user_admin/validations/add_user_validation.feature
@@ -1,0 +1,84 @@
+Feature: Manage users - User admin - Add user - Validations
+
+  Background: Navigate to add user page
+    Given I sign in as an 'user admin' user go to the crown marketplace dashboard
+    When I click on 'Invite a new user'
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the role for the user'
+
+  Scenario: Select the role for the user - no role selected
+    Given I click on 'Continue'
+    Then I should see the following error messages:
+      | Select one role for the user |
+
+  Scenario: Select the service access for the user - no service access selected
+    Given I choose the 'Buyer' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    Then I click on 'Continue'
+    Then I should see the following error messages:
+      | You must select the service access for the user from this list  |
+
+  Scenario Outline: Email address - invalid
+    Given I choose the 'Buyer' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And I have an existing user in cognito with email '<email>'
+    And I enter the following details into the form:
+      | Email address | <email> |
+    Then I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | email             | error_message                                                       |
+      |                   | Enter an email address in the correct format, like name@example.com |
+      | name@Example.com  | Email address cannot contain any capital letters                    |
+      | name@example.com  | An account with this email already exists                           |
+
+  Scenario Outline: Telephone number - invalid
+    Given I choose the 'User support' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+      | Mobile telephone number | <telephone_number>  |
+    Then I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | telephone_number  | error_message                                               |
+      |                   | Enter a UK mobile telephone number, for example 07700900982 |
+      | 0712345678        | Enter a UK mobile telephone number, for example 07700900982 |
+      | 01702123456       | Enter a UK mobile telephone number, for example 07700900982 |
+
+  Scenario: Create user - service error
+    Given I choose the 'Buyer' radio button
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address | name@example.com  |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And I cannot create a user account because of the 'service' error
+    Then I click on 'Create user account'
+    Then I should see the following error messages:
+      | An error occured: service |

--- a/features/crown_marketplace/manage_users/user_support/add_user.feature
+++ b/features/crown_marketplace/manage_users/user_support/add_user.feature
@@ -1,0 +1,119 @@
+@allow_list
+Feature: Manage users - User support - Add user
+
+  Background: Navigate to add user page
+    Given I sign in as an 'user support' user go to the crown marketplace dashboard
+    When I click on 'Invite a new user'
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    And the 'role' in the summary is:
+      | Buyer |
+
+  @pipeline
+  Scenario: Create a Buyer user
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And I am able to create a user account with:
+      | role              | Buyer                 |
+      | service access    | Facilities Management |
+      | email             | name@example.com      |
+    Then I click on 'Create user account'
+    And I am on the 'Crown Marketplace dashboard' page
+    And the account 'name@example.com' has been added
+
+  Scenario: Change the service access
+    And I select 'Legal Services'
+    And I select 'Management Consultancy'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And I change the 'service access' from the user summary
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+    Then I click on 'Continue'
+    And the 'role' in the summary is:
+      | Buyer |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+    And I change the 'service access' from the user summary
+    And I select 'Supply Teachers'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Legal Services          |
+      | Management Consultancy  |
+      | Supply Teachers         |
+
+  Scenario: Change the user detail access
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address           | name@example.com    |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And I change the 'email' from the user summary
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And I enter the following details into the form:
+      | Email address | name@test.com |
+    And I do not have an existing user in cognito with email 'name@test.com'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And the 'email' in the summary is:
+      | name@test.com |

--- a/features/crown_marketplace/manage_users/user_support/validations/add_user_validation.feature
+++ b/features/crown_marketplace/manage_users/user_support/validations/add_user_validation.feature
@@ -1,0 +1,61 @@
+@allow_list @pipeline
+Feature: Manage users - User support - Add user - Validations
+
+  Background: Navigate to add user page
+    Given I sign in as an 'user support' user go to the crown marketplace dashboard
+    When I click on 'Invite a new user'
+    Then I am on the 'Add a user' page
+    And the legend is 'Select the service access for the user'
+
+  Scenario: Select the service access for the user - no service access selected
+    Then I click on 'Continue'
+    Then I should see the following error messages:
+      | You must select the service access for the user from this list  |
+
+  Scenario Outline: Email address - invalid
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And I have an existing user in cognito with email '<email>'
+    And I enter the following details into the form:
+      | Email address | <email> |
+    Then I click on 'Continue'
+    Then I should see the following error messages:
+      | <error_message> |
+
+    Examples:
+      | email             | error_message                                                       |
+      |                   | Enter an email address in the correct format, like name@example.com |
+      | name@Example.com  | Email address cannot contain any capital letters                    |
+      | name@example.com  | An account with this email already exists                           |
+
+  Scenario: Email address - allow list
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And I do not have an existing user in cognito with email 'name@test.gov.uk'
+    And I enter the following details into the form:
+      | Email address | name@test.gov.uk |
+    Then I click on 'Continue'
+    Then I should see the following error messages:
+      | Email domain is not in the allow list |
+
+  Scenario: Create user - service error
+    And I select 'Facilities Management'
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And I do not have an existing user in cognito with email 'name@example.com'
+    And I enter the following details into the form:
+      | Email address | name@example.com  |
+    Then I click on 'Continue'
+    And I am on the 'Add a user' page
+    And the 'role' in the summary is:
+      | Buyer |
+    And the 'service access' in the summary is:
+      | Facilities Management |
+    And the 'email' in the summary is:
+      | name@example.com  |
+    And I cannot create a user account because of the 'service' error
+    Then I click on 'Create user account'
+    Then I should see the following error messages:
+      | An error occured: service |

--- a/features/helpers/crown_marketplace/cognito_helper.rb
+++ b/features/helpers/crown_marketplace/cognito_helper.rb
@@ -1,0 +1,117 @@
+def stub_admin_cognito(option, **options)
+  aws_client = instance_double(Aws::CognitoIdentityProvider::Client)
+  allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+
+  method = "stub_#{option}".to_sym
+
+  send(
+    method,
+    aws_client,
+    **options
+  )
+end
+
+def stub_cognito_admin_with_error(option, error_key)
+  aws_client = instance_double(Aws::CognitoIdentityProvider::Client)
+  allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+
+  method = "stub_#{option}_error".to_sym
+
+  send(
+    method,
+    aws_client,
+    get_aws_error(error_key)
+  )
+end
+
+def stub_list_users(aws_client, **options)
+  users = options[:resp_email] ? [options[:resp_email]] : []
+
+  allow(aws_client).to receive(:list_users).with(**list_users_params(options[:search_email])).and_return(OpenStruct.new(users: users))
+end
+
+# rubocop:disable Metrics/AbcSize
+def stub_create_user(aws_client, **options)
+  cognito_uuid = SecureRandom.uuid
+
+  allow(aws_client).to receive(:admin_create_user).with(**create_user_params(options[:email], options[:'telephone number'])).and_return(OpenStruct.new(user: { 'username' => cognito_uuid }))
+  allow(aws_client).to receive(:admin_set_user_mfa_preference).with(**enable_mfa_params(cognito_uuid))
+
+  role_and_service_access_to_group_names([options[:role]], options[:'service access']&.split(',')).each do |group_name|
+    allow(aws_client).to receive(:admin_add_user_to_group).with(**add_user_to_group_params(cognito_uuid, group_name))
+  end
+end
+# rubocop:enable Metrics/AbcSize
+
+def stub_create_user_error(aws_client, error)
+  allow(aws_client).to receive(:admin_create_user).and_raise(error)
+end
+
+def role_and_service_access_to_group_names(roles, service_accesses)
+  (roles || []).map { |role| ROLE_SERVICE_ACCESS_TO_GROUP_NAMES[role] } + (service_accesses || []).map { |service_access| ROLE_SERVICE_ACCESS_TO_GROUP_NAMES[service_access] }
+end
+
+def list_users_params(email)
+  {
+    user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+    attributes_to_get: ['email'],
+    filter: "email = \"#{email}\""
+  }
+end
+
+def create_user_params(email, telephone_number)
+  user_attributes = {
+    user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+    username: email,
+    user_attributes: [
+      {
+        name: 'email',
+        value: email
+      },
+      {
+        name: 'email_verified',
+        value: 'true'
+      }
+    ],
+    desired_delivery_mediums: ['EMAIL']
+  }
+
+  if telephone_number
+    user_attributes[:user_attributes] << {
+      name: 'phone_number',
+      value: telephone_number
+    }
+  end
+
+  user_attributes
+end
+
+def enable_mfa_params(cognito_uuid)
+  {
+    sms_mfa_settings: {
+      enabled: true,
+      preferred_mfa: true,
+    },
+    user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+    username: cognito_uuid
+  }
+end
+
+def add_user_to_group_params(cognito_uuid, group_name)
+  {
+    user_pool_id: ENV['COGNITO_USER_POOL_ID'],
+    username: cognito_uuid,
+    group_name: group_name
+  }
+end
+
+ROLE_SERVICE_ACCESS_TO_GROUP_NAMES = {
+  'Buyer' => 'buyer',
+  'Service admin' => 'ccs_employee',
+  'User support' => 'allow_list_access',
+  'User admin' => 'ccs_user_admin',
+  'Facilities Management' => 'fm_access',
+  'Supply Teachers' => 'st_access',
+  'Legal Services' => 'ls_access',
+  'Management Consultancy' => 'mc_access'
+}.freeze

--- a/features/step_definitions/crown_marketplace/cognito_steps.rb
+++ b/features/step_definitions/crown_marketplace/cognito_steps.rb
@@ -1,0 +1,17 @@
+Then('I have an existing user in cognito with email {string}') do |email|
+  stub_admin_cognito(:list_users, search_email: email, resp_email: email)
+end
+
+Then('I do not have an existing user in cognito with email {string}') do |email|
+  stub_admin_cognito(:list_users, search_email: email)
+end
+
+Then('I am able to create a user account with:') do |user_account_details_table|
+  user_account_details = user_account_details_table.raw.to_h.symbolize_keys
+
+  stub_admin_cognito(:create_user, **user_account_details)
+end
+
+Then('I cannot create a user account because of the {string} error') do |error_key|
+  stub_cognito_admin_with_error(:create_user, error_key)
+end

--- a/features/step_definitions/crown_marketplace/manage_users_steps.rb
+++ b/features/step_definitions/crown_marketplace/manage_users_steps.rb
@@ -1,0 +1,18 @@
+Then('the legend is {string}') do |legend_text|
+  expect(page.find('fieldset > legend')).to have_content(legend_text)
+end
+
+Then('the {string} in the summary is:') do |option, details|
+  details.raw.flatten.each do |detail|
+    expect(manage_users_page.user_details_summary.send(option).value).to have_content(detail)
+  end
+end
+
+Then('the account {string} has been added') do |email|
+  expect(manage_users_page.notification_banner.heading).to have_content('User account created')
+  expect(manage_users_page.notification_banner.content).to have_content("An email has been sent to #{email} with the details for them to sign in")
+end
+
+Then('I change the {string} from the user summary') do |option|
+  manage_users_page.user_details_summary.send(option).action.click
+end

--- a/features/step_definitions/facilities_management/common_steps.rb
+++ b/features/step_definitions/facilities_management/common_steps.rb
@@ -97,6 +97,10 @@ Then('I select {string}') do |item|
   page.check(item)
 end
 
+Then 'I choose the {string} radio button' do |option|
+  page.choose(option)
+end
+
 Then('I select the following items:') do |items|
   items.raw.flatten.each do |item|
     page.check(item)

--- a/features/support/pages.rb
+++ b/features/support/pages.rb
@@ -57,6 +57,10 @@ module Pages
     @home_page ||= RM3830::Home.new
   end
 
+  def manage_users_page
+    @manage_users_page ||= ManageUsers.new
+  end
+
   def procurement_page
     @procurement_page ||= case @framework
                           when 'RM3830'

--- a/features/support/pages/manage_users.rb
+++ b/features/support/pages/manage_users.rb
@@ -1,0 +1,21 @@
+module Pages
+  class UserDetailRow < SitePrism::Section
+    element :key, 'dt.govuk-summary-list__key'
+    element :value, 'dd.govuk-summary-list__value'
+    element :action, 'dd.govuk-summary-list__actions > a'
+  end
+
+  class ManageUsers < SitePrism::Page
+    section :user_details_summary, '#add-user-details-summary' do
+      section :role, UserDetailRow, '#add-user-details-summary--roles'
+      section :'service access', UserDetailRow, '#add-user-details-summary--service-access'
+      section :email, UserDetailRow, '#add-user-details-summary--email'
+      section :'telephone number', UserDetailRow, '#add-user-details-summary--telephone-number'
+    end
+
+    section :notification_banner, 'div.govuk-notification-banner' do
+      element :heading, 'p.govuk-notification-banner__heading'
+      element :content, 'div.govuk-notification-banner__content'
+    end
+  end
+end

--- a/spec/controllers/crown_marketplace/allow_list_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/allow_list_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
     end
 
     context 'when logged in with read only allow list access' do
-      login_crown_marketplace_read_only
+      login_user_support_admin
 
       it 'renders the index page' do
         get :index
@@ -39,7 +39,7 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
     end
 
     context 'when logged in with full allow list access' do
-      login_crown_marketplace_admin
+      login_user_admin
 
       it 'renders the index page' do
         get :index
@@ -51,7 +51,7 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
 
   describe 'GET new' do
     context 'when logged in with read only allow list access' do
-      login_crown_marketplace_read_only
+      login_user_support_admin
 
       it 'redirects to the not permited path' do
         get :new
@@ -61,7 +61,7 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
     end
 
     context 'when logged in with full allow list access' do
-      login_crown_marketplace_admin
+      login_user_admin
 
       it 'renders the new page' do
         get :new
@@ -72,7 +72,7 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
   end
 
   describe 'POST create' do
-    login_crown_marketplace_admin
+    login_user_admin
 
     before { post :create, params: { allowed_email_domain: { email_domain: email_domain } } }
 
@@ -96,7 +96,7 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
 
   describe 'GET search_allow_list' do
     context 'when logged in with read only allow list access' do
-      login_crown_marketplace_read_only
+      login_user_support_admin
 
       before { get :search_allow_list, params: { allowed_email_domain: { email_domain: 'email' } }, xhr: true }
 
@@ -110,7 +110,7 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
     end
 
     context 'when logged in with full allow list access' do
-      login_crown_marketplace_admin
+      login_user_admin
 
       before { get :search_allow_list, params: { allowed_email_domain: { email_domain: 'email' } }, xhr: true }
 
@@ -126,7 +126,7 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
 
   describe 'GET delete' do
     context 'when logged in with read only allow list access' do
-      login_crown_marketplace_read_only
+      login_user_support_admin
 
       it 'redirects to the not permited path' do
         get :delete, params: { email_domain: 'email' }
@@ -136,7 +136,7 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
     end
 
     context 'when logged in with full allow list access' do
-      login_crown_marketplace_admin
+      login_user_admin
 
       it 'renders the delete page' do
         get :delete, params: { email_domain: 'email' }
@@ -147,7 +147,7 @@ RSpec.describe CrownMarketplace::AllowListController, type: :controller do
   end
 
   describe 'DESTROY destroy' do
-    login_crown_marketplace_admin
+    login_user_admin
 
     it 'redirects to the allow list index page with the flash message' do
       delete :destroy, params: { allowed_email_domain: { email_domain: 'email.com' } }

--- a/spec/controllers/crown_marketplace/home_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/home_controller_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe CrownMarketplace::HomeController, type: :controller do
     end
 
     context 'when logged in as a user support user' do
-      login_crown_marketplace_read_only
+      login_user_support_admin
 
       it 'renders the index page' do
         get :index
@@ -197,7 +197,7 @@ RSpec.describe CrownMarketplace::HomeController, type: :controller do
     end
 
     context 'when logged in as a user admin user' do
-      login_crown_marketplace_admin
+      login_user_admin
 
       it 'renders the index page' do
         get :index
@@ -206,7 +206,7 @@ RSpec.describe CrownMarketplace::HomeController, type: :controller do
       end
 
       context 'when logged in as a super admin user' do
-        login_ccs_developer
+        login_super_admin
 
         it 'renders the index page' do
           get :index

--- a/spec/controllers/crown_marketplace/manage_users_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/manage_users_controller_spec.rb
@@ -1,0 +1,332 @@
+require 'rails_helper'
+
+RSpec.describe CrownMarketplace::ManageUsersController, type: :controller do
+  let(:default_params) { { service: 'crown_marketplace' } }
+
+  describe 'callbacks' do
+    context 'when I log in as a buyer' do
+      login_fm_buyer
+
+      it 'redirects to the not permited path' do
+        get :new
+
+        expect(response).to redirect_to '/crown-marketplace/not-permitted'
+      end
+    end
+
+    context 'when I log in as a supplier' do
+      login_fm_supplier
+
+      it 'redirects to the not permited path' do
+        get :new
+
+        expect(response).to redirect_to '/crown-marketplace/not-permitted'
+      end
+    end
+
+    context 'when I log in as a service admin' do
+      login_fm_admin
+
+      it 'redirects to the not permited path' do
+        get :new
+
+        expect(response).to redirect_to '/crown-marketplace/not-permitted'
+      end
+    end
+
+    context 'when I log in as a user support admin' do
+      login_user_support_admin
+
+      before { get :new }
+
+      it 'renders the new page' do
+        expect(response).to render_template(:new)
+      end
+
+      it 'sets the current user access to user_support' do
+        expect(assigns(:current_user_access)).to eq :user_support
+      end
+    end
+
+    context 'when I log in as a user admin' do
+      login_user_admin
+
+      before { get :new }
+
+      it 'renders the new page' do
+        expect(response).to render_template(:new)
+      end
+
+      it 'sets the current user access to user_admin' do
+        expect(assigns(:current_user_access)).to eq :user_admin
+      end
+    end
+
+    context 'when I log in as a super admin' do
+      login_super_admin
+
+      before { get :new }
+
+      it 'renders the new page' do
+        expect(response).to render_template(:new)
+      end
+
+      it 'sets the current user access to super_admin' do
+        expect(assigns(:current_user_access)).to eq :super_admin
+      end
+    end
+  end
+
+  # rubocop:disable RSpec/NestedGroups
+  describe 'GET add_user' do
+    context 'and I am a super admin' do
+      let(:additional_params) { {} }
+
+      login_super_admin
+
+      before { get :add_user, params: { section: section, **additional_params } }
+
+      context 'and the section is select-role' do
+        let(:section) { 'select-role' }
+
+        it 'sets the user' do
+          expect(assigns(:user)).to be_present
+        end
+
+        context 'and we render the template' do
+          render_views
+
+          it 'renders the select_role template' do
+            expect(response).to render_template(partial: 'crown_marketplace/manage_users/add_user_partials/_select_role')
+          end
+        end
+
+        context 'and additional params are passed' do
+          let(:additional_params) { { roles: ['buyer'], service_access: ['fm_access'] } }
+
+          it 'sets the user with the data from the params' do
+            expect(assigns(:user).roles).to eq ['buyer']
+            expect(assigns(:user).service_access).to eq ['fm_access']
+          end
+        end
+      end
+
+      context 'and the section is select-service-access' do
+        let(:additional_params) { { roles: ['buyer'] } }
+        let(:section) { 'select-service-access' }
+
+        it 'sets the user with the roles' do
+          expect(assigns(:user)).to be_present
+          expect(assigns(:user).roles).to eq ['buyer']
+        end
+
+        context 'and we render the template' do
+          render_views
+
+          it 'renders the select_service_access template' do
+            expect(response).to render_template(partial: 'crown_marketplace/manage_users/add_user_partials/_select_service_access')
+          end
+        end
+
+        context 'and additional params are passed' do
+          let(:additional_params) { super().merge({ service_access: ['fm_access'], email: 'example@email.com' }) }
+
+          it 'sets the user with the data from the params' do
+            expect(assigns(:user).service_access).to eq ['fm_access']
+            expect(assigns(:user).email).to eq 'example@email.com'
+          end
+        end
+
+        context 'and the role does not require service access' do
+          let(:additional_params) { { roles: ['allow_list_access'] } }
+
+          it 'redirects to the select enter user details section with the current params' do
+            expect(response).to redirect_to(add_user_crown_marketplace_manage_users_path(section: 'enter-user-details', roles: ['allow_list_access']))
+          end
+        end
+      end
+
+      context 'and the section is enter-user-details' do
+        let(:additional_params) { { roles: ['buyer'], service_access: ['fm_access'] } }
+        let(:section) { 'enter-user-details' }
+
+        it 'sets the user with the roles and service access' do
+          expect(assigns(:user)).to be_present
+          expect(assigns(:user).roles).to eq ['buyer']
+          expect(assigns(:user).service_access).to eq ['fm_access']
+        end
+
+        context 'and we render the template' do
+          render_views
+
+          it 'renders the select_service_access template' do
+            expect(response).to render_template(partial: 'crown_marketplace/manage_users/add_user_partials/_enter_user_details')
+          end
+        end
+
+        context 'and additional params are passed' do
+          let(:additional_params) { super().merge({ email: 'example@email.com', telephone_number: '07123456789' }) }
+
+          it 'sets the user with the data from the params' do
+            expect(assigns(:user).email).to eq 'example@email.com'
+            expect(assigns(:user).telephone_number).to eq '07123456789'
+          end
+        end
+      end
+    end
+
+    context 'and I am a user support admin and I go to the select role page' do
+      login_user_support_admin
+
+      before { get :add_user, params: { section: 'select-role' } }
+
+      it 'redirects to the select service access section with the role as buyer' do
+        expect(response).to redirect_to(add_user_crown_marketplace_manage_users_path(section: 'select-service-access', roles: ['buyer']))
+      end
+    end
+  end
+
+  describe 'POST create_add_user' do
+    context 'and I am a super admin' do
+      let(:create_add_user_params) { {} }
+
+      login_super_admin
+
+      before do
+        aws_client = instance_double(Aws::CognitoIdentityProvider::Client)
+
+        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+        allow(aws_client).to receive(:list_users).and_return(OpenStruct.new(users: []))
+
+        post :create_add_user, params: { section: section, cognito_admin_user: create_add_user_params }
+      end
+
+      context 'and the section is select-role' do
+        let(:section) { 'select-role' }
+        let(:create_add_user_params) { { roles: roles } }
+
+        context 'and the data is valid' do
+          let(:roles) { ['buyer'] }
+
+          it 'redirects to the edit user details section with the role as a param' do
+            expect(response).to redirect_to(add_user_crown_marketplace_manage_users_path(section: 'select-service-access', roles: ['buyer']))
+          end
+        end
+
+        context 'and the data is invalid' do
+          let(:roles) { [] }
+
+          it 'renders the add_user page' do
+            expect(response).to render_template(:add_user)
+          end
+        end
+      end
+
+      context 'and the section is select-service-access' do
+        let(:section) { 'select-service-access' }
+        let(:create_add_user_params) { { roles: ['buyer'], service_access: service_access } }
+
+        context 'and the data is valid' do
+          let(:service_access) { ['fm_access'] }
+
+          it 'redirects to the edit user details section with the role and service access as a param' do
+            expect(response).to redirect_to(add_user_crown_marketplace_manage_users_path(section: 'enter-user-details', roles: ['buyer'], service_access: ['fm_access']))
+          end
+        end
+
+        context 'and the data is invalid' do
+          let(:service_access) { [] }
+
+          it 'renders the add_user page' do
+            expect(response).to render_template(:add_user)
+          end
+        end
+      end
+
+      context 'and the section is enter-user-details' do
+        let(:section) { 'enter-user-details' }
+        let(:create_add_user_params) { { roles: ['buyer'], service_access: ['fm_access'], email: email } }
+
+        context 'and the data is valid' do
+          let(:email) { 'email@email.com' }
+
+          it 'redirects to the new page with the role, service access and email as a param' do
+            expect(response).to redirect_to(new_crown_marketplace_manage_user_path(roles: ['buyer'], service_access: ['fm_access'], email: 'email@email.com'))
+          end
+        end
+
+        context 'and the data is invalid' do
+          let(:email) { nil }
+
+          it 'renders the add_user page' do
+            expect(response).to render_template(:add_user)
+          end
+        end
+      end
+    end
+
+    context 'and I am a user support admin and I go to the select role page' do
+      login_user_support_admin
+
+      before { post :create_add_user, params: { section: 'select-role' } }
+
+      it 'redirects to the select service access section with the role as buyer' do
+        expect(response).to redirect_to(add_user_crown_marketplace_manage_users_path(section: 'select-service-access', roles: ['buyer']))
+      end
+    end
+  end
+
+  describe 'GET new' do
+    login_super_admin
+
+    before { get :new, params: { roles: ['buyer'], service_access: ['fm_access'], email: 'example@email.com' } }
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'sets the user with the roles, service access and email' do
+      expect(assigns(:user)).to be_present
+      expect(assigns(:user).roles).to eq ['buyer']
+      expect(assigns(:user).service_access).to eq ['fm_access']
+      expect(assigns(:user).email).to eq 'example@email.com'
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+
+    it 'renders the new page' do
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST create' do
+    let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
+
+    login_super_admin
+
+    before { allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client) }
+
+    context 'when the user is successfully created' do
+      before do
+        allow(aws_client).to receive(:admin_create_user).and_return(OpenStruct.new(user: { 'username' => SecureRandom.uuid }))
+        allow(aws_client).to receive(:admin_add_user_to_group)
+
+        post :create, params: { cognito_admin_user: { roles: ['buyer'], service_access: ['fm_access'], email: 'example@email.com' } }
+      end
+
+      it 'redirects to the crown marketplace home page and sets the flash message' do
+        expect(response).to redirect_to crown_marketplace_path
+        expect(flash[:account_added]).to eq 'example@email.com'
+      end
+    end
+
+    context 'when there is an issue creating the user' do
+      before do
+        allow(aws_client).to receive(:admin_create_user).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('Some context', 'Some message'))
+
+        post :create, params: { cognito_admin_user: { roles: ['buyer'], service_access: ['fm_access'], email: 'example@email.com' } }
+      end
+
+      it 'renders the new page' do
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+  # rubocop:enable RSpec/NestedGroups
+end

--- a/spec/controllers/facilities_management/admin/frameworks_controller_spec.rb
+++ b/spec/controllers/facilities_management/admin/frameworks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe FacilitiesManagement::Admin::FrameworksController do
   let(:default_params) { { service: 'facilities_management/admin' } }
 
-  login_ccs_developer
+  login_super_admin
 
   describe 'GET index' do
     it 'renders the index page' do

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -42,7 +42,7 @@ module ControllerMacros
     end
   end
 
-  def login_crown_marketplace_admin
+  def login_user_admin
     before do
       @request.env['devise.mapping'] = Devise.mappings[:user]
       user = FactoryBot.create(:user, :without_detail, confirmed_at: Time.zone.now, roles: %i[ccs_user_admin])
@@ -50,7 +50,7 @@ module ControllerMacros
     end
   end
 
-  def login_crown_marketplace_read_only
+  def login_user_support_admin
     before do
       @request.env['devise.mapping'] = Devise.mappings[:user]
       user = FactoryBot.create(:user, :without_detail, confirmed_at: Time.zone.now, roles: %i[allow_list_access])
@@ -58,7 +58,7 @@ module ControllerMacros
     end
   end
 
-  def login_ccs_developer
+  def login_super_admin
     before do
       @request.env['devise.mapping'] = Devise.mappings[:user]
       user = FactoryBot.create(:user, confirmed_at: Time.zone.now, roles: %i[fm_access ccs_employee ccs_developer])


### PR DESCRIPTION
Ticket: [FMFR-1318](https://crowncommercialservice.atlassian.net/browse/FMFR-1318)

We are going to give CSC the ability to manage users in the Digital Foundations project. In this commit I have added the ability to create a new user. When a user is created, an email will be sent to them with a temporary password.

In addition, I have (as always) added unit, feature and accessibility tests to account for the changes.