### PR TITLE
FMFR-1360 - Make sure user entered emails are downcased

### DIFF
--- a/app/services/cognito/confirm_sign_up.rb
+++ b/app/services/cognito/confirm_sign_up.rb
@@ -11,7 +11,7 @@ module Cognito
               length: { is: 6, message: :invalid_length }
 
     def initialize(email, confirmation_code)
-      @email = email
+      @email = email.try(:downcase)
       @confirmation_code = confirmation_code
       @error = nil
     end

--- a/app/services/cognito/forgot_password.rb
+++ b/app/services/cognito/forgot_password.rb
@@ -3,10 +3,10 @@ module Cognito
     include ActiveModel::Validations
     attr_reader :email, :error
 
-    validates :email, format: { with: /\A([\w+-].?)+@[a-z\d-]+(\.[a-z]+)*\.[a-z]+\z/i }
+    validates :email, format: { with: /\A([\w+\d-].?)+@[a-z\d-]+(\.[a-z]+)*\.[a-z]+\z/i }
 
     def initialize(email)
-      @email = email
+      @email = email.try(:downcase)
       @error = nil
     end
 

--- a/spec/services/cognito/create_user_from_cognito_spec.rb
+++ b/spec/services/cognito/create_user_from_cognito_spec.rb
@@ -32,120 +32,103 @@ RSpec.describe Cognito::CreateUserFromCognito do
 
     let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
 
+    let(:response) { described_class.call(username) }
+
+    before { allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client) }
+
     context 'when success' do
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:admin_get_user).and_return(cognito_user)
         allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
       end
 
       it 'creates user' do
-        expect { described_class.call(username) }.to change(User, :count).by 1
+        expect { response }.to change(User, :count).by 1
       end
 
       it 'returns the newly created resource' do
-        response = described_class.call(username)
         expect(response.user).to eq User.order(created_at: :asc).last
       end
 
       it 'returns the newly created resource with the right email' do
-        response = described_class.call(username)
         expect(response.user.email).to eq email
       end
 
       it 'returns the newly created resource with the right first name' do
-        response = described_class.call(username)
         expect(response.user.first_name).to eq name
       end
 
       it 'returns the newly created resource with the right last name' do
-        response = described_class.call(username)
         expect(response.user.last_name).to eq family_name
       end
 
       it 'returns the newly created resource with the right phone number' do
-        response = described_class.call(username)
         expect(response.user.phone_number).to eq phone_number
       end
 
       it 'returns the newly created resource with the buyer and st_access role' do
-        response = described_class.call(username)
         expect(response.user.has_role?(:buyer)).to be true
         expect(response.user.has_role?(:st_access)).to be true
       end
 
       it 'returns the newly created resource with no fm_access role' do
-        response = described_class.call(username)
         expect(response.user.has_role?(:fm_access)).to be false
       end
 
       it 'returns the newly created resource with no ls_access role' do
-        response = described_class.call(username)
         expect(response.user.has_role?(:ls_access)).to be false
       end
 
       it 'returns the newly created resource with no mc_access role' do
-        response = described_class.call(username)
         expect(response.user.has_role?(:mc_access)).to be false
       end
 
       it 'returns success' do
-        response = described_class.call(username)
         expect(response.success?).to be true
       end
 
       it 'returns no error' do
-        response = described_class.call(username)
         expect(response.error).to be_nil
       end
     end
 
     context 'when user already exists' do
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:admin_get_user).and_return(cognito_user)
         allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
         create(:user, :without_detail, cognito_uuid: '0987', email: email, roles: %i[buyer fm_access])
       end
 
       it 'does not create a new user' do
-        expect { described_class.call(username) }.not_to change(User, :count)
+        expect { response }.not_to change(User, :count)
       end
 
       it 'updates cognito_uuid' do
-        response = described_class.call(username)
         expect(response.user.cognito_uuid).to eq username
       end
 
       it 'updates roles' do
-        response = described_class.call(username)
         expect(response.user.has_role?(:st_access)).to be true
         expect(response.user.has_role?(:buyer)).to be true
       end
     end
 
     context 'when cognito error' do
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:admin_get_user).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops'))
-      end
+      before { allow(aws_client).to receive(:admin_get_user).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops')) }
 
       it 'does not create user' do
-        expect { described_class.call(username) }.not_to change(User, :count)
+        expect { response }.not_to change(User, :count)
       end
 
       it 'does not return user' do
-        response = described_class.call(username)
         expect(response.user).to be_nil
       end
 
       it 'does not return success' do
-        response = described_class.call(username)
         expect(response.success?).to be false
       end
 
       it 'returns an error' do
-        response = described_class.call(username)
         expect(response.error).to eq 'Oops'
       end
     end
@@ -161,7 +144,6 @@ RSpec.describe Cognito::CreateUserFromCognito do
       end
 
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:admin_get_user).and_return(cognito_user)
         allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
       end
@@ -173,7 +155,6 @@ RSpec.describe Cognito::CreateUserFromCognito do
         end
 
         it 'matches the right supplier detail to the user record' do
-          response = described_class.call(email)
           expect(response.user.supplier_detail.contact_email).to eq response.user.email
         end
       end
@@ -184,7 +165,6 @@ RSpec.describe Cognito::CreateUserFromCognito do
         end
 
         it 'leaves the supplier_detail blank' do
-          response = described_class.call(username)
           expect(response.user.supplier_detail).to be_nil
         end
       end

--- a/spec/services/cognito/forgot_password_spec.rb
+++ b/spec/services/cognito/forgot_password_spec.rb
@@ -2,19 +2,39 @@ require 'rails_helper'
 
 RSpec.describe Cognito::ForgotPassword do
   let(:email) { 'test@email.com' }
+  let(:email_upercase) { 'Test@Email.com' }
   let(:invalid_email_char) { '@!"£$£"' }
   let(:invalid_email) { 'someRandomString' }
   let(:aws_client) { instance_double(Aws::CognitoIdentityProvider::Client) }
 
   describe '#call' do
+    let(:response) { described_class.call(email) }
+
+    before { allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client) }
+
     context 'when success' do
       include_context 'with cognito structs'
 
-      let(:response) { described_class.call(email) }
+      before { allow(aws_client).to receive(:forgot_password).and_return(forgot_password_resp_struct.new('USER_ID_FOR_SRP' => email)) }
 
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:forgot_password).and_return(forgot_password_resp_struct.new('USER_ID_FOR_SRP' => email))
+      it 'returns success' do
+        expect(response.success?).to be true
+      end
+
+      it 'returns no error' do
+        expect(response.error).to be_nil
+      end
+    end
+
+    context 'when success with an upercase email' do
+      let(:email) { email_upercase }
+
+      include_context 'with cognito structs'
+
+      before { allow(aws_client).to receive(:forgot_password).and_return(forgot_password_resp_struct.new('USER_ID_FOR_SRP' => email)) }
+
+      it 'converts the email to lowercase' do
+        expect(response.email).to eq('test@email.com')
       end
 
       it 'returns success' do
@@ -27,67 +47,49 @@ RSpec.describe Cognito::ForgotPassword do
     end
 
     context 'when cognito error' do
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:forgot_password).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops'))
-      end
+      before { allow(aws_client).to receive(:forgot_password).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops')) }
 
       it 'does not return success' do
-        response = described_class.call(email)
         expect(response.success?).to be false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(email)
         expect(response.error).to eq 'Oops'
       end
     end
 
     context 'when cognito error is UserNotFoundException' do
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-        allow(aws_client).to receive(:forgot_password).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('oops', 'Oops'))
-      end
+      before { allow(aws_client).to receive(:forgot_password).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('oops', 'Oops')) }
 
       it 'does not return success' do
-        response = described_class.call(email)
         expect(response.success?).to be true
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(email)
         expect(response.error).to be_nil
       end
     end
 
     context 'when user enter invalid_email_char' do
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-      end
+      let(:email) { invalid_email_char }
 
       it 'does not return success' do
-        response = described_class.call(invalid_email_char)
         expect(response.success?).to be false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(invalid_email_char)
         expect(response.error).to eq 'Enter your email address in the correct format, like name@example.com'
       end
     end
 
     context 'when user enter invalid_email' do
-      before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-      end
+      let(:email) { invalid_email }
 
       it 'does not return success' do
-        response = described_class.call(invalid_email)
         expect(response.success?).to be false
       end
 
       it 'does returns cognito error' do
-        response = described_class.call(invalid_email)
         expect(response.error).to eq 'Enter your email address in the correct format, like name@example.com'
       end
     end

--- a/spec/services/cognito/sign_in_user_spec.rb
+++ b/spec/services/cognito/sign_in_user_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe Cognito::SignInUser do
 
     let(:sign_in_user) { described_class.new(email, password, cookies_disabled) }
 
-    before { allow(sign_in_user).to receive(:sleep) }
+    before do
+      allow(sign_in_user).to receive(:sleep)
+      allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
+    end
 
     context 'when success' do
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_return(initiate_auth_resp_struct.new(challenge_name: challenge_name, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => user_id_for_srp }))
         sign_in_user.call
       end
@@ -47,7 +49,6 @@ RSpec.describe Cognito::SignInUser do
 
     context 'when cognito error' do
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops'))
         sign_in_user.call
       end
@@ -63,7 +64,6 @@ RSpec.describe Cognito::SignInUser do
 
     context 'when user not confirmed' do
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotConfirmedException.new('oops', 'Oops'))
         sign_in_user.call
       end
@@ -83,7 +83,6 @@ RSpec.describe Cognito::SignInUser do
 
     context 'when password reset required' do
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_raise(Aws::CognitoIdentityProvider::Errors::PasswordResetRequiredException.new('oops', 'Oops'))
         sign_in_user.call
       end
@@ -103,7 +102,6 @@ RSpec.describe Cognito::SignInUser do
 
     context 'when Cogito error is UserNotFoundException' do
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_raise(Aws::CognitoIdentityProvider::Errors::UserNotFoundException.new('oops', 'Oops'))
         sign_in_user.call
       end
@@ -125,7 +123,6 @@ RSpec.describe Cognito::SignInUser do
       let(:cookies_disabled) { true }
 
       before do
-        allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:initiate_auth).and_return(initiate_auth_resp_struct.new(challenge_name: challenge_name, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => user_id_for_srp }))
         sign_in_user.call
       end


### PR DESCRIPTION
Ticket: [FMFR-1360](https://crowncommercialservice.atlassian.net/browse/FMFR-1360)

I have made sure that the email is lowercased for the forgot password and confirm sign up routes (where the user has to enter an email).
In addition, I have refactored all of the cognito service unit tests.

[FMFR-1360]: https://crowncommercialservice.atlassian.net/browse/FMFR-1360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ