### PR TITLE
FMFR-1358 - Freeze data when RM3830 has expired

### DIFF
--- a/app/controllers/facilities_management/admin/framework_controller.rb
+++ b/app/controllers/facilities_management/admin/framework_controller.rb
@@ -39,6 +39,10 @@ module FacilitiesManagement
       def service_scope
         :facilities_management
       end
+
+      def set_framework_has_expired
+        @framework_has_expired = Framework.find_by(framework: params[:framework]).status == :expired
+      end
     end
   end
 end

--- a/app/controllers/facilities_management/admin/supplier_details_controller.rb
+++ b/app/controllers/facilities_management/admin/supplier_details_controller.rb
@@ -1,6 +1,8 @@
 module FacilitiesManagement
   module Admin
     class SupplierDetailsController < FacilitiesManagement::Admin::FrameworkController
+      before_action :set_framework_has_expired
+      before_action :redirect_if_framework_has_expired, only: %i[edit update]
       before_action :set_data_for_framework
       before_action :set_supplier
       before_action :set_page, only: %i[edit update]
@@ -51,6 +53,10 @@ module FacilitiesManagement
 
       def supplier_params
         params.require(@suppliers_admin_param_key).permit(PERMITED_PARAMS[@page])
+      end
+
+      def redirect_if_framework_has_expired
+        redirect_to facilities_management_admin_supplier_detail_path if @framework_has_expired
       end
 
       PERMITED_PARAMS = {

--- a/app/controllers/facilities_management/rm3830/admin/service_rates_controller.rb
+++ b/app/controllers/facilities_management/rm3830/admin/service_rates_controller.rb
@@ -2,6 +2,8 @@ module FacilitiesManagement
   module RM3830
     module Admin
       class ServiceRatesController < FacilitiesManagement::Admin::FrameworkController
+        before_action :set_framework_has_expired
+        before_action :redirect_if_framework_has_expired, only: :update
         before_action :set_slug, :set_rate_type, :full_services, :set_variances, :initialise_errors
 
         def edit; end
@@ -73,6 +75,10 @@ module FacilitiesManagement
           end
 
           @variances.each { |_label, rate| rate.save if rate.changed? }
+        end
+
+        def redirect_if_framework_has_expired
+          redirect_to edit_facilities_management_rm3830_admin_service_rate_path if @framework_has_expired
         end
       end
     end

--- a/app/controllers/facilities_management/rm3830/admin/sublot_regions_controller.rb
+++ b/app/controllers/facilities_management/rm3830/admin/sublot_regions_controller.rb
@@ -2,6 +2,8 @@ module FacilitiesManagement
   module RM3830
     module Admin
       class SublotRegionsController < FacilitiesManagement::Admin::FrameworkController
+        before_action :set_framework_has_expired
+        before_action :redirect_if_framework_has_expired, only: :update
         before_action :set_supplier, :set_lot, :redirect_if_lot_out_of_range
         before_action :set_region_data, only: :edit
 
@@ -21,6 +23,10 @@ module FacilitiesManagement
           @sublot_region_name = "Sub-lot #{@lot} regions"
           @selected_supplier_regions = Supplier::SupplierRegionsHelper.supllier_selected_regions(supplier_lot_data)
           @subregions = FacilitiesManagement::Region.all.to_h { |region| [region.code, region.name] }
+        end
+
+        def redirect_if_framework_has_expired
+          redirect_to edit_facilities_management_rm3830_admin_supplier_framework_datum_sublot_region_path if @framework_has_expired
         end
       end
     end

--- a/app/controllers/facilities_management/rm3830/admin/sublot_services_controller.rb
+++ b/app/controllers/facilities_management/rm3830/admin/sublot_services_controller.rb
@@ -2,6 +2,8 @@ module FacilitiesManagement
   module RM3830
     module Admin
       class SublotServicesController < FacilitiesManagement::Admin::FrameworkController
+        before_action :set_framework_has_expired
+        before_action :redirect_if_framework_has_expired, only: :update
         before_action :set_supplier, :set_lot, :redirect_if_lot_out_of_range
         before_action :full_services
         before_action :set_service_data, only: :edit
@@ -85,6 +87,10 @@ module FacilitiesManagement
         def update_checkboxes
           @supplier.replace_services_for_lot(params[:checked_services], @lot)
           @supplier.save
+        end
+
+        def redirect_if_framework_has_expired
+          redirect_to edit_facilities_management_rm3830_admin_supplier_framework_datum_sublot_service_path if @framework_has_expired
         end
       end
     end

--- a/app/helpers/facilities_management/admin/framework_helper.rb
+++ b/app/helpers/facilities_management/admin/framework_helper.rb
@@ -4,4 +4,8 @@ module FacilitiesManagement::Admin::FrameworkHelper
 
     govuk_breadcrumbs(*breadcrumbs)
   end
+
+  def framework_expired_warning(text)
+    warning_text(text) if @framework_has_expired
+  end
 end

--- a/app/views/facilities_management/admin/supplier_details/show.html.erb
+++ b/app/views/facilities_management/admin/supplier_details/show.html.erb
@@ -5,6 +5,8 @@
 ) %>
 <%= govuk_page_header(FacilitiesManagement::PageDetail::Heading.new(t('.supplier_details'), @supplier.supplier_name, nil, nil, nil)) %>
 
+<%= framework_expired_warning(t("facilities_management.#{params[:framework].downcase}.admin.you_cannot_update.details")) %>
+
 <p class="govuk-body govuk-!-font-weight-regular govuk-hint">
   <%= t('.edit_supplier_details') %>
 </p>
@@ -24,9 +26,11 @@
           <dd class="govuk-summary-list__value">
             <%= supplier_user_email %>
           </dd>
-          <dd class="govuk-summary-list__actions">
-            <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :supplier_user), class: 'govuk-link--no-visited-state') %>
-          </dd>
+          <% unless @framework_has_expired %>
+            <dd class="govuk-summary-list__actions">
+              <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :supplier_user), class: 'govuk-link--no-visited-state') %>
+            </dd>
+          <% end %>
         </div>
       </dl>
     </div>
@@ -48,9 +52,11 @@
           <dd class="govuk-summary-list__value">
             <%= govuk_tag_with_text(*@supplier.current_status) %>
           </dd>
-          <dd class="govuk-summary-list__actions">
-            <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :supplier_status), class: 'govuk-link--no-visited-state') %>
-          </dd>
+          <% unless @framework_has_expired %>
+            <dd class="govuk-summary-list__actions">
+              <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :supplier_status), class: 'govuk-link--no-visited-state') %>
+            </dd>
+          <% end %>
         </div>
       </dl>
     </div>
@@ -71,9 +77,11 @@
           <dd class="govuk-summary-list__value">
             <%= contact_detail(:supplier_name) %>
           </dd>
-          <dd class="govuk-summary-list__actions">
-            <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :supplier_name), class: 'govuk-link--no-visited-state') %>
-          </dd>
+          <% unless @framework_has_expired %>
+            <dd class="govuk-summary-list__actions">
+              <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :supplier_name), class: 'govuk-link--no-visited-state') %>
+            </dd>
+          <% end %>
         </div>
       <% if params[:framework] == 'RM3830' %>
         <% %i[contact_name contact_email contact_phone].each do |attribute| %>
@@ -84,9 +92,11 @@
             <dd class="govuk-summary-list__value">
               <%= contact_detail(attribute) %>
             </dd>
-            <dd class="govuk-summary-list__actions">
-              <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :supplier_contact_information), class: 'govuk-link--no-visited-state') %>
-            </dd>
+            <% unless @framework_has_expired %>
+              <dd class="govuk-summary-list__actions">
+                <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :supplier_contact_information), class: 'govuk-link--no-visited-state') %>
+              </dd>
+            <% end %>
           </div>
         <% end %>
       <% end %>
@@ -109,9 +119,11 @@
           <dd class="govuk-summary-list__value">
             <%= contact_detail(attribute) %>
           </dd>
-          <dd class="govuk-summary-list__actions">
-            <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :additional_supplier_information), class: 'govuk-link--no-visited-state') %>
-          </dd>
+          <% unless @framework_has_expired %>
+            <dd class="govuk-summary-list__actions">
+              <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :additional_supplier_information), class: 'govuk-link--no-visited-state') %>
+            </dd>
+          <% end %>
         </div>
       <% end %>
       <div id="supplier-details--full_address"class="govuk-summary-list__row">
@@ -121,9 +133,11 @@
         <dd class="govuk-summary-list__value">
           <%= full_address %>
         </dd>
-        <dd class="govuk-summary-list__actions">
-          <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :supplier_address), class: 'govuk-link--no-visited-state') %>
-        </dd>
+        <% unless @framework_has_expired %>
+          <dd class="govuk-summary-list__actions">
+            <%= link_to(t('.change'), edit_facilities_management_admin_supplier_detail_path(@framework, @supplier, page: :supplier_address), class: 'govuk-link--no-visited-state') %>
+          </dd>
+        <% end %>
       </div>
     </dl>
   </div>

--- a/app/views/facilities_management/rm3830/admin/service_rates/_average-framework-rates.html.erb
+++ b/app/views/facilities_management/rm3830/admin/service_rates/_average-framework-rates.html.erb
@@ -1,6 +1,9 @@
 <h1 class="govuk-heading-xl">
   <%= t('.heading') %>
 </h1>
+
+<%= framework_expired_warning(t('facilities_management.rm3830.admin.you_cannot_update.rates')) %>
+
 <p class="govuk-body govuk-!-font-weight-regular govuk-hint">
   <%= t('.leading_text') %><br/>
   <%= t('.percentage_note') %>
@@ -36,7 +39,7 @@
           </td>
 
           <td class="govuk-table__cell supplier-rates-td">
-            <%= text_field_tag "rates[#{rate.id}]", rate.read_attribute_before_type_cast(:framework), class: "govuk-input govuk-input--width-3 #{'govuk-input--error' if rate_invalid }" %>
+            <%= text_field_tag "rates[#{rate.id}]", rate.read_attribute_before_type_cast(:framework), class: "govuk-input govuk-input--width-3 #{'govuk-input--error' if rate_invalid }", disabled: @framework_has_expired %>
           </td>
         </tr>
       <% end %>

--- a/app/views/facilities_management/rm3830/admin/service_rates/_call-off-benchmark-rates.html.erb
+++ b/app/views/facilities_management/rm3830/admin/service_rates/_call-off-benchmark-rates.html.erb
@@ -1,4 +1,7 @@
 <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
+
+<%= framework_expired_warning(t('facilities_management.rm3830.admin.you_cannot_update.rates')) %>
+
 <p class="govuk-body govuk-!-font-weight-regular govuk-hint">
   <%= t('.leading_text') %><br/>
   <%= t('.percentage_note') %>
@@ -49,7 +52,7 @@
             <td class="govuk-table__cell supplier-rates-td">
               <% rate = work_pckg['rates'].find(&selector) %>
               <% if rate %>
-                <%= text_field_tag "rates[#{rate.id}]", rate.read_attribute_before_type_cast(:benchmark), class: "govuk-input govuk-input--width-3 #{'govuk-input--error' if rate.errors.any?}", 'aria-label': "#{work_pckg['name']} #{rate.standard.blank? ? 'normal price' : "standard #{rate.standard}"}"  %>
+                <%= text_field_tag "rates[#{rate.id}]", rate.read_attribute_before_type_cast(:benchmark), class: "govuk-input govuk-input--width-3 #{'govuk-input--error' if rate.errors.any?}", 'aria-label': "#{work_pckg['name']} #{rate.standard.blank? ? 'normal price' : "standard #{rate.standard}"}", disabled: @framework_has_expired  %>
               <% end %>
             </td>
           <% end %>

--- a/app/views/facilities_management/rm3830/admin/service_rates/_variance_table.html.erb
+++ b/app/views/facilities_management/rm3830/admin/service_rates/_variance_table.html.erb
@@ -22,7 +22,7 @@
           </div>
         </td>
         <td class="govuk-table__cell supplier-rates-td">
-          <%= text_field_tag "rates[#{rate.id}]", rate.read_attribute_before_type_cast(attribue), class: "govuk-input govuk-input--width-3 #{'govuk-input--error' if rate_invalid }" %>
+          <%= text_field_tag "rates[#{rate.id}]", rate.read_attribute_before_type_cast(attribue), class: "govuk-input govuk-input--width-3 #{'govuk-input--error' if rate_invalid }", disabled: @framework_has_expired %>
         </td>
       </tr>
     <% end %>

--- a/app/views/facilities_management/rm3830/admin/service_rates/edit.html.erb
+++ b/app/views/facilities_management/rm3830/admin/service_rates/edit.html.erb
@@ -5,6 +5,6 @@
 
 <%= form_with url: facilities_management_rm3830_admin_service_rate_path(slug: @slug), method: :put, html: { specialvalidation: true, novalidate: true }, local: 'false' do |f| %>
   <%= render partial: @slug, locals: { f: f } %>
-  <%= f.submit t('.update_button'), class: 'govuk-button', name: 'update_benchmark_rates', aria: { label: t('.update_button') } %>
+  <%= f.submit t('.update_button'), class: 'govuk-button', name: 'update_benchmark_rates', aria: { label: t('.update_button') }, disabled: @framework_has_expired %>
   <%= link_to t('.return_link'), facilities_management_rm3830_admin_path, class: 'govuk-link govuk-caption-m'%>
 <% end %>

--- a/app/views/facilities_management/rm3830/admin/sublot_regions/edit.html.erb
+++ b/app/views/facilities_management/rm3830/admin/sublot_regions/edit.html.erb
@@ -6,6 +6,7 @@
 
 <h2 class="govuk-caption-l govuk-!-margin-bottom-2 govuk-!-font-weight-regular"><%= @supplier.supplier_name %></h1>
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-2"><%= @sublot_region_name %></h2>
+<%= framework_expired_warning(t('facilities_management.rm3830.admin.you_cannot_update.regions')) %>
 <p class="govuk-body govuk-!-font-weight-regular govuk-hint"><%= t('.leading_text') %></p>
 
 <%= form_with url: facilities_management_rm3830_admin_supplier_framework_datum_sublot_region_path, method: 'put', local: 'false', html: { specialvalidation: true }  do |f| %>
@@ -25,7 +26,8 @@
                           key2,
                           @selected_supplier_regions[key2],
                           class: "govuk-checkboxes__input",
-                          id: "#{key2}"
+                          id: "#{key2}",
+                          disabled: @framework_has_expired
                       ) %>
                   <label id="<%= key2 %>_label" class="govuk-label govuk-checkboxes__label" for="<%= key2 %>">
                     <%= value2 %>
@@ -39,6 +41,6 @@
     </fieldset>
   <% end %>
 
-  <%= f.submit t('.update_button'), class: 'govuk-button', name: 'update_supplier_regions', aria: { label: t('.update_button') }%>
+  <%= f.submit t('.update_button'), class: 'govuk-button', name: 'update_supplier_regions', aria: { label: t('.update_button') }, disabled: @framework_has_expired%>
 <% end %>
 <%= link_to t('.return_link'), facilities_management_rm3830_admin_supplier_framework_data_path, class: 'govuk-link govuk-caption-m' %>

--- a/app/views/facilities_management/rm3830/admin/sublot_services/_services.html.erb
+++ b/app/views/facilities_management/rm3830/admin/sublot_services/_services.html.erb
@@ -8,6 +8,7 @@
   <span class="govuk-caption-l"><%= @supplier.supplier_name %></span>
 </div>
 <h1 class="govuk-heading-xl"><%= @lot_name %></h1>
+<%= framework_expired_warning(t('facilities_management.rm3830.admin.you_cannot_update.services')) %>
 <p class="govuk-body govuk-!-font-weight-regular govuk-hint">
   <%= t('.note') %>
 </p>
@@ -35,7 +36,8 @@
                         work_pckg['code'],
                         @supplier_rate_data_checkboxes[work_pckg['code']],
                         class: "govuk-checkboxes__input",
-                        id: "rates_#{work_pckg['code']}"
+                        id: "rates_#{work_pckg['code']}",
+                        disabled: @framework_has_expired
                     ) %>
                 <label class="govuk-label govuk-checkboxes__label" for="rates_<%=work_pckg['code'] %>">
 
@@ -49,6 +51,6 @@
       </table>
     </fieldset>
   <% end %>
-  <%= f.submit t('.update_button'), class: 'govuk-button', name: 'update_benchmark_rates', aria: { label:  t('.update_button') }%>
+  <%= f.submit t('.update_button'), class: 'govuk-button', name: 'update_benchmark_rates', aria: { label:  t('.update_button') }, disabled: @framework_has_expired %>
   <%= link_to t('.return_button'), facilities_management_rm3830_admin_supplier_framework_data_path, class: 'govuk-link govuk-caption-m' %>
 <% end %>

--- a/app/views/facilities_management/rm3830/admin/sublot_services/_services_prices_and_variances.html.erb
+++ b/app/views/facilities_management/rm3830/admin/sublot_services/_services_prices_and_variances.html.erb
@@ -25,7 +25,8 @@
   </div>
 </div>
 <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
-<h2 class="govuk-heading-l govuk-!-font-weight-bold "><%= t('.services_and_prices') %></h1>
+<h2 class="govuk-heading-l govuk-!-font-weight-bold "><%= t('.services_and_prices') %></h2>
+<%= framework_expired_warning(t('facilities_management.rm3830.admin.you_cannot_update.services')) %>
 
 <p class="govuk-body govuk-!-font-weight-regular govuk-hint">
   <%= t('.note') %><br/>
@@ -61,7 +62,8 @@
                         @supplier_rate_data_checkboxes[work_pckg['code']],
                         class: "govuk-checkboxes__input",
                         id: "rates_#{work_pckg['code']}",
-                        'aria-label': "#{work_pckg['name']} checkbox"
+                        'aria-label': "#{work_pckg['name']} checkbox",
+                        disabled: @framework_has_expired
                     ) %>
 
                 <%= label_tag "rates_#{work_pckg['code']}", "#{work_pckg['code']} #{work_pckg['name']}", id: "#{work_pckg['code']}_label", class: 'govuk-label govuk-checkboxes__label' %>
@@ -78,7 +80,7 @@
                   <% input_value = determine_rate_card_service_price_text(service_type, work_pckg['code'], @supplier_data_ratecard_prices, @supplier_data_ratecard_discounts) %>
                   <% class_list = 'govuk-input govuk-input--width-3' %>
                 <% end %>
-                <%= text_field_tag "data[#{work_pckg['code']}][#{service_type}]", input_value, class: class_list, aria: { label: work_pckg['name'] } %>
+                <%= text_field_tag "data[#{work_pckg['code']}][#{service_type}]", input_value, class: class_list, aria: { label: work_pckg['name'] }, disabled: @framework_has_expired %>
               </td>
             <% end %>
           </tr>
@@ -117,14 +119,14 @@
           <% input_value = @variance_supplier_data[variance_values[i].to_sym] %>
           <% class_list = 'govuk-input govuk-input--width-3' %>
         <% end %>
-        <%= text_field_tag "rate[#{variance}]", input_value, class: class_list %>
+        <%= text_field_tag "rate[#{variance}]", input_value, class: class_list, disabled: @framework_has_expired %>
       </td>
     </tr>
     <% end %>
     </tbody>
   </table>
 
-  <%= f.submit t('.update_button'), class: 'govuk-button', name: 'update_sublot_data_services_prices', aria: { label: 'update_sublot_data_services_prices' } %><br/>
+  <%= f.submit t('.update_button'), class: 'govuk-button', name: 'update_sublot_data_services_prices', aria: { label: 'update_sublot_data_services_prices' }, disabled: @framework_has_expired %><br/>
   <%= link_to t('.return_link'), facilities_management_rm3830_admin_supplier_framework_data_path, class: 'govuk-link govuk-!-font-size-19' %>
   <% end %>
 </div>

--- a/config/locales/views/facilities_management.rm3830.en.yml
+++ b/config/locales/views/facilities_management.rm3830.en.yml
@@ -576,6 +576,11 @@ en:
             supplier_framework_data: Supplier framework data
           upload:
             upload_name: 'Upload session #%{number}'
+        you_cannot_update:
+          details: The RM3830 has expired, you cannot update the supplier's details.
+          rates: The RM3830 has expired, you cannot update these rates.
+          regions: The RM3830 has expired, you cannot update the supplier's regions.
+          services: The RM3830 has expired, you cannot update the supplier's services.
       buyer_account:
         index:
           buyer_account_dashboard: Buyer account dashboard

--- a/config/locales/views/facilities_management.rm6232.en.yml
+++ b/config/locales/views/facilities_management.rm6232.en.yml
@@ -415,6 +415,8 @@ en:
             uploaded_by: 'Uploaded by:'
           upload:
             upload_name: 'Upload session #%{number}'
+        you_cannot_update:
+          details: The RM6232 has expired, you cannot update the supplier's details.
       buyer_account:
         index:
           buyer_account_dashboard: Buyer account dashboard

--- a/features/facilities_management/rm3830/admin/assessed_value/service_rates_framework_expired.feature
+++ b/features/facilities_management/rm3830/admin/assessed_value/service_rates_framework_expired.feature
@@ -1,0 +1,16 @@
+Feature: Service rates - Framework expired
+
+  Scenario Outline: The framework rates page inputs are disabled
+    Given the 'RM3830' framework has expired
+    And I sign in as an admin and navigate to the 'RM3830' dashboard
+    And I click on '<rates_page>'
+    Then I am on the '<rates_page>' page
+    And I should see the following warning text:
+      | The RM3830 has expired, you cannot update these rates. |
+    And all the text inputs are disabled
+    And the submit button is disabled
+  
+  Examples:
+    | rates_page                |
+    | Average framework rates   |
+    | Call-off benchmark rates  |

--- a/features/facilities_management/rm3830/admin/supplier_data/supplier_details/supplier_details_framework_expired.feature
+++ b/features/facilities_management/rm3830/admin/supplier_data/supplier_details/supplier_details_framework_expired.feature
@@ -1,0 +1,12 @@
+Feature: Supplier details - Framework expired
+
+  Scenario: I cannot change the supplier details
+    Given the 'RM3830' framework has expired
+    And I sign in as an admin and navigate to the 'RM3830' dashboard
+    And I click on 'Supplier details'
+    Then I am on the 'Supplier details' page
+    And I click on 'Ullrich, Ratke and Botsford'
+    Then I am on the 'Supplier details' page
+    And I should see the following warning text:
+      | The RM3830 has expired, you cannot update the supplier's details. |
+    And I cannot change the supplier details

--- a/features/facilities_management/rm3830/admin/supplier_data/supplier_framework_data/supplier_framework_data_framework_expired.feature
+++ b/features/facilities_management/rm3830/admin/supplier_data/supplier_framework_data/supplier_framework_data_framework_expired.feature
@@ -1,0 +1,37 @@
+Feature: Supplier framework data - Framework expired
+
+  Background: Navigate to the services and prices page
+    Given the 'RM3830' framework has expired
+    And I sign in as an admin and navigate to the 'RM3830' dashboard
+    And I click on 'Supplier framework data'
+    Then I am on the 'Supplier framework data' page
+    Given I show all sections
+
+  Scenario Outline: Supplier service data inputs are disabled
+    And select 'Services' for sublot '<lot>' for '<supplier>'
+    Then I am on the '<page>' page
+    And I should see the following warning text:
+      | The RM3830 has expired, you cannot update the supplier's services. |
+    And all the text inputs are disabled
+    And all the checkbox inputs are disabled
+    And the submit button is disabled
+
+    Examples:
+      | lot | supplier            | page                                        |
+      | 1a  | Cartwright and Sons | Sub-lot 1a services, prices, and variances  |
+      | 1b  | Graham-Farrell      | Sub-lot 1b services                         |
+      | 1c  | Smitham-Brown       | Sub-lot 1c services                         |
+  
+  Scenario Outline: Supplier region data inputs are disabled
+    And select 'Regions' for sublot '<lot>' for '<supplier>'
+    Then I am on the 'Sub-lot <lot> regions' page
+    And I should see the following warning text:
+      | The RM3830 has expired, you cannot update the supplier's regions. |
+    And all the checkbox inputs are disabled
+    And the submit button is disabled
+
+    Examples:
+      | lot | supplier            |
+      | 1a  | Cartwright and Sons |
+      | 1b  | Graham-Farrell      |
+      | 1c  | Smitham-Brown       |

--- a/features/facilities_management/rm6232/admin/supplier_data/supplier_details/supplier_details_framework_expired.feature
+++ b/features/facilities_management/rm6232/admin/supplier_data/supplier_details/supplier_details_framework_expired.feature
@@ -1,0 +1,13 @@
+Feature: Supplier details - Framework expired
+
+  Scenario: I cannot change the supplier details
+    Given the 'RM6232' framework has expired
+    And I sign in as an admin and navigate to the 'RM6232' dashboard
+    And I click on 'Supplier data'
+    Then I am on the 'Supplier data' page
+    Then I click on 'View details' for 'Zboncak and Sons'
+    And I am on the 'Supplier details' page
+    And the supplier name on the details page is 'Zboncak and Sons'
+    And I should see the following warning text:
+      | The RM6232 has expired, you cannot update the supplier's details. |
+    And I cannot change the supplier details

--- a/features/step_definitions/facilities_management/rm3830/framework_status_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/framework_status_steps.rb
@@ -1,0 +1,23 @@
+Given('the {string} framework has expired') do |framework|
+  Framework.find_by(framework: framework).update(expires_at: 1.day.ago)
+end
+
+Then('I should see the following warning text:') do |warning_text_table|
+  expect(page.find('strong.govuk-warning-text__text')).to have_content("Warning#{warning_text_table.raw.flatten.first}")
+end
+
+Then('all the text inputs are disabled') do
+  expect(page.all('input[type="text"]')).to be_all(&:disabled?)
+end
+
+Given('all the checkbox inputs are disabled') do
+  expect(page.all('input[type="checkbox"]')).to be_all(&:disabled?)
+end
+
+Then('the submit button is disabled') do
+  expect(page.find('input[type="submit"]')).to be_disabled
+end
+
+Then('I cannot change the supplier details') do
+  expect(page).not_to have_css('dd.govuk-summary-list__actions')
+end

--- a/features/support/pages/admin.rb
+++ b/features/support/pages/admin.rb
@@ -6,7 +6,7 @@ module Pages
 
   class Admin < SitePrism::Page
     section :supplier_details, '#main-content' do
-      element :supplier_name_title, 'span'
+      element :supplier_name_title, '#main_title > span'
 
       section :'Current user', SupplierDetailsSection, '#supplier-details--supplier_user'
       section :'Supplier status', SupplierDetailsSection, '#supplier-details--supplier_status'

--- a/spec/controllers/facilities_management/admin/supplier_details_controller_rm3830_spec.rb
+++ b/spec/controllers/facilities_management/admin/supplier_details_controller_rm3830_spec.rb
@@ -49,116 +49,164 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController do
 
     login_fm_admin
 
-    render_views
+    context 'when the framework is live' do
+      render_views
 
-    before { get :edit, params: { id: supplier_id, page: page } }
+      before { get :edit, params: { id: supplier_id, page: page } }
 
-    context 'when the supplier does not exist' do
-      let(:supplier_id) { 'not-real-id' }
-      let(:page) { :supplier_user }
+      context 'when the supplier does not exist' do
+        let(:supplier_id) { 'not-real-id' }
+        let(:page) { :supplier_user }
 
-      it 'redirects to the supplier details' do
-        expect(response).to redirect_to facilities_management_rm3830_admin_supplier_details_path
+        it 'redirects to the supplier details' do
+          expect(response).to redirect_to facilities_management_rm3830_admin_supplier_details_path
+        end
+      end
+
+      context 'when on the supplier user page' do
+        let(:page) { :supplier_user }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the correct partial' do
+          expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_user')
+        end
+
+        it 'sets the supplier' do
+          expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+        end
+
+        it 'sets the page' do
+          expect(assigns(:page)).to eq page
+        end
+      end
+
+      context 'when on the supplier name page' do
+        let(:page) { :supplier_name }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the correct partial' do
+          expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_name')
+        end
+
+        it 'sets the supplier' do
+          expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+        end
+
+        it 'sets the page' do
+          expect(assigns(:page)).to eq page
+        end
+      end
+
+      context 'when on the supplier contact information page' do
+        let(:page) { :supplier_contact_information }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the correct partial' do
+          expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_contact_information')
+        end
+
+        it 'sets the supplier' do
+          expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+        end
+
+        it 'sets the page' do
+          expect(assigns(:page)).to eq page
+        end
+      end
+
+      context 'when on the additional supplier information page' do
+        let(:page) { :additional_supplier_information }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the correct partial' do
+          expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_additional_supplier_information')
+        end
+
+        it 'sets the supplier' do
+          expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+        end
+
+        it 'sets the page' do
+          expect(assigns(:page)).to eq page
+        end
+      end
+
+      context 'when on the supplier address page' do
+        let(:page) { :supplier_address }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the correct partial' do
+          expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_address')
+        end
+
+        it 'sets the supplier' do
+          expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+        end
+
+        it 'sets the page' do
+          expect(assigns(:page)).to eq page
+        end
       end
     end
 
-    context 'when on the supplier user page' do
-      let(:page) { :supplier_user }
+    context 'when the framework has expired' do
+      include_context 'and RM3830 has expired'
 
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
+      before { get :edit, params: { id: supplier_id, page: page } }
+
+      context 'when on the supplier user page' do
+        let(:page) { :supplier_user }
+
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
+        end
       end
 
-      it 'renders the correct partial' do
-        expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_user')
+      context 'when on the supplier name page' do
+        let(:page) { :supplier_name }
+
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
+        end
       end
 
-      it 'sets the supplier' do
-        expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+      context 'when on the supplier contact information page' do
+        let(:page) { :supplier_contact_information }
+
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
+        end
       end
 
-      it 'sets the page' do
-        expect(assigns(:page)).to eq page
-      end
-    end
+      context 'when on the additional supplier information page' do
+        let(:page) { :additional_supplier_information }
 
-    context 'when on the supplier name page' do
-      let(:page) { :supplier_name }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
+        end
       end
 
-      it 'renders the correct partial' do
-        expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_name')
-      end
+      context 'when on the supplier address page' do
+        let(:page) { :supplier_address }
 
-      it 'sets the supplier' do
-        expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
-      end
-
-      it 'sets the page' do
-        expect(assigns(:page)).to eq page
-      end
-    end
-
-    context 'when on the supplier contact information page' do
-      let(:page) { :supplier_contact_information }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
-      end
-
-      it 'renders the correct partial' do
-        expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_contact_information')
-      end
-
-      it 'sets the supplier' do
-        expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
-      end
-
-      it 'sets the page' do
-        expect(assigns(:page)).to eq page
-      end
-    end
-
-    context 'when on the additional supplier information page' do
-      let(:page) { :additional_supplier_information }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
-      end
-
-      it 'renders the correct partial' do
-        expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_additional_supplier_information')
-      end
-
-      it 'sets the supplier' do
-        expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
-      end
-
-      it 'sets the page' do
-        expect(assigns(:page)).to eq page
-      end
-    end
-
-    context 'when on the supplier address page' do
-      let(:page) { :supplier_address }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
-      end
-
-      it 'renders the correct partial' do
-        expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_address')
-      end
-
-      it 'sets the supplier' do
-        expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
-      end
-
-      it 'sets the page' do
-        expect(assigns(:page)).to eq page
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
+        end
       end
     end
   end
@@ -166,107 +214,157 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController do
   describe 'PUT update' do
     login_fm_admin
 
-    before { put :update, params: { id: supplier.supplier_id, page: page, facilities_management_rm3830_admin_suppliers_admin: supplier_params } }
+    # rubocop:disable RSpec/NestedGroups
+    context 'when the framework is live' do
+      before { put :update, params: { id: supplier.supplier_id, page: page, facilities_management_rm3830_admin_suppliers_admin: supplier_params } }
 
-    context 'when updating on the supplier name page' do
-      let(:page) { :supplier_name }
-      let(:supplier_params) { { supplier_name: supplier_name } }
+      context 'when updating on the supplier name page' do
+        let(:page) { :supplier_name }
+        let(:supplier_params) { { supplier_name: supplier_name } }
 
-      context 'and the data is not valid' do
-        let(:supplier_name) { '' }
+        context 'and the data is not valid' do
+          let(:supplier_name) { '' }
 
-        it 'renders the edit page' do
-          expect(response).to render_template :edit
+          it 'renders the edit page' do
+            expect(response).to render_template :edit
+          end
+        end
+
+        context 'and the data is valid' do
+          let(:supplier_name) { 'Pollyanna' }
+
+          it 'redirects to the show page' do
+            expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
+          end
         end
       end
 
-      context 'and the data is valid' do
-        let(:supplier_name) { 'Pollyanna' }
+      context 'when updating on the supplier contact information page' do
+        let(:page) { :supplier_contact_information }
+        let(:supplier_params) { { contact_name: contact_name, contact_email: 'fake@email.com', contact_phone: '(03456) 867 431' } }
+
+        context 'and the data is not valid' do
+          let(:contact_name) { '' }
+
+          it 'renders the edit page' do
+            expect(response).to render_template :edit
+          end
+        end
+
+        context 'and the data is valid' do
+          let(:contact_name) { 'Ness' }
+
+          it 'redirects to the show page' do
+            expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
+          end
+        end
+      end
+
+      context 'when updating on the additional supplier information page' do
+        let(:page) { :additional_supplier_information }
+        let(:supplier_params) { { duns: duns, registration_number: 'AB123456' } }
+
+        context 'and the data is not valid' do
+          let(:duns) { '0123456789' }
+
+          it 'renders the edit page' do
+            expect(response).to render_template :edit
+          end
+        end
+
+        context 'and the data is valid' do
+          let(:duns) { '123456789' }
+
+          it 'redirects to the show page' do
+            expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
+          end
+        end
+      end
+
+      context 'when updating on the supplier address page' do
+        let(:page) { :supplier_address }
+        let(:supplier_params) { { address_line_1: '3 Avery Way', address_line_2: '', address_town: 'Eastliegh', address_county: 'Anglesux', address_postcode: address_postcode } }
+
+        context 'and the data is not valid' do
+          let(:address_postcode) { 'AAA111' }
+
+          it 'renders the edit page' do
+            expect(response).to render_template :edit
+          end
+        end
+
+        context 'and the data is valid' do
+          let(:address_postcode) { 'AA1 1AA' }
+
+          it 'redirects to the show page' do
+            expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
+          end
+        end
+      end
+
+      context 'when updating on the supplier user page' do
+        let(:user) { create(:user, roles: :supplier) }
+        let(:page) { :supplier_user }
+        let(:supplier_params) { { user_email: user_email } }
+
+        context 'and the data is not valid' do
+          let(:user_email) { 'AAA111' }
+
+          it 'renders the edit page' do
+            expect(response).to render_template :edit
+          end
+        end
+
+        context 'and the data is valid' do
+          let(:user_email) { user.email }
+
+          it 'redirects to the show page' do
+            expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
+          end
+        end
+      end
+    end
+    # rubocop:enable RSpec/NestedGroups
+
+    context 'when the framework has expired' do
+      include_context 'and RM3830 has expired'
+
+      before { put :update, params: { id: supplier.supplier_id, page: page } }
+
+      context 'when updating on the supplier name page' do
+        let(:page) { :supplier_name }
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
         end
       end
-    end
 
-    context 'when updating on the supplier contact information page' do
-      let(:page) { :supplier_contact_information }
-      let(:supplier_params) { { contact_name: contact_name, contact_email: 'fake@email.com', contact_phone: '(03456) 867 431' } }
-
-      context 'and the data is not valid' do
-        let(:contact_name) { '' }
-
-        it 'renders the edit page' do
-          expect(response).to render_template :edit
-        end
-      end
-
-      context 'and the data is valid' do
-        let(:contact_name) { 'Ness' }
+      context 'when updating on the supplier contact information page' do
+        let(:page) { :supplier_contact_information }
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
         end
       end
-    end
 
-    context 'when updating on the additional supplier information page' do
-      let(:page) { :additional_supplier_information }
-      let(:supplier_params) { { duns: duns, registration_number: 'AB123456' } }
-
-      context 'and the data is not valid' do
-        let(:duns) { '0123456789' }
-
-        it 'renders the edit page' do
-          expect(response).to render_template :edit
-        end
-      end
-
-      context 'and the data is valid' do
-        let(:duns) { '123456789' }
+      context 'when updating on the additional supplier information page' do
+        let(:page) { :additional_supplier_information }
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
         end
       end
-    end
 
-    context 'when updating on the supplier address page' do
-      let(:page) { :supplier_address }
-      let(:supplier_params) { { address_line_1: '3 Avery Way', address_line_2: '', address_town: 'Eastliegh', address_county: 'Anglesux', address_postcode: address_postcode } }
-
-      context 'and the data is not valid' do
-        let(:address_postcode) { 'AAA111' }
-
-        it 'renders the edit page' do
-          expect(response).to render_template :edit
-        end
-      end
-
-      context 'and the data is valid' do
-        let(:address_postcode) { 'AA1 1AA' }
+      context 'when updating on the supplier address page' do
+        let(:page) { :supplier_address }
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')
         end
       end
-    end
 
-    context 'when updating on the supplier user page' do
-      let(:user) { create(:user, roles: :supplier) }
-      let(:page) { :supplier_user }
-      let(:supplier_params) { { user_email: user_email } }
-
-      context 'and the data is not valid' do
-        let(:user_email) { 'AAA111' }
-
-        it 'renders the edit page' do
-          expect(response).to render_template :edit
-        end
-      end
-
-      context 'and the data is valid' do
-        let(:user_email) { user.email }
+      context 'when updating on the supplier user page' do
+        let(:page) { :supplier_user }
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM3830')

--- a/spec/controllers/facilities_management/admin/supplier_details_controller_rm6232_spec.rb
+++ b/spec/controllers/facilities_management/admin/supplier_details_controller_rm6232_spec.rb
@@ -49,116 +49,164 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController do
 
     login_fm_admin
 
-    render_views
+    context 'when the framework is live' do
+      render_views
 
-    before { get :edit, params: { id: supplier_id, page: page } }
+      before { get :edit, params: { id: supplier_id, page: page } }
 
-    context 'when the supplier does not exist' do
-      let(:supplier_id) { 'not-real-id' }
-      let(:page) { :supplier_name }
+      context 'when the supplier does not exist' do
+        let(:supplier_id) { 'not-real-id' }
+        let(:page) { :supplier_name }
 
-      it 'redirects to the supplier data' do
-        expect(response).to redirect_to facilities_management_rm6232_admin_supplier_data_path
+        it 'redirects to the supplier data' do
+          expect(response).to redirect_to facilities_management_rm6232_admin_supplier_data_path
+        end
+      end
+
+      context 'when on the supplier name page' do
+        let(:page) { :supplier_name }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the correct partial' do
+          expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_name')
+        end
+
+        it 'sets the supplier' do
+          expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+        end
+
+        it 'sets the page' do
+          expect(assigns(:page)).to eq page
+        end
+      end
+
+      context 'when on the supplier contact information page' do
+        let(:page) { :supplier_contact_information }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the correct partial' do
+          expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_contact_information')
+        end
+
+        it 'sets the supplier' do
+          expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+        end
+
+        it 'sets the page' do
+          expect(assigns(:page)).to eq page
+        end
+      end
+
+      context 'when on the additional supplier information page' do
+        let(:page) { :additional_supplier_information }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the correct partial' do
+          expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_additional_supplier_information')
+        end
+
+        it 'sets the supplier' do
+          expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+        end
+
+        it 'sets the page' do
+          expect(assigns(:page)).to eq page
+        end
+      end
+
+      context 'when on the supplier address page' do
+        let(:page) { :supplier_address }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the correct partial' do
+          expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_address')
+        end
+
+        it 'sets the supplier' do
+          expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+        end
+
+        it 'sets the page' do
+          expect(assigns(:page)).to eq page
+        end
+      end
+
+      context 'when on the supplier status page' do
+        let(:page) { :supplier_status }
+
+        it 'renders the edit page' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'renders the correct partial' do
+          expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_status')
+        end
+
+        it 'sets the supplier' do
+          expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+        end
+
+        it 'sets the page' do
+          expect(assigns(:page)).to eq page
+        end
       end
     end
 
-    context 'when on the supplier name page' do
-      let(:page) { :supplier_name }
+    context 'when the framework has expired' do
+      include_context 'and RM6232 has expired'
 
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
+      before { get :edit, params: { id: supplier_id, page: page } }
+
+      context 'when on the supplier name page' do
+        let(:page) { :supplier_name }
+
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+        end
       end
 
-      it 'renders the correct partial' do
-        expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_name')
+      context 'when on the supplier contact information page' do
+        let(:page) { :supplier_contact_information }
+
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+        end
       end
 
-      it 'sets the supplier' do
-        expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
+      context 'when on the additional supplier information page' do
+        let(:page) { :additional_supplier_information }
+
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+        end
       end
 
-      it 'sets the page' do
-        expect(assigns(:page)).to eq page
-      end
-    end
+      context 'when on the supplier address page' do
+        let(:page) { :supplier_address }
 
-    context 'when on the supplier contact information page' do
-      let(:page) { :supplier_contact_information }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+        end
       end
 
-      it 'renders the correct partial' do
-        expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_contact_information')
-      end
+      context 'when on the supplier status page' do
+        let(:page) { :supplier_status }
 
-      it 'sets the supplier' do
-        expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
-      end
-
-      it 'sets the page' do
-        expect(assigns(:page)).to eq page
-      end
-    end
-
-    context 'when on the additional supplier information page' do
-      let(:page) { :additional_supplier_information }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
-      end
-
-      it 'renders the correct partial' do
-        expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_additional_supplier_information')
-      end
-
-      it 'sets the supplier' do
-        expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
-      end
-
-      it 'sets the page' do
-        expect(assigns(:page)).to eq page
-      end
-    end
-
-    context 'when on the supplier address page' do
-      let(:page) { :supplier_address }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
-      end
-
-      it 'renders the correct partial' do
-        expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_address')
-      end
-
-      it 'sets the supplier' do
-        expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
-      end
-
-      it 'sets the page' do
-        expect(assigns(:page)).to eq page
-      end
-    end
-
-    context 'when on the supplier status page' do
-      let(:page) { :supplier_status }
-
-      it 'renders the edit page' do
-        expect(response).to render_template(:edit)
-      end
-
-      it 'renders the correct partial' do
-        expect(response).to render_template(partial: 'facilities_management/admin/supplier_details/_supplier_status')
-      end
-
-      it 'sets the supplier' do
-        expect(assigns(:supplier).supplier_name).to eq supplier.supplier_name
-      end
-
-      it 'sets the page' do
-        expect(assigns(:page)).to eq page
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+        end
       end
     end
   end
@@ -166,108 +214,158 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController do
   describe 'PUT update' do
     login_fm_admin
 
-    before do
-      allow(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to receive(:log_change)
-      allow(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to receive(:log_change).with(controller.current_user, supplier)
-      put :update, params: { id: supplier.id, page: page, facilities_management_rm6232_admin_suppliers_admin: supplier_params }
-    end
+    # rubocop:disable RSpec/NestedGroups
+    context 'when the framework is live' do
+      before do
+        allow(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to receive(:log_change)
+        allow(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to receive(:log_change).with(controller.current_user, supplier)
+        put :update, params: { id: supplier.id, page: page, facilities_management_rm6232_admin_suppliers_admin: supplier_params }
+      end
 
-    context 'when updating on the supplier name page' do
-      let(:page) { :supplier_name }
-      let(:supplier_params) { { supplier_name: supplier_name } }
+      context 'when updating on the supplier name page' do
+        let(:page) { :supplier_name }
+        let(:supplier_params) { { supplier_name: supplier_name } }
 
-      context 'and the data is not valid' do
-        let(:supplier_name) { '' }
+        context 'and the data is not valid' do
+          let(:supplier_name) { '' }
 
-        it 'renders the edit page' do
-          expect(response).to render_template :edit
+          it 'renders the edit page' do
+            expect(response).to render_template :edit
+          end
+        end
+
+        context 'and the data is valid' do
+          let(:supplier_name) { 'Pollyanna' }
+
+          it 'redirects to the show page' do
+            expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+          end
+
+          it 'adds a log to the database' do
+            expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
+          end
         end
       end
 
-      context 'and the data is valid' do
-        let(:supplier_name) { 'Pollyanna' }
+      context 'when updating on the additional supplier information page' do
+        let(:page) { :additional_supplier_information }
+        let(:supplier_params) { { duns: duns, registration_number: 'AB123456' } }
+
+        context 'and the data is not valid' do
+          let(:duns) { '0123456789' }
+
+          it 'renders the edit page' do
+            expect(response).to render_template :edit
+          end
+        end
+
+        context 'and the data is valid' do
+          let(:duns) { '123456789' }
+
+          it 'redirects to the show page' do
+            expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+          end
+
+          it 'adds a log to the database' do
+            expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
+          end
+        end
+      end
+
+      context 'when updating on the supplier address page' do
+        let(:page) { :supplier_address }
+        let(:supplier_params) { { address_line_1: '3 Avery Way', address_line_2: '', address_town: 'Eastliegh', address_county: 'Anglesux', address_postcode: address_postcode } }
+
+        context 'and the data is not valid' do
+          let(:address_postcode) { 'AAA111' }
+
+          it 'renders the edit page' do
+            expect(response).to render_template :edit
+          end
+        end
+
+        context 'and the data is valid' do
+          let(:address_postcode) { 'AA1 1AA' }
+
+          it 'redirects to the show page' do
+            expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+          end
+
+          it 'adds a log to the database' do
+            expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
+          end
+        end
+      end
+
+      context 'when updating on the supplier status page' do
+        let(:page) { :supplier_status }
+        let(:supplier_params) { { active: supplier_status } }
+
+        context 'and the data is not valid' do
+          let(:supplier_status) { '' }
+
+          it 'renders the edit page' do
+            expect(response).to render_template :edit
+          end
+        end
+
+        context 'and the data is valid' do
+          let(:supplier_status) { 'true' }
+
+          it 'redirects to the show page' do
+            expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
+          end
+
+          it 'adds a log to the database' do
+            expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
+          end
+        end
+      end
+    end
+    # rubocop:enable RSpec/NestedGroups
+
+    context 'when the framework has expired' do
+      include_context 'and RM6232 has expired'
+
+      before { put :update, params: { id: supplier.id, page: page } }
+
+      context 'when on the supplier name page' do
+        let(:page) { :supplier_name }
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
         end
-
-        it 'adds a log to the database' do
-          expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
-        end
-      end
-    end
-
-    context 'when updating on the additional supplier information page' do
-      let(:page) { :additional_supplier_information }
-      let(:supplier_params) { { duns: duns, registration_number: 'AB123456' } }
-
-      context 'and the data is not valid' do
-        let(:duns) { '0123456789' }
-
-        it 'renders the edit page' do
-          expect(response).to render_template :edit
-        end
       end
 
-      context 'and the data is valid' do
-        let(:duns) { '123456789' }
+      context 'when on the supplier contact information page' do
+        let(:page) { :supplier_contact_information }
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
         end
-
-        it 'adds a log to the database' do
-          expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
-        end
-      end
-    end
-
-    context 'when updating on the supplier address page' do
-      let(:page) { :supplier_address }
-      let(:supplier_params) { { address_line_1: '3 Avery Way', address_line_2: '', address_town: 'Eastliegh', address_county: 'Anglesux', address_postcode: address_postcode } }
-
-      context 'and the data is not valid' do
-        let(:address_postcode) { 'AAA111' }
-
-        it 'renders the edit page' do
-          expect(response).to render_template :edit
-        end
       end
 
-      context 'and the data is valid' do
-        let(:address_postcode) { 'AA1 1AA' }
+      context 'when on the additional supplier information page' do
+        let(:page) { :additional_supplier_information }
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
         end
-
-        it 'adds a log to the database' do
-          expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
-        end
-      end
-    end
-
-    context 'when updating on the supplier status page' do
-      let(:page) { :supplier_status }
-      let(:supplier_params) { { active: supplier_status } }
-
-      context 'and the data is not valid' do
-        let(:supplier_status) { '' }
-
-        it 'renders the edit page' do
-          expect(response).to render_template :edit
-        end
       end
 
-      context 'and the data is valid' do
-        let(:supplier_status) { 'true' }
+      context 'when on the supplier address page' do
+        let(:page) { :supplier_address }
 
         it 'redirects to the show page' do
           expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
         end
+      end
 
-        it 'adds a log to the database' do
-          expect(FacilitiesManagement::RM6232::Admin::SupplierData::Edit).to have_received(:log_change).with(controller.current_user, supplier)
+      context 'when on the supplier status page' do
+        let(:page) { :supplier_status }
+
+        it 'redirects to the show page' do
+          expect(response).to redirect_to facilities_management_admin_supplier_detail_path(framework: 'RM6232')
         end
       end
     end

--- a/spec/controllers/facilities_management/rm3830/admin/sublot_regions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/sublot_regions_controller_spec.rb
@@ -86,31 +86,43 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SublotRegionsController do
   end
 
   describe 'PUT update' do
-    before { put :update, params: { supplier_framework_datum_id: supplier_id, lot: '1a', regions: regions } }
+    context 'when the framework is live' do
+      before { put :update, params: { supplier_framework_datum_id: supplier_id, lot: '1a', regions: regions } }
 
-    context 'when updating the data with regions' do
-      let(:regions) { ['UKC1', 'UKC2'] }
+      context 'when updating the data with regions' do
+        let(:regions) { ['UKC1', 'UKC2'] }
 
-      it 'redirects to the supplier_framework_data_path' do
-        expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
+        it 'redirects to the supplier_framework_data_path' do
+          expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
+        end
+
+        it 'updates the regions correctly' do
+          supplier.reload
+          expect(supplier.lot_data['1a']['regions']).to eq regions
+        end
       end
 
-      it 'updates the regions correctly' do
-        supplier.reload
-        expect(supplier.lot_data['1a']['regions']).to eq regions
+      context 'when updating the data without regions' do
+        let(:regions) { [] }
+
+        it 'redirects to the supplier_framework_data_path' do
+          expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
+        end
+
+        it 'updates the regions correctly' do
+          supplier.reload
+          expect(supplier.lot_data['1a']['regions']).to eq regions
+        end
       end
     end
 
-    context 'when updating the data without regions' do
-      let(:regions) { [] }
+    context 'when the framework has expired' do
+      include_context 'and RM3830 has expired'
 
-      it 'redirects to the supplier_framework_data_path' do
-        expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
-      end
+      before { put :update, params: { supplier_framework_datum_id: supplier_id, lot: '1a' } }
 
-      it 'updates the regions correctly' do
-        supplier.reload
-        expect(supplier.lot_data['1a']['regions']).to eq regions
+      it 'redirects to the edit page' do
+        expect(response).to redirect_to edit_facilities_management_rm3830_admin_supplier_framework_datum_sublot_region_path
       end
     end
   end

--- a/spec/controllers/facilities_management/rm3830/admin/sublot_services_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/sublot_services_controller_spec.rb
@@ -97,111 +97,143 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SublotServicesController do
 
   describe 'PUT update' do
     # rubocop:disable RSpec/NestedGroups
-    context 'when updating the data for lot 1a' do
-      let(:checked_services) { ['C.1', 'D.4'] }
-      let(:data) { { 'C.1': { 'Direct Award Discount (%)': '1.0', 'Call Centre Operations (£)': '12.0' }, 'G.4': { 'Direct Award Discount (%)': '0.5', 'Special Schools (£)': '4.6789' } } }
-      let(:rate) { { 'M.141': '0.1123', 'B.1': '0.35' } }
+    context 'when the framework is live' do
+      context 'when updating the data for lot 1a' do
+        let(:checked_services) { ['C.1', 'D.4'] }
+        let(:data) { { 'C.1': { 'Direct Award Discount (%)': '1.0', 'Call Centre Operations (£)': '12.0' }, 'G.4': { 'Direct Award Discount (%)': '0.5', 'Special Schools (£)': '4.6789' } } }
+        let(:rate) { { 'M.141': '0.1123', 'B.1': '0.35' } }
 
-      before { put :update, params: { supplier_framework_datum_id: supplier_id, lot: '1a', checked_services: checked_services, data: data, rate: rate } }
+        before { put :update, params: { supplier_framework_datum_id: supplier_id, lot: '1a', checked_services: checked_services, data: data, rate: rate } }
 
-      context 'when updating the service selection for lot 1a' do
-        it 'redirects to the supplier_framework_data_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
-        end
-
-        it 'updates the services correctly' do
-          supplier.reload
-          expect(supplier.lot_data['1a']['services']).to eq checked_services
-        end
-      end
-
-      context 'and the service discount and prices are updated' do
-        let(:latest_rate_card) { FacilitiesManagement::RM3830::RateCard.latest }
-
-        context 'and the data is valid' do
+        context 'when updating the service selection for lot 1a' do
           it 'redirects to the supplier_framework_data_path' do
             expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
           end
 
-          it 'updates the discount data correctly' do
-            expect(latest_rate_card[:data][:Discounts][supplier_id.to_sym][:'C.1'][:'Disc %']).to eq 1.0
-            expect(latest_rate_card[:data][:Discounts][supplier_id.to_sym][:'G.4'][:'Disc %']).to eq 0.5
-          end
-
-          it 'updates the discount prices data correctly' do
-            expect(latest_rate_card[:data][:Prices][supplier_id.to_sym][:'C.1'][:'Call Centre Operations']).to eq 12.0
-            expect(latest_rate_card[:data][:Prices][supplier_id.to_sym][:'G.4'][:'Special Schools']).to eq 4.6789
+          it 'updates the services correctly' do
+            supplier.reload
+            expect(supplier.lot_data['1a']['services']).to eq checked_services
           end
         end
 
-        context 'and the data is not valid' do
-          let(:data) { { 'C.1': { 'Direct Award Discount (%)': '1.0', 'Call Centre Operations (£)': 'TARDIS' }, 'G.4': { 'Direct Award Discount (%)': '1.005', 'Special Schools (£)': 'Doctor' } } }
+        context 'and the service discount and prices are updated' do
+          let(:latest_rate_card) { FacilitiesManagement::RM3830::RateCard.latest }
 
-          it 'renders the edit page' do
-            expect(response).to render_template(:edit)
+          context 'and the data is valid' do
+            it 'redirects to the supplier_framework_data_path' do
+              expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
+            end
+
+            it 'updates the discount data correctly' do
+              expect(latest_rate_card[:data][:Discounts][supplier_id.to_sym][:'C.1'][:'Disc %']).to eq 1.0
+              expect(latest_rate_card[:data][:Discounts][supplier_id.to_sym][:'G.4'][:'Disc %']).to eq 0.5
+            end
+
+            it 'updates the discount prices data correctly' do
+              expect(latest_rate_card[:data][:Prices][supplier_id.to_sym][:'C.1'][:'Call Centre Operations']).to eq 12.0
+              expect(latest_rate_card[:data][:Prices][supplier_id.to_sym][:'G.4'][:'Special Schools']).to eq 4.6789
+            end
           end
 
-          it 'has the correct errors' do
-            expect(assigns(:invalid_services)).to match('C.1' => { 'Call Centre Operations (£)' => { value: 'TARDIS', error_type: 'not_a_number' } }, 'G.4' => { 'Direct Award Discount (%)' => { value: '1.005', error_type: 'less_than_or_equal_to' }, 'Special Schools (£)' => { value: 'Doctor', error_type: 'not_a_number' } })
+          context 'and the data is not valid' do
+            let(:data) { { 'C.1': { 'Direct Award Discount (%)': '1.0', 'Call Centre Operations (£)': 'TARDIS' }, 'G.4': { 'Direct Award Discount (%)': '1.005', 'Special Schools (£)': 'Doctor' } } }
+
+            it 'renders the edit page' do
+              expect(response).to render_template(:edit)
+            end
+
+            it 'has the correct errors' do
+              expect(assigns(:invalid_services)).to match('C.1' => { 'Call Centre Operations (£)' => { value: 'TARDIS', error_type: 'not_a_number' } }, 'G.4' => { 'Direct Award Discount (%)' => { value: '1.005', error_type: 'less_than_or_equal_to' }, 'Special Schools (£)' => { value: 'Doctor', error_type: 'not_a_number' } })
+            end
+          end
+        end
+
+        context 'and the variance is updated' do
+          let(:latest_rate_card) { FacilitiesManagement::RM3830::RateCard.latest }
+
+          context 'and the data is valid' do
+            it 'redirects to the supplier_framework_data_path' do
+              expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
+            end
+
+            it 'updated the variances correctly' do
+              expect(latest_rate_card[:data][:Variances][supplier_id.to_sym][:'Corporate Overhead %']).to eq 0.1123
+              expect(latest_rate_card[:data][:Variances][supplier_id.to_sym][:'Mobilisation Cost (DA %)']).to eq 0.35
+            end
+          end
+
+          context 'and the data is not valid' do
+            let(:rate) { { 'M.141': '0.1123', 'B.1': '1.0001' } }
+
+            it 'renders the edit page' do
+              expect(response).to render_template(:edit)
+            end
+
+            it 'has the correct errors' do
+              expect(assigns(:invalid_services)).to match('B.1' => { value: '1.0001', error_type: 'less_than_or_equal_to' })
+            end
           end
         end
       end
 
-      context 'and the variance is updated' do
-        let(:latest_rate_card) { FacilitiesManagement::RM3830::RateCard.latest }
+      context 'when updating the checkboxes for lots 1b and 1c' do
+        before { put :update, params: { supplier_framework_datum_id: supplier_id, lot: '1b', checked_services: services } }
 
-        context 'and the data is valid' do
+        context 'when updating the data with services' do
+          let(:services) { ['C.1', 'D.4'] }
+
           it 'redirects to the supplier_framework_data_path' do
             expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
           end
 
-          it 'updated the variances correctly' do
-            expect(latest_rate_card[:data][:Variances][supplier_id.to_sym][:'Corporate Overhead %']).to eq 0.1123
-            expect(latest_rate_card[:data][:Variances][supplier_id.to_sym][:'Mobilisation Cost (DA %)']).to eq 0.35
+          it 'updates the services correctly' do
+            supplier.reload
+            expect(supplier.lot_data['1b']['services']).to eq services
           end
         end
 
-        context 'and the data is not valid' do
-          let(:rate) { { 'M.141': '0.1123', 'B.1': '1.0001' } }
+        context 'when updating the data without services' do
+          let(:services) { [] }
 
-          it 'renders the edit page' do
-            expect(response).to render_template(:edit)
+          it 'redirects to the supplier_framework_data_path' do
+            expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
           end
 
-          it 'has the correct errors' do
-            expect(assigns(:invalid_services)).to match('B.1' => { value: '1.0001', error_type: 'less_than_or_equal_to' })
+          it 'updates the services correctly' do
+            supplier.reload
+            expect(supplier.lot_data['1b']['services']).to eq services
           end
         end
       end
     end
     # rubocop:enable RSpec/NestedGroups
 
-    context 'when updating the checkboxes for lots 1b and 1c' do
-      before { put :update, params: { supplier_framework_datum_id: supplier_id, lot: '1b', checked_services: services } }
+    context 'when the framework has expired' do
+      include_context 'and RM3830 has expired'
 
-      context 'when updating the data with services' do
-        let(:services) { ['C.1', 'D.4'] }
+      before { put :update, params: { supplier_framework_datum_id: supplier_id, lot: lot_number } }
 
-        it 'redirects to the supplier_framework_data_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
-        end
+      context 'when updating the data for lot 1a' do
+        let(:lot_number) { '1a' }
 
-        it 'updates the services correctly' do
-          supplier.reload
-          expect(supplier.lot_data['1b']['services']).to eq services
+        it 'redirects to the edit page' do
+          expect(response).to redirect_to edit_facilities_management_rm3830_admin_supplier_framework_datum_sublot_service_path
         end
       end
 
-      context 'when updating the data without services' do
-        let(:services) { [] }
+      context 'when updating the data for lot 1b' do
+        let(:lot_number) { '1b' }
 
-        it 'redirects to the supplier_framework_data_path' do
-          expect(response).to redirect_to facilities_management_rm3830_admin_supplier_framework_data_path
+        it 'redirects to the edit page' do
+          expect(response).to redirect_to edit_facilities_management_rm3830_admin_supplier_framework_datum_sublot_service_path
         end
+      end
 
-        it 'updates the services correctly' do
-          supplier.reload
-          expect(supplier.lot_data['1b']['services']).to eq services
+      context 'when updating the data for lot 1c' do
+        let(:lot_number) { '1c' }
+
+        it 'redirects to the edit page' do
+          expect(response).to redirect_to edit_facilities_management_rm3830_admin_supplier_framework_datum_sublot_service_path
         end
       end
     end

--- a/spec/helpers/facilities_management/admin/framework_helper_spec.rb
+++ b/spec/helpers/facilities_management/admin/framework_helper_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe FacilitiesManagement::Admin::FrameworkHelper do
+  describe '.framework_expired_warning' do
+    let(:result) { helper.framework_expired_warning('The framework has expired') }
+
+    before { @framework_has_expired = framework_has_expired }
+
+    context 'when the framework has expired' do
+      let(:framework_has_expired) { true }
+
+      it 'renders HTML with the text' do
+        expect(result).to eq('<div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span><strong class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span>The framework has expired</strong></div>')
+      end
+    end
+
+    context 'when the framework has not epxired' do
+      let(:framework_has_expired) { false }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: [FMFR-1358](https://crowncommercialservice.atlassian.net/browse/FMFR-1358)

I have updated the RM3830 admin section so that when the framework has expired, admins will be unable to edit/update any of the service/supplier data in the system.

I’ve also added specs to validate these changes.

[FMFR-1358]: https://crowncommercialservice.atlassian.net/browse/FMFR-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ