### PR TITLE
Fixed bug where all users could not leave service access empty. 

### DIFF
--- a/app/services/cognito/admin/user.rb
+++ b/app/services/cognito/admin/user.rb
@@ -28,7 +28,7 @@ module Cognito
       validate :validate_role, on: %i[roles select_role create]
       validate :can_set_admin_role, on: :roles
 
-      validates :service_access, length: { minimum: 1 }, on: %i[select_service_access service_access]
+      validates :service_access, length: { minimum: 1 }, on: %i[select_service_access]
       validate :validate_service_access, on: %i[create select_service_access service_access]
 
       with_options on: :mfa_enabled do

--- a/features/crown_marketplace/manage_users/super_admin/edit_user.feature
+++ b/features/crown_marketplace/manage_users/super_admin/edit_user.feature
@@ -119,6 +119,37 @@ Feature: Manage users - Super admin - Edit user
     And the user has the following details:
       | Service access  | Facilities Management Supply Teachers  |
 
+  Scenario: Edit user - No Service access required
+    And I change the 'Roles' for the user
+    And I am on the 'Update user roles' page
+    And I have the following options for roles:
+      | Buyer         |
+      | Service admin |
+      | User support  |
+      | User admin    |
+    And the users details after the update will be:
+      | Mobile telephone number | 07123456789        |
+      | MFA enabled             | true               |
+      | Roles                   | allow_list_access  |
+    And I am going to succesfully update the user on 'roles'
+    And I deselect the following items:
+      | Buyer |
+    And I select 'User support'
+    And I click on 'Save and return'
+    Then I am on the 'View user' page
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    Then the users details after the update will be:
+      | Service access  ||
+    And I am going to succesfully update the user on 'service_access'
+    And I deselect the following items:
+      | Facilities Management |
+      | Legal Services        |
+    And I click on 'Save and return'
+    Then I am on the 'View user' page
+    And the user has the following details:
+      | Service access  | None |
+    
   Scenario: Edit user - Service error
     And I cannot edit the user account because of an error
     And I change the 'Service access' for the user

--- a/features/crown_marketplace/manage_users/super_admin/validations/edit_user_validation.feature
+++ b/features/crown_marketplace/manage_users/super_admin/validations/edit_user_validation.feature
@@ -79,7 +79,7 @@ Feature: Manage users - Super admin - Edit user - Validations
       | Management Consultancy |
     And I click on 'Save and return'
     Then I should see the following error messages:
-      | You must select the service access for the user from this list |
+      | You must select the service access for the user if they have the buyer or service admin role |
 
   Scenario: Service error
     And I change the 'Service access' for the user

--- a/features/crown_marketplace/manage_users/user_admin/edit_user.feature
+++ b/features/crown_marketplace/manage_users/user_admin/edit_user.feature
@@ -123,3 +123,33 @@ Feature: Manage users - User admin - Edit user
     And I change the 'Service access' for the user
     Then I am on the 'Crown Marketplace dashboard' page
     And there is an error notification with the message 'An error occured when trying to edit the user'
+    
+  Scenario: Edit user - No Service access required
+    And I change the 'Roles' for the user
+    And I am on the 'Update user roles' page
+    And I have the following options for roles:
+      | Buyer         |
+      | Service admin |
+      | User support  |
+    And the users details after the update will be:
+      | Mobile telephone number | 07123456789        |
+      | MFA enabled             | true               |
+      | Roles                   | allow_list_access  |
+    And I am going to succesfully update the user on 'roles'
+    And I deselect the following items:
+      | Buyer |
+    And I select 'User support'
+    And I click on 'Save and return'
+    Then I am on the 'View user' page
+    And I change the 'Service access' for the user
+    And I am on the 'Update user service access' page
+    Then the users details after the update will be:
+      | Service access  ||
+    And I am going to succesfully update the user on 'service_access'
+    And I deselect the following items:
+      | Facilities Management |
+      | Legal Services        |
+    And I click on 'Save and return'
+    Then I am on the 'View user' page
+    And the user has the following details:
+      | Service access  | None |

--- a/features/crown_marketplace/manage_users/user_admin/validations/edit_user_validation.feature
+++ b/features/crown_marketplace/manage_users/user_admin/validations/edit_user_validation.feature
@@ -78,7 +78,7 @@ Feature: Manage users - User admin - Edit user - Validations
       | Management Consultancy |
     And I click on 'Save and return'
     Then I should see the following error messages:
-      | You must select the service access for the user from this list |
+      | You must select the service access for the user if they have the buyer or service admin role |
 
   Scenario: Service error
     And I change the 'Service access' for the user

--- a/features/crown_marketplace/manage_users/user_support/validations/edit_user_validation.feature
+++ b/features/crown_marketplace/manage_users/user_support/validations/edit_user_validation.feature
@@ -35,7 +35,7 @@ Feature: Manage users - User support - Edit user - Validations
       | Legal Services        |
     And I click on 'Save and return'
     Then I should see the following error messages:
-      | You must select the service access for the user from this list |
+      | You must select the service access for the user if they have the buyer or service admin role |
 
   Scenario: Service error
     And I change the 'Service access' for the user

--- a/features/step_definitions/crown_marketplace/cognito_steps.rb
+++ b/features/step_definitions/crown_marketplace/cognito_steps.rb
@@ -89,7 +89,8 @@ Then('the users details after the update will be:') do |user_details_table|
     confirmation_status: user_details['Confirmation status'] || @user_details[:confirmation_status],
     mfa_enabled: user_details['MFA enabled'] == 'true' || @user_details[:mfa_enabled] == 'true',
     roles: (user_details['Roles'] || '').split(',').presence || @user_details[:roles],
-    service_access: (user_details['Service access'] || '').split(',').presence || @user_details[:service_access]
+    service_access: user_details.key?('Service access') ? user_details['Service access'].split(',') : @user_details[:service_access]
+
   }
   allow(Cognito::Admin::UserClientInterface).to receive(:find_user_from_cognito_uuid).and_return(@user_details)
 end

--- a/spec/services/cognito/admin/user_spec.rb
+++ b/spec/services/cognito/admin/user_spec.rb
@@ -682,16 +682,15 @@ RSpec.describe Cognito::Admin::User do
         context 'and the role requires a service' do
           it 'is invalid and it has the correct error message' do
             expect(cognito_admin_user).not_to be_valid(:service_access)
-            expect(cognito_admin_user.errors[:service_access].first).to eq 'You must select the service access for the user from this list'
+            expect(cognito_admin_user.errors[:service_access].first).to eq 'You must select the service access for the user if they have the buyer or service admin role'
           end
         end
 
         context 'and the role does not require a service' do
           let(:roles) { %w[user_admin] }
 
-          it 'is invalid and it has the correct error message' do
-            expect(cognito_admin_user).not_to be_valid(:service_access)
-            expect(cognito_admin_user.errors[:service_access].first).to eq 'You must select the service access for the user from this list'
+          it 'is valid' do
+            expect(cognito_admin_user).to be_valid(:service_access)
           end
         end
       end
@@ -1614,7 +1613,7 @@ RSpec.describe Cognito::Admin::User do
 
         it 'returns false it has the correct error message' do
           expect(result).to be false
-          expect(cognito_admin_user.errors[:service_access].first).to eq 'You must select the service access for the user from this list'
+          expect(cognito_admin_user.errors[:service_access].first).to eq 'You must select the service access for the user if they have the buyer or service admin role'
         end
 
         it 'does not call admin_remove_user_from_group or admin_add_user_to_group' do


### PR DESCRIPTION
Link to issue: https://crowncommercialservice.atlassian.net/browse/FMFR-1343

Fixed bug where all users could not leave service access empty. 

Only should have been the case for buyers and service admins.