### PR TITLE
FMFR-1327 - Add ability to edit user service access

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -9,6 +9,7 @@
 @import "inset-text/inset-text";
 @import "label/label";
 @import "logo/logo";
+@import "notification-banner/notification-banner";
 @import "supplier-record/supplier-record";
 @import "typography/typography";
 /* CCS override and bespoke styles; re-used globally across all modules */

--- a/app/assets/stylesheets/components/notification-banner/_notification-banner.scss
+++ b/app/assets/stylesheets/components/notification-banner/_notification-banner.scss
@@ -1,0 +1,5 @@
+.govuk-notification-banner--error {
+  border-color: $govuk-error-colour;
+
+  background-color: $govuk-error-colour;
+}

--- a/app/helpers/crown_marketplace/manage_users_helper.rb
+++ b/app/helpers/crown_marketplace/manage_users_helper.rb
@@ -10,7 +10,7 @@ module CrownMarketplace::ManageUsersHelper
     add_user_crown_marketplace_manage_users_path(section: section_name, **link_params.select { |_, value| value.present? })
   end
 
-  def user_account_status_tag(enabled)
+  def enabled_disabled_status_tag(enabled)
     if enabled
       [:blue, t('crown_marketplace.manage_users.edit_partials.account_status.options.enabled')]
     else
@@ -27,6 +27,7 @@ module CrownMarketplace::ManageUsersHelper
              else
                :grey
              end
+
     [colour, confirmation_status]
   end
 end

--- a/app/helpers/gov_uk_helper/notification_banner.rb
+++ b/app/helpers/gov_uk_helper/notification_banner.rb
@@ -15,6 +15,9 @@ module GovUKHelper::NotificationBanner
     end
   end
 
-  BANNER_TYPE = { success: { class: 'govuk-notification-banner--success', text: 'Success' },
-                  neutral: { text: 'Important' } }.freeze
+  BANNER_TYPE = {
+    success: { class: 'govuk-notification-banner--success', text: 'Success' },
+    error: { class: 'govuk-notification-banner--error', text: 'Error' },
+    neutral: { text: 'Important' }
+  }.freeze
 end

--- a/app/services/cognito/admin/roles.rb
+++ b/app/services/cognito/admin/roles.rb
@@ -43,7 +43,7 @@ module Cognito
         application_locations
       end
 
-      def array_of_users_that_could_edit
+      def can_edit_user_with_current_access?
         if @roles.include?('ccs_developer')
           []
         elsif @roles.include?('ccs_user_admin')
@@ -54,7 +54,7 @@ module Cognito
           %i[user_support user_admin super_admin]
         else
           []
-        end
+        end.include?(@access)
       end
 
       def minimum_editor_role

--- a/app/services/cognito/admin/user.rb
+++ b/app/services/cognito/admin/user.rb
@@ -54,9 +54,7 @@ module Cognito
         @origional_groups = @cognito_roles.combine_roles
       end
 
-      delegate :array_of_users_that_could_edit, to: :cognito_roles
-
-      delegate :minimum_editor_role, to: :cognito_roles
+      delegate :can_edit_user_with_current_access?, :minimum_editor_role, to: :cognito_roles
 
       def assign_attributes(**new_attributes)
         raise ArgumentError, 'When assigning attributes, you must pass a hash as an argument.' unless new_attributes.respond_to?(:stringify_keys)

--- a/app/views/crown_marketplace/home/index.html.erb
+++ b/app/views/crown_marketplace/home/index.html.erb
@@ -8,18 +8,9 @@
       <% end %>
     <% end %>
     <% if flash[:error_message] %>
-      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-          <%= t('.something_went_wrong_banner.title') %>
-        </h2>
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <li>
-              <%= t('.something_went_wrong_banner.message', error_message: flash[:error_message]) %>
-            </li>
-          </ul>
-        </div>
-      </div>
+      <%= govuk_notification_banner(:error, t('.something_went_wrong_banner.title')) do %>
+        <%= t('.something_went_wrong_banner.message', error_message: flash[:error_message]) %>
+      <% end %>
     <% end %>
     <h1 class="govuk-heading-xl"><%= t('.admin_page_heading') %></h1>
     <p class="govuk-body"><%= t('.support_users_blurb') %></p>

--- a/app/views/crown_marketplace/manage_users/_users_table.html.erb
+++ b/app/views/crown_marketplace/manage_users/_users_table.html.erb
@@ -15,7 +15,7 @@
       <% users.each do |user| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-padding-right-2" style="word-break: break-all;"><%= user[:email] %></td>
-          <td class="govuk-table__cell govuk-!-padding-right-2"><%= govuk_tag_with_text(*user_account_status_tag(user[:account_status])) %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= govuk_tag_with_text(*enabled_disabled_status_tag(user[:account_status])) %></td>
           <td class="govuk-table__cell govuk-!-padding-right-2">
             <%= link_to(t('.view_user'), crown_marketplace_manage_user_path(cognito_uuid: user[:cognito_uuid]), class: 'govuk-link govuk-link--no-visited-state', aria: { label: t('.view_user_email', email: user[:email]) }) %>
           </td>

--- a/app/views/crown_marketplace/manage_users/edit.html.erb
+++ b/app/views/crown_marketplace/manage_users/edit.html.erb
@@ -1,0 +1,27 @@
+<%= content_for :page_title, t('.heading', section: t("crown_marketplace.manage_users.edit_partials.#{section}.section")) %>
+<%= crown_marketplace_breadcrumbs(
+  { text: t('crown_marketplace.manage_users.index.heading'), link: crown_marketplace_manage_users_path },
+  { text: t('crown_marketplace.manage_users.show.heading'), link: crown_marketplace_manage_user_path },
+  { text: t('.heading', section: t("crown_marketplace.manage_users.edit_partials.#{section}.section")) }
+)%>
+
+<%= render partial: 'shared/error_summary', locals: { errors: @user.errors } %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-l"><%= @user.email %></span>
+      <%= t('.heading', section: t("crown_marketplace.manage_users.edit_partials.#{section}.section")) %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @user, url: update_crown_marketplace_manage_user_path, method: :put, local: 'false', html: { novalidate: true } do |f| %>
+      <%= render partial: "crown_marketplace/manage_users/edit_partials/#{section}", locals: { f: f } %>
+
+      <%= f.submit t('.save_and_return'), class: "govuk-button", aria: { label: t('.save_and_return') } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/crown_marketplace/manage_users/edit_partials/_service_access.html.erb
+++ b/app/views/crown_marketplace/manage_users/edit_partials/_service_access.html.erb
@@ -1,0 +1,22 @@
+<%= form_group_with_error(f.object, :service_access) do |displayed_error| %>
+  <fieldset class="govuk-fieldset" aria-describedby="service-access-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <%= t('.legend') %>
+    </legend>
+  </fieldset>
+  <%= displayed_error %>
+  <%= govuk_hint(
+    {
+      text: t('.hint'),
+      id: 'service-access-hint'
+    }
+  ) %>
+  <div class="govuk-checkboxes", data-module="govuk-checkboxes">
+    <% Cognito::Admin::Roles::SERVICE_ROLES_ACCESS.each do |service_access| %>
+      <div class="govuk-checkboxes__item">
+        <%= f.check_box(:service_access, { class: 'govuk-checkboxes__input', multiple: true, include_hidden: false }, service_access) %>
+        <%= f.label(:service_access, t("crown_marketplace.service_access_map.#{service_access}.text"), value: service_access, class: 'govuk-label govuk-checkboxes__label') %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/crown_marketplace/manage_users/index.html.erb
+++ b/app/views/crown_marketplace/manage_users/index.html.erb
@@ -40,7 +40,7 @@
               value: params[:email]
             }
           }
-        )%>
+        ) %>
         <%= f.submit t('.search'), class: 'govuk-button govuk-button--secondary' %>
       </div>
     <% end %>

--- a/app/views/crown_marketplace/manage_users/show.html.erb
+++ b/app/views/crown_marketplace/manage_users/show.html.erb
@@ -1,16 +1,16 @@
 <%= content_for :page_title, t('.heading') %>
 <%= crown_marketplace_breadcrumbs(
-  { text: t('crown_marketplace.home.index.manage_users_title'), link: crown_marketplace_manage_users_path },
+  { text: t('crown_marketplace.manage_users.index.heading'), link: crown_marketplace_manage_users_path },
   { text: t('.heading') }
 )%>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-l"><%= @user.email %></span>
       <%= t('.heading') %>
     </h1>
-    <% unless @current_row_change_access %>
+    <% unless can_edit_user? %>
       <%= warning_text(
         if @minimum_editor
           t('.warning_text', minimum_editor_text: t("crown_marketplace.role_map.#{@minimum_editor}.text"))
@@ -22,11 +22,10 @@
   </div>
 </div>
 
-
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <dl id="show-user-details-summary" class="govuk-summary-list">
-      <div id="view-user__email" class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+  <div class="govuk-grid-column-three-quarters">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row" id="view-user__email">
         <dt class="govuk-summary-list__key">
           <%= t('.email') %>
         </dt>
@@ -34,20 +33,23 @@
           <%= @user.email %>
         </dd>
       </div>
-      <div id= "view-user__account-status" class="govuk-summary-list__row">
+      <div class="govuk-summary-list__row" id="view-user__account-status">
         <dt class="govuk-summary-list__key">
           <%= t('.account_status') %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= govuk_tag_with_text(*user_account_status_tag(@user.account_status)) %>
+          <%= govuk_tag_with_text(*enabled_disabled_status_tag(@user.account_status)) %>
         </dd>
-        <% if @current_row_change_access %>
+        <% if can_edit_user? %>
           <dd class="govuk-summary-list__actions">
-            <%= link_to(t('.change'), class: 'govuk-link govuk-link--no-visited-state') %>
+            <%= link_to('#account-status', class: 'govuk-link govuk-link--no-visited-state') do %>
+              <%= t('.change') %>
+              <span class="govuk-visually-hidden"><%= t('.account_status') %></span>
+            <% end %>
           </dd>
-        <%end%>
+        <% end %>
       </div>
-      <div id= "view-user__confirmation-status" class="govuk-summary-list__row">
+      <div class="govuk-summary-list__row" id="view-user__confirmation-status">
         <dt class="govuk-summary-list__key">
           <%= t('.confirmation_status') %>
         </dt>
@@ -55,82 +57,92 @@
           <%= govuk_tag_with_text(*user_confirmation_status_tag(@user.confirmation_status)) %>
         </dd>
       </div>
-      <div id= "view-user__telephone-number" class="govuk-summary-list__row">
+      <div class="govuk-summary-list__row" id="view-user__telephone-number">
         <dt class="govuk-summary-list__key">
           <%= t('.telephone_number') %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <% if @user.telephone_number.present?%>
-            <%= @user.telephone_number %>
-          <% else %>
-            <%= t('.none') %>
-          <% end %> 
+          <%= @user.telephone_number.blank? ? t('.none') : @user.telephone_number %>
         </dd>
-        <% if @current_row_change_access %>
+        <% if can_edit_user? %>
           <dd class="govuk-summary-list__actions">
-            <%= link_to(t('.change'), class: 'govuk-link govuk-link--no-visited-state') %>
+            <%= link_to('#telephone-number', class: 'govuk-link govuk-link--no-visited-state') do %>
+              <%= t('.change') %>
+              <span class="govuk-visually-hidden"><%= t('.telephone_number') %></span>
+            <% end %>
           </dd>
-        <%end%>
+        <% end %>
       </div>
-      <% if @user.telephone_number.present? %>
-        <div id= "view-user__mfa-status" class="govuk-summary-list__row">
+      <% unless @user.telephone_number.blank? %>
+        <div class="govuk-summary-list__row" id="view-user__mfa-status">
           <dt class="govuk-summary-list__key">
             <%= t('.mfa_status') %>
           </dt>
           <dd class="govuk-summary-list__value">
-            <% if @user.mfa_enabled%>
-                <strong class="govuk-tag">
-                    <%= t('.enabled') %>
-                </strong>
-            <% else %>
-                <strong class="govuk-tag govuk-tag--red">
-                    <%= t('.disabled') %>
-                </strong>
-            <% end %>
+            <%= govuk_tag_with_text(*enabled_disabled_status_tag(@user.mfa_enabled)) %>
           </dd>
+          <% if can_edit_user? %>
+            <dd class="govuk-summary-list__actions">
+              <%= link_to('#mfa-enabled', class: 'govuk-link govuk-link--no-visited-state') do %>
+                <%= t('.change') %>
+                <span class="govuk-visually-hidden"><%= t('.mfa_status') %></span>
+              <% end %>
+            </dd>
+          <% end %>
         </div>
-      <%end%>
-      <div id= "view-user__roles" class="govuk-summary-list__row">
+      <% end %>
+      <div class="govuk-summary-list__row" id="view-user__roles">
         <dt class="govuk-summary-list__key">
           <%= t('.roles') %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%if @user.roles.present?%>
-            <% @user.roles.each do |role| %>
-              <%= t("crown_marketplace.role_map.#{role}.text") %><br>
-            <% end %>
+          <% if @user.roles.any? %>
+            <ul class="govuk-list">
+              <% @user.roles.each do |role| %>
+                <li>
+                  <%= t("crown_marketplace.role_map.#{role}.text") %>
+                </li>
+              <% end %>
+            </ul>
           <% else %>
             <%= t('.none') %>
           <% end %>
         </dd>
-        <% if @current_row_change_access %>
+        <% if can_edit_user? %>
           <dd class="govuk-summary-list__actions">
-            <%= link_to(t('.change'), class: 'govuk-link govuk-link--no-visited-state') %>
+            <%= link_to('#roles', class: 'govuk-link govuk-link--no-visited-state') do %>
+              <%= t('.change') %>
+              <span class="govuk-visually-hidden"><%= t('.roles') %></span>
+            <% end %>
           </dd>
-        <%end%>
+        <% end %>
       </div>
-      <div id= "view-user__service-access" class="govuk-summary-list__row">
+      <div class="govuk-summary-list__row" id="view-user__service-access">
         <dt class="govuk-summary-list__key">
           <%= t('.service_access') %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%if @user.service_access.present?%>
-            <% @user.service_access.each do |service_access| %>
-              <%= t("crown_marketplace.service_access_map.#{service_access}.text") %><br>
-            <% end %>
-          <%else%>
+          <% if @user.service_access.any? %>
+            <ul class="govuk-list">
+              <% @user.service_access.each do |service_access| %>
+                <li>
+                  <%= t("crown_marketplace.service_access_map.#{service_access}.text") %>
+                </li>
+              <% end %>
+            </ul>
+          <% else %>
             <%= t('.none') %>
-          <%end%>
+          <% end %>
         </dd>
-        <% if @current_row_change_access %>
+        <% if can_edit_user? %>
           <dd class="govuk-summary-list__actions">
-            <%= link_to(t('.change'), class: 'govuk-link govuk-link--no-visited-state') %>
+            <%= link_to(edit_crown_marketplace_manage_user_path(section: 'service-access'), class: 'govuk-link govuk-link--no-visited-state') do %>
+              <%= t('.change') %>
+              <span class="govuk-visually-hidden"><%= t('.service_access') %></span>
+            <% end %>
           </dd>
-        <%end%>
+        <% end %>
       </div>
     </dl>
   </div>
 </div>
-
-
-

--- a/config/locales/views/crown_marketplace.en.yml
+++ b/config/locales/views/crown_marketplace.en.yml
@@ -75,6 +75,7 @@ en:
         allow_list_body: View and update the allow list so users can create their own accounts
         allow_list_heading: Allow list
         facilities_management: Facilities Management
+        lack_permissions: You do not have the required permissions to edit this user
         legal_service: Legal Service
         manage_users_body: Find a user by email to view and update their details
         manage_users_title: Manage users
@@ -83,7 +84,7 @@ en:
         new_user_invite_title: Invite a new user
         something_went_wrong_banner:
           message: 'The following error occured: "%{error_message}"'
-          title: There is a problem
+          title: Something went wrong
         supply_teachers: Supply Teachers
         support_users_blurb: 'Support users on the following four services:'
         user_account_created_banner:
@@ -106,11 +107,18 @@ en:
         select_service_access:
           hint: Buyer and service admin users need to be assigned access to at least one service
           legend: Select the service access for the user
+      edit:
+        heading: Update user %{section}
+        save_and_return: Save and return
       edit_partials:
         account_status:
           options:
             disabled: Disabled
             enabled: Enabled
+        service_access:
+          hint: Buyer and service admin users need to be assigned access to at least one service, otherwise this can be left empty
+          legend: Select the service access for the user
+          section: service access
       index:
         enter_an_email: Enter the email of the user and click 'Search' to see if that user has an account in Crown Marketplace.
         find_a_user: Find a user
@@ -123,9 +131,7 @@ en:
         account_status: Account status
         change: Change
         confirmation_status: Confirmation status
-        disabled: Disabled
         email: Email address
-        enabled: Enabled
         heading: View user
         mfa_status: MFA status
         none: None

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -243,6 +243,10 @@ Rails.application.routes.draw do
         get '/:section/add-user', action: :add_user, as: :add_user
         post '/:section/add-user', action: :create_add_user, as: :create_add_user
       end
+      member do
+        get '/:section/edit', action: :edit, as: :edit
+        put '/:section/', action: :update, as: :update
+      end
     end
   end
 

--- a/features/accessibility/crown_marketplace/super_admin/edit_user_accessibility.feature
+++ b/features/accessibility/crown_marketplace/super_admin/edit_user_accessibility.feature
@@ -1,0 +1,32 @@
+@javascript @accessibility
+Feature: Manage users - Super admin - Edit user - Accessibility
+
+  Background: Navigate to the user show page
+    Given I sign in as an 'super admin' user go to the crown marketplace dashboard
+    When I click on 'Manage users'
+    Then I am on the 'Manage users' page
+    Given I am going to do a search to find users
+    And I search for 'buyer@test.com' and there is a user with the following details:
+      | Account enabled     | true                |
+      | Confirmation status | confirmed           |
+      | Roles               | buyer               |
+      | Service access      | fm_access,ls_access |
+    And I enter 'buyer@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | buyer@test.com  | Enabled   |
+    And I view the user with email 'buyer@test.com'
+    Then I am on the 'View user' page
+    And I can manage the user
+    And the user has the following details:
+      | Email address           | buyer@test.com                        |
+      | Account status          | Enabled                               |
+      | Confirmation status     | confirmed                             |
+      | Mobile telephone number | None                                  |
+      | Roles                   | Buyer                                 |
+      | Service access          | Facilities Management Legal Services  |
+
+  Scenario: Service access - Accessibility
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    And the page should be axe clean

--- a/features/accessibility/crown_marketplace/super_admin/view_user_accessibility.feature
+++ b/features/accessibility/crown_marketplace/super_admin/view_user_accessibility.feature
@@ -1,0 +1,128 @@
+@javascript @accessibility
+Feature: Manage users - Super admin - View user - accessibility
+
+  Background: Navigate to manage users page
+    Given I sign in as an 'super admin' user go to the crown marketplace dashboard
+    When I click on 'Manage users'
+    Then I am on the 'Manage users' page
+    Given I am going to do a search to find users
+  
+  Scenario: View Buyer - Accessibility
+    And I search for 'buyer@test.com' and there is a user with the following details:
+      | Account enabled     | true                |
+      | Confirmation status | confirmed           |
+      | Roles               | buyer               |
+      | Service access      | fm_access,ls_access |
+    And I enter 'buyer@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | buyer@test.com  | Enabled   |
+    And I view the user with email 'buyer@test.com'
+    Then I am on the 'View user' page
+    And I can manage the user
+    And the user has the following details:
+      | Email address           | buyer@test.com                        |
+      | Account status          | Enabled                               |
+      | Confirmation status     | confirmed                             |
+      | Mobile telephone number | None                                  |
+      | Roles                   | Buyer                                 |
+      | Service access          | Facilities Management Legal Services  |
+    And the page should be axe clean
+
+  Scenario: View Service admin - Accessibility
+    And I search for 'service_admin@test.com' and there is a user with the following details:
+      | Account enabled         | true          |
+      | Confirmation status     | confirmed     |
+      | Mobile telephone number | 07987654321   |
+      | MFA enabled             | true          |
+      | Roles                   | ccs_employee  | 
+      | Service access          | mc_access     |
+    And I enter 'service_admin@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | service_admin@test.com  | Enabled   |
+    And I view the user with email 'service_admin@test.com'
+    Then I am on the 'View user' page
+    And I can manage the user
+    And the user has the following details:
+      | Email address           | service_admin@test.com  |
+      | Account status          | Enabled                 |
+      | Confirmation status     | confirmed               |
+      | Mobile telephone number | 07987654321             |
+      | MFA status              | Enabled                 |
+      | Roles                   | Service admin           |
+      | Service access          | Management Consultancy  |
+    And the page should be axe clean
+
+  Scenario: View User support - Accessibility
+    And I search for 'user_support@test.com' and there is a user with the following details:
+      | Account enabled         | true              |
+      | Confirmation status     | confirmed         |
+      | Mobile telephone number | 07123456789       |
+      | MFA enabled             | true              |
+      | Roles                   | allow_list_access | 
+    And I enter 'user_support@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | user_support@test.com | Enabled   |
+    And I view the user with email 'user_support@test.com'
+    Then I am on the 'View user' page
+    And I can manage the user
+    And the user has the following details:
+      | Email address           | user_support@test.com |
+      | Account status          | Enabled               |
+      | Confirmation status     | confirmed             |
+      | Mobile telephone number | 07123456789           |
+      | MFA status              | Enabled               |
+      | Roles                   | User support          |
+      | Service access          | None                  |
+    And the page should be axe clean
+
+  Scenario: View User admin - Accessibility
+    And I search for 'user_admin@test.com' and there is a user with the following details:
+      | Account enabled         | true            |
+      | Confirmation status     | confirmed       |
+      | Mobile telephone number | 07123456789     |
+      | MFA enabled             | true            |
+      | Roles                   | ccs_user_admin  |
+    And I enter 'user_admin@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | user_admin@test.com | Enabled   |
+    And I view the user with email 'user_admin@test.com'
+    Then I am on the 'View user' page
+    And I can manage the user
+    And the user has the following details:
+      | Email address           | user_admin@test.com |
+      | Account status          | Enabled             |
+      | Confirmation status     | confirmed           |
+      | Mobile telephone number | 07123456789         |
+      | MFA status              | Enabled             |
+      | Roles                   | User admin          |
+      | Service access          | None                |
+    And the page should be axe clean
+
+  Scenario: View Super admin - Accessibility
+    And I search for 'super_admin@test.com' and there is a user with the following details:
+      | Account enabled         | true          |
+      | Confirmation status     | confirmed     |
+      | Mobile telephone number | 07123456789   |
+      | MFA enabled             | true          |
+      | Roles                   | ccs_developer |
+    And I enter 'super_admin@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | super_admin@test.com  | Enabled   |
+    And I view the user with email 'super_admin@test.com'
+    Then I am on the 'View user' page
+    And I cannot manage the user and there is the following warning:
+      | You cannot make changes to this user. 'Super admins' can only be updated in the AWS Cognito console.  |
+    And the user has the following details:
+      | Email address           | super_admin@test.com  |
+      | Account status          | Enabled               |
+      | Confirmation status     | confirmed             |
+      | Mobile telephone number | 07123456789           |
+      | MFA status              | Enabled               |
+      | Roles                   | Super admin           |
+      | Service access          | None                  |
+    And the page should be axe clean

--- a/features/crown_marketplace/manage_users/super_admin/edit_user.feature
+++ b/features/crown_marketplace/manage_users/super_admin/edit_user.feature
@@ -1,0 +1,46 @@
+Feature: Manage users - Super admin - Edit user
+
+  Background: Navigate to the user show page
+    Given I sign in as an 'super admin' user go to the crown marketplace dashboard
+    When I click on 'Manage users'
+    Then I am on the 'Manage users' page
+    Given I am going to do a search to find users
+    And I search for 'buyer@test.com' and there is a user with the following details:
+      | Account enabled     | true                |
+      | Confirmation status | confirmed           |
+      | Roles               | buyer               |
+      | Service access      | fm_access,ls_access |
+    And I enter 'buyer@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | buyer@test.com  | Enabled   |
+    And I view the user with email 'buyer@test.com'
+    Then I am on the 'View user' page
+    And I can manage the user
+    And the user has the following details:
+      | Email address           | buyer@test.com                        |
+      | Account status          | Enabled                               |
+      | Confirmation status     | confirmed                             |
+      | Mobile telephone number | None                                  |
+      | Roles                   | Buyer                                 |
+      | Service access          | Facilities Management Legal Services  |
+
+  Scenario: Edit user - Service access
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    And the users details after the update will be:
+      | Service access      | fm_access,st_access |
+    And I am going to succesfully update the user on 'service_access'
+    And I deselect the following items:
+      | Legal Services |
+    And I select 'Supply Teachers'
+    And I click on 'Save and return'
+    Then I am on the 'View user' page
+    And the user has the following details:
+      | Service access  | Facilities Management Supply Teachers  |
+
+  Scenario: Edit user - Service error
+    And I cannot edit the user account because of an error
+    And I change the 'Service access' for the user
+    Then I am on the 'Crown Marketplace dashboard' page
+    And there is an error notification with the message 'An error occured when trying to edit the user'

--- a/features/crown_marketplace/manage_users/super_admin/validations/edit_user_validation.feature
+++ b/features/crown_marketplace/manage_users/super_admin/validations/edit_user_validation.feature
@@ -1,0 +1,47 @@
+@pipeline
+Feature: Manage users - Super admin - Edit user - Validations
+
+  Background: Navigate to the user show page
+    Given I sign in as an 'super admin' user go to the crown marketplace dashboard
+    When I click on 'Manage users'
+    Then I am on the 'Manage users' page
+    Given I am going to do a search to find users
+    And I search for 'service_admin@test.com' and there is a user with the following details:
+      | Account enabled         | true          |
+      | Confirmation status     | confirmed     |
+      | Mobile telephone number | 07987654321   |
+      | MFA enabled             | true          |
+      | Roles                   | ccs_employee  | 
+      | Service access          | mc_access     |
+    And I enter 'service_admin@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | service_admin@test.com  | Enabled   |
+    And I view the user with email 'service_admin@test.com'
+    Then I am on the 'View user' page
+    And I can manage the user
+    And the user has the following details:
+      | Email address           | service_admin@test.com  |
+      | Account status          | Enabled                 |
+      | Confirmation status     | confirmed               |
+      | Mobile telephone number | 07987654321             |
+      | MFA status              | Enabled                 |
+      | Roles                   | Service admin           |
+      | Service access          | Management Consultancy  |
+
+  Scenario: Service access - Validations
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    And I deselect the following items:
+      | Management Consultancy |
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | You must select the service access for the user from this list |
+
+  Scenario: Service error
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    And I cannot update the user account because of an error
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | An error occured when trying to update the user |

--- a/features/crown_marketplace/manage_users/super_admin/view_user/something_went_wrong.feature
+++ b/features/crown_marketplace/manage_users/super_admin/view_user/something_went_wrong.feature
@@ -14,5 +14,4 @@ Feature: Manage users - Super admin - View user - Something went wron
     And I cannot view the user account because of the 'service' error
     And I view the user with email 'buyer@test.com'
     Then I am on the 'Crown Marketplace dashboard' page
-    And I can see the following error message in the summary:
-      | The following error occured: "An error occured: service" |
+    And there is an error notification with the message 'An error occured: service'

--- a/features/crown_marketplace/manage_users/user_admin/edit_user.feature
+++ b/features/crown_marketplace/manage_users/user_admin/edit_user.feature
@@ -1,0 +1,46 @@
+Feature: Manage users - User admin - Edit user
+
+  Background: Navigate to the user show page
+    Given I sign in as an 'user admin' user go to the crown marketplace dashboard
+    When I click on 'Manage users'
+    Then I am on the 'Manage users' page
+    Given I am going to do a search to find users
+    And I search for 'buyer@test.com' and there is a user with the following details:
+      | Account enabled     | true                |
+      | Confirmation status | confirmed           |
+      | Roles               | buyer               |
+      | Service access      | fm_access,ls_access |
+    And I enter 'buyer@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | buyer@test.com  | Enabled   |
+    And I view the user with email 'buyer@test.com'
+    Then I am on the 'View user' page
+    And I can manage the user
+    And the user has the following details:
+      | Email address           | buyer@test.com                        |
+      | Account status          | Enabled                               |
+      | Confirmation status     | confirmed                             |
+      | Mobile telephone number | None                                  |
+      | Roles                   | Buyer                                 |
+      | Service access          | Facilities Management Legal Services  |
+
+  Scenario: Edit user - Service access
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    And the users details after the update will be:
+      | Service access      | fm_access,st_access |
+    And I am going to succesfully update the user on 'service_access'
+    And I deselect the following items:
+      | Legal Services |
+    And I select 'Supply Teachers'
+    And I click on 'Save and return'
+    Then I am on the 'View user' page
+    And the user has the following details:
+      | Service access  | Facilities Management Supply Teachers  |
+
+  Scenario: Edit user - Service error
+    And I cannot edit the user account because of an error
+    And I change the 'Service access' for the user
+    Then I am on the 'Crown Marketplace dashboard' page
+    And there is an error notification with the message 'An error occured when trying to edit the user'

--- a/features/crown_marketplace/manage_users/user_admin/validations/edit_user_validation.feature
+++ b/features/crown_marketplace/manage_users/user_admin/validations/edit_user_validation.feature
@@ -1,0 +1,46 @@
+Feature: Manage users - User admin - Edit user - Validations
+
+  Background: Navigate to the user show page
+    Given I sign in as an 'super admin' user go to the crown marketplace dashboard
+    When I click on 'Manage users'
+    Then I am on the 'Manage users' page
+    Given I am going to do a search to find users
+    And I search for 'service_admin@test.com' and there is a user with the following details:
+      | Account enabled         | true          |
+      | Confirmation status     | confirmed     |
+      | Mobile telephone number | 07987654321   |
+      | MFA enabled             | true          |
+      | Roles                   | ccs_employee  | 
+      | Service access          | mc_access     |
+    And I enter 'service_admin@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | service_admin@test.com  | Enabled   |
+    And I view the user with email 'service_admin@test.com'
+    Then I am on the 'View user' page
+    And I can manage the user
+    And the user has the following details:
+      | Email address           | service_admin@test.com  |
+      | Account status          | Enabled                 |
+      | Confirmation status     | confirmed               |
+      | Mobile telephone number | 07987654321             |
+      | MFA status              | Enabled                 |
+      | Roles                   | Service admin           |
+      | Service access          | Management Consultancy  |
+
+  Scenario: Service access - Validations
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    And I deselect the following items:
+      | Management Consultancy |
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | You must select the service access for the user from this list |
+
+  Scenario: Service error
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    And I cannot update the user account because of an error
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | An error occured when trying to update the user |

--- a/features/crown_marketplace/manage_users/user_admin/view_user/something_went_wrong.feature
+++ b/features/crown_marketplace/manage_users/user_admin/view_user/something_went_wrong.feature
@@ -14,5 +14,4 @@ Feature: Manage users - User admin - View user - Something went wron
     And I cannot view the user account because of the 'service' error
     And I view the user with email 'buyer@test.com'
     Then I am on the 'Crown Marketplace dashboard' page
-    And I can see the following error message in the summary:
-      | The following error occured: "An error occured: service" |
+    And there is an error notification with the message 'An error occured: service'

--- a/features/crown_marketplace/manage_users/user_support/edit_user.feature
+++ b/features/crown_marketplace/manage_users/user_support/edit_user.feature
@@ -1,0 +1,47 @@
+@pipeline
+Feature: Manage users - User support - Edit user
+
+  Background: Navigate to the user show page
+    Given I sign in as an 'user support' user go to the crown marketplace dashboard
+    When I click on 'Manage users'
+    Then I am on the 'Manage users' page
+    Given I am going to do a search to find users
+    And I search for 'buyer@test.com' and there is a user with the following details:
+      | Account enabled     | true                |
+      | Confirmation status | confirmed           |
+      | Roles               | buyer               |
+      | Service access      | fm_access,ls_access |
+    And I enter 'buyer@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | buyer@test.com  | Enabled   |
+    And I view the user with email 'buyer@test.com'
+    Then I am on the 'View user' page
+    And I can manage the user
+    And the user has the following details:
+      | Email address           | buyer@test.com                        |
+      | Account status          | Enabled                               |
+      | Confirmation status     | confirmed                             |
+      | Mobile telephone number | None                                  |
+      | Roles                   | Buyer                                 |
+      | Service access          | Facilities Management Legal Services  |
+
+  Scenario: Edit user - Service access
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    And the users details after the update will be:
+      | Service access      | fm_access,st_access |
+    And I am going to succesfully update the user on 'service_access'
+    And I deselect the following items:
+      | Legal Services |
+    And I select 'Supply Teachers'
+    And I click on 'Save and return'
+    Then I am on the 'View user' page
+    And the user has the following details:
+      | Service access  | Facilities Management Supply Teachers  |
+
+  Scenario: Edit user - Service error
+    And I cannot edit the user account because of an error
+    And I change the 'Service access' for the user
+    Then I am on the 'Crown Marketplace dashboard' page
+    And there is an error notification with the message 'An error occured when trying to edit the user'

--- a/features/crown_marketplace/manage_users/user_support/validations/edit_user_validation.feature
+++ b/features/crown_marketplace/manage_users/user_support/validations/edit_user_validation.feature
@@ -1,0 +1,44 @@
+Feature: Manage users - User support - Edit user - Validations
+
+  Background: Navigate to the user show page
+    Given I sign in as an 'user support' user go to the crown marketplace dashboard
+    When I click on 'Manage users'
+    Then I am on the 'Manage users' page
+    Given I am going to do a search to find users
+    And I search for 'buyer@test.com' and there is a user with the following details:
+      | Account enabled     | true                |
+      | Confirmation status | confirmed           |
+      | Roles               | buyer               |
+      | Service access      | fm_access,ls_access |
+    And I enter 'buyer@test.com' into the search
+    And I click on 'Search'
+    Then I should see the following users in the results:
+      | buyer@test.com  | Enabled   |
+    And I view the user with email 'buyer@test.com'
+    Then I am on the 'View user' page
+    And I can manage the user
+    And the user has the following details:
+      | Email address           | buyer@test.com                        |
+      | Account status          | Enabled                               |
+      | Confirmation status     | confirmed                             |
+      | Mobile telephone number | None                                  |
+      | Roles                   | Buyer                                 |
+      | Service access          | Facilities Management Legal Services  |
+
+  Scenario: Service access - Validations
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    And I deselect the following items:
+      | Facilities Management |
+      | Legal Services        |
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | You must select the service access for the user from this list |
+
+  Scenario: Service error
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    And I cannot update the user account because of an error
+    And I click on 'Save and return'
+    Then I should see the following error messages:
+      | An error occured when trying to update the user |

--- a/features/crown_marketplace/manage_users/user_support/view_user/something_went_wrong.feature
+++ b/features/crown_marketplace/manage_users/user_support/view_user/something_went_wrong.feature
@@ -14,5 +14,4 @@ Feature: Manage users - User support - View user - Something went wron
     And I cannot view the user account because of the 'service' error
     And I view the user with email 'buyer@test.com'
     Then I am on the 'Crown Marketplace dashboard' page
-    And I can see the following error message in the summary:
-      | The following error occured: "An error occured: service" |
+    And there is an error notification with the message 'An error occured: service'

--- a/features/step_definitions/crown_marketplace/cognito_steps.rb
+++ b/features/step_definitions/crown_marketplace/cognito_steps.rb
@@ -36,20 +36,57 @@ Then('I cannot view the user account because of the {string} error') do |error_k
   stub_cognito_admin_with_error(:find_user, error_key)
 end
 
+Then('I cannot edit the user account because of an error') do
+  allow(Cognito::Admin::UserClientInterface).to receive(:find_user_from_cognito_uuid).and_return({ error: 'An error occured when trying to edit the user' })
+end
+
+Then('I cannot update the user account because of an error') do
+  allow(Cognito::Admin::UserClientInterface).to receive(:update_user_and_return_errors).and_return('An error occured when trying to update the user')
+end
+
 Given('I search for {string} and there is a user with the following details:') do |email, user_details_table|
   stub_admin_cognito(:find_users, search: email, users: [{ email: email, account_status: 'enabled' }])
 
   user_details = user_details_table.raw.to_h
-  allow(Cognito::Admin::UserClientInterface).to receive(:find_user_from_cognito_uuid).and_return(
+  @user_details = {
+    cognito_uuid: SecureRandom.uuid,
+    email: email,
+    telephone_number: user_details['Mobile telephone number'],
+    account_status: user_details['Account enabled'] == 'true',
+    confirmation_status: user_details['Confirmation status'],
+    mfa_enabled: user_details['MFA enabled'] == 'true',
+    roles: (user_details['Roles'] || '').split(','),
+    service_access: (user_details['Service access'] || '').split(',')
+  }
+  allow(Cognito::Admin::UserClientInterface).to receive(:find_user_from_cognito_uuid).and_return(@user_details)
+end
+
+Then('I am going to succesfully update the user on {string}') do |section|
+  allow(Cognito::Admin::UserClientInterface).to receive(:update_user_and_return_errors).with(
+    @user_details[:cognito_uuid],
     {
-      cognito_uuid: SecureRandom.uuid,
-      email: email,
-      telephone_number: user_details['Mobile telephone number'],
-      account_status: user_details['Account enabled'] == 'true',
-      confirmation_status: user_details['Confirmation status'],
-      mfa_enabled: user_details['MFA enabled'] == 'true',
-      roles: (user_details['Roles'] || '').split(','),
-      service_access: (user_details['Service access'] || '').split(',')
-    }
-  )
+      email: @user_details[:email],
+      account_status: @user_details[:account_status],
+      telephone_number: @user_details[:telephone_number],
+      groups: @user_details[:service_access] + @user_details[:roles],
+      origional_groups: @user_details[:service_access] + @user_details[:roles],
+      mfa_enabled: @user_details[:mfa_enabled]
+    },
+    section.to_sym
+  ).and_return(nil)
+end
+
+Then('the users details after the update will be:') do |user_details_table|
+  user_details = user_details_table.raw.to_h
+  @user_details = {
+    cognito_uuid: @user_details[:cognito_uuid],
+    email: @user_details[:email],
+    telephone_number: user_details['Mobile telephone number'] || @user_details[:telephone_number],
+    account_status: user_details['Account enabled'] == 'true' || @user_details[:account_status],
+    confirmation_status: user_details['Confirmation status'] || @user_details[:confirmation_status],
+    mfa_enabled: user_details['MFA enabled'] == 'true' || @user_details[:mfa_enabled],
+    roles: (user_details['Roles'] || '').split(',').presence || @user_details[:roles],
+    service_access: (user_details['Service access'] || '').split(',').presence || @user_details[:service_access]
+  }
+  allow(Cognito::Admin::UserClientInterface).to receive(:find_user_from_cognito_uuid).and_return(@user_details)
 end

--- a/features/step_definitions/crown_marketplace/manage_users_steps.rb
+++ b/features/step_definitions/crown_marketplace/manage_users_steps.rb
@@ -13,6 +13,11 @@ Then('the account {string} has been added') do |email|
   expect(manage_users_page.notification_banner.content).to have_content("An email has been sent to #{email} with the details for them to sign in")
 end
 
+Then('there is an error notification with the message {string}') do |error_message|
+  expect(manage_users_page.notification_banner.heading).to have_content('Something went wrong')
+  expect(manage_users_page.notification_banner.content).to have_content("The following error occured: \"#{error_message}\"")
+end
+
 Then('I change the {string} from the user summary') do |option|
   manage_users_page.user_details_summary.send(option).action.click
 end
@@ -67,4 +72,8 @@ end
 Then('I can see the following error message in the summary:') do |table|
   expect(page).to have_css('div.govuk-error-summary')
   expect(page.find('.govuk-error-summary__list').find_all('li').map(&:text).reject(&:empty?)).to eq table.raw.flatten
+end
+
+Then('I change the {string} for the user') do |section|
+  manage_users_page.view_user_summary.send(section).edit.click
 end

--- a/spec/helpers/crown_marketplace/manage_users_helper_spec.rb
+++ b/spec/helpers/crown_marketplace/manage_users_helper_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe CrownMarketplace::ManageUsersHelper, type: :helper do
+  describe '.add_users_back_link' do
+    let(:result) { helper.add_users_back_link(cognito_admin_user, 'my_section') }
+
+    let(:cognito_admin_user) { Cognito::Admin::User.new(current_user_access, attributes) }
+    let(:current_user_access) { :super_admin }
+    let(:email) { 'user@crowncommercial.gov.uk' }
+    let(:roles) { %w[buyer] }
+    let(:telephone_number) { '07123456789' }
+    let(:service_access) { %w[fm_access] }
+
+    let(:attributes) do
+      {
+        email: email,
+        telephone_number: telephone_number,
+        roles: roles,
+        service_access: service_access,
+      }
+    end
+
+    context 'when all attributes are present' do
+      it 'creates a link with all the attributes' do
+        expect(result).to eq '/crown-marketplace/manage-users/my_section/add-user?email=user%40crowncommercial.gov.uk&roles%5B%5D=buyer&service_access%5B%5D=fm_access&telephone_number=07123456789'
+      end
+    end
+
+    context 'when only attributes are present' do
+      let(:telephone_number) { nil }
+      let(:service_access) { [] }
+
+      it 'creates a link with only the present attributes' do
+        expect(result).to eq '/crown-marketplace/manage-users/my_section/add-user?email=user%40crowncommercial.gov.uk&roles%5B%5D=buyer'
+      end
+    end
+  end
+
+  describe '.enabled_disabled_status_tag' do
+    let(:result) { helper.enabled_disabled_status_tag(enabled) }
+
+    context 'when the account is enabled' do
+      let(:enabled) { true }
+
+      it 'returns blue with enabled' do
+        expect(result).to eq [:blue, 'Enabled']
+      end
+    end
+
+    context 'when the account is not enabled' do
+      let(:enabled) { false }
+
+      it 'returns red with disabled' do
+        expect(result).to eq [:red, 'Disabled']
+      end
+    end
+  end
+
+  describe '.user_confirmation_status_tag' do
+    let(:result) { helper.user_confirmation_status_tag(status) }
+
+    context 'when the current status is UNCONFIRMED' do
+      let(:status) { 'UNCONFIRMED' }
+
+      it 'returns grey and UNCONFIRMED' do
+        expect(result).to eq [:grey, 'UNCONFIRMED']
+      end
+    end
+
+    context 'when the current status is CONFIRMED' do
+      let(:status) { 'CONFIRMED' }
+
+      it 'returns blue and CONFIRMED' do
+        expect(result).to eq [:blue, 'CONFIRMED']
+      end
+    end
+
+    context 'when the current status is ARCHIVED' do
+      let(:status) { 'ARCHIVED' }
+
+      it 'returns grey and ARCHIVED' do
+        expect(result).to eq [:grey, 'ARCHIVED']
+      end
+    end
+
+    context 'when the current status is COMPROMISED' do
+      let(:status) { 'COMPROMISED' }
+
+      it 'returns red and COMPROMISED' do
+        expect(result).to eq [:red, 'COMPROMISED']
+      end
+    end
+
+    context 'when the current status is UNKNOWN' do
+      let(:status) { 'UNKNOWN' }
+
+      it 'returns grey and UNKNOWN' do
+        expect(result).to eq [:grey, 'UNKNOWN']
+      end
+    end
+
+    context 'when the current status is RESET_REQUIRED' do
+      let(:status) { 'RESET_REQUIRED' }
+
+      it 'returns grey and RESET_REQUIRED' do
+        expect(result).to eq [:grey, 'RESET_REQUIRED']
+      end
+    end
+
+    context 'when the current status is FORCE_CHANGE_PASSWORD' do
+      let(:status) { 'FORCE_CHANGE_PASSWORD' }
+
+      it 'returns grey and FORCE_CHANGE_PASSWORD' do
+        expect(result).to eq [:grey, 'FORCE_CHANGE_PASSWORD']
+      end
+    end
+  end
+end

--- a/spec/services/cognito/admin/roles_spec.rb
+++ b/spec/services/cognito/admin/roles_spec.rb
@@ -737,58 +737,6 @@ RSpec.describe Cognito::Admin::Roles do
     end
   end
 
-  describe '.array_of_users_that_could_edit' do
-    let(:result) { cognito_roles.array_of_users_that_could_edit }
-
-    context 'when the user is a buyer' do
-      let(:roles) { %w[buyer] }
-
-      it 'returns user support, user admin and super admin ' do
-        expect(result).to eq %i[user_support user_admin super_admin]
-      end
-    end
-
-    context 'when the user is a User Support' do
-      let(:roles) { %w[allow_list_access] }
-
-      it 'returns user admin and super admin ' do
-        expect(result).to eq %i[user_admin super_admin]
-      end
-    end
-
-    context 'when the user is a User Admin' do
-      let(:roles) { %w[ccs_user_admin] }
-
-      it 'returns a super_admin' do
-        expect(result).to eq [:super_admin]
-      end
-    end
-
-    context 'when the user is a ccs_developer' do
-      let(:roles) { %w[ccs_developer] }
-
-      it 'returns a blank array' do
-        expect(result).to eq []
-      end
-    end
-
-    context 'when the user is a ccs_developer and a User Admin' do
-      let(:roles) { %w[ccs_developer ccs_user_admin] }
-
-      it 'returns a blank array' do
-        expect(result).to eq []
-      end
-    end
-
-    context 'when the user is a Buyer and a User Support' do
-      let(:roles) { %w[buyer allow_list_access] }
-
-      it 'returns user admin and super admin' do
-        expect(result).to eq %i[user_admin super_admin]
-      end
-    end
-  end
-
   describe '.minimum_editor_role' do
     let(:result) { cognito_roles.minimum_editor_role }
 
@@ -840,4 +788,707 @@ RSpec.describe Cognito::Admin::Roles do
       end
     end
   end
+
+  # rubocop:disable RSpec/NestedGroups
+  describe '.can_edit_user_with_current_access?' do
+    let(:result) { cognito_roles.can_edit_user_with_current_access? }
+    let(:roles) { primary_role + additional_roles }
+
+    context 'when the user is a super_admin' do
+      let(:user_access) { :super_admin }
+
+      context 'when there are no roles' do
+        let(:roles) { [] }
+
+        it 'returns false' do
+          expect(result).to eq false
+        end
+      end
+
+      context 'when the roles include buyer' do
+        let(:primary_role) { %w[buyer] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include ccs_employee' do
+        let(:primary_role) { %w[ccs_employee] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include allow_list_access' do
+        let(:primary_role) { %w[allow_list_access] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include ccs_user_admin' do
+        let(:primary_role) { %w[ccs_user_admin] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include ccs_developer' do
+        let(:primary_role) { %w[ccs_developer] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+    end
+
+    context 'when the user is a user_admin' do
+      let(:user_access) { :user_admin }
+
+      context 'when there are no roles' do
+        let(:roles) { [] }
+
+        it 'returns false' do
+          expect(result).to eq false
+        end
+      end
+
+      context 'when the roles include buyer' do
+        let(:primary_role) { %w[buyer] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include ccs_employee' do
+        let(:primary_role) { %w[ccs_employee] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include allow_list_access' do
+        let(:primary_role) { %w[allow_list_access] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include ccs_user_admin' do
+        let(:primary_role) { %w[ccs_user_admin] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include ccs_developer' do
+        let(:primary_role) { %w[ccs_developer] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+    end
+
+    context 'when the user is a user_support' do
+      let(:user_access) { :user_support }
+
+      context 'when there are no roles' do
+        let(:roles) { [] }
+
+        it 'returns false' do
+          expect(result).to eq false
+        end
+      end
+
+      context 'when the roles include buyer' do
+        let(:primary_role) { %w[buyer] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns true' do
+            expect(result).to eq true
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include ccs_employee' do
+        let(:primary_role) { %w[ccs_employee] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include allow_list_access' do
+        let(:primary_role) { %w[allow_list_access] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include ccs_user_admin' do
+        let(:primary_role) { %w[ccs_user_admin] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_developer' do
+          let(:additional_roles) { %w[ccs_developer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+
+      context 'when the roles include ccs_developer' do
+        let(:primary_role) { %w[ccs_developer] }
+
+        context 'and there are no additional roles' do
+          let(:additional_roles) { [] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are buyer' do
+          let(:additional_roles) { %w[buyer] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_employee' do
+          let(:additional_roles) { %w[ccs_employee] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are allow_list_access' do
+          let(:additional_roles) { %w[allow_list_access] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+
+        context 'and the additional roles are ccs_user_admin' do
+          let(:additional_roles) { %w[ccs_user_admin] }
+
+          it 'returns false' do
+            expect(result).to eq false
+          end
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/NestedGroups
 end


### PR DESCRIPTION
Ticket: [FMFR-1327](https://crowncommercialservice.atlassian.net/browse/FMFR-1327)

In this commit I have added the ability to edit a user’s service access. Before I started this I first refactored some of the work for the show users page so that it could be more easily shared between the controller methods.

I’ve added tests for all my changes including:
- Specs for the new helper methods
- Specs for the changes to roles
- Specs for the controller (both edit and update)
- Feature tests for editing and updating the user

[FMFR-1327]: https://crowncommercialservice.atlassian.net/browse/FMFR-1327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ