### PR TITLE
FMFR-1355 - Make changes with rubocop based on new ruby 3 syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -164,12 +164,5 @@ Rails/HelperInstanceVariable:
 Style/OptionalBooleanParameter:
     Enabled: false
 
-# TODO: Reenable these cops
 Style/HashSyntax:
-    Enabled: false
-
-Naming/BlockForwarding:
-    Enabled: false
-
-Style/ArrayIntersect:
-    Enabled: false
+    EnforcedShorthandSyntax: consistent

--- a/app/controllers/facilities_management/buyer_details_controller.rb
+++ b/app/controllers/facilities_management/buyer_details_controller.rb
@@ -12,7 +12,7 @@ module FacilitiesManagement
 
       context = context_from_params
 
-      if @buyer_detail.save(context: context)
+      if @buyer_detail.save(context:)
         redirect_to redirect_path(context)
       else
         render render_template(context)

--- a/app/controllers/facilities_management/rm3830/buildings_controller.rb
+++ b/app/controllers/facilities_management/rm3830/buildings_controller.rb
@@ -12,7 +12,7 @@ module FacilitiesManagement
       end
 
       def edit_path(building, section)
-        edit_facilities_management_rm3830_building_path(building, section: section)
+        edit_facilities_management_rm3830_building_path(building, section:)
       end
 
       def create_path
@@ -20,7 +20,7 @@ module FacilitiesManagement
       end
 
       def update_path
-        facilities_management_rm3830_building_path(@building, section: section)
+        facilities_management_rm3830_building_path(@building, section:)
       end
 
       def start_a_procurement_path

--- a/app/controllers/facilities_management/rm3830/edit_buildings_controller.rb
+++ b/app/controllers/facilities_management/rm3830/edit_buildings_controller.rb
@@ -12,7 +12,7 @@ module FacilitiesManagement
       end
 
       def edit_path(building, section)
-        edit_facilities_management_rm3830_procurement_edit_building_path(@procurement, building, section: section)
+        edit_facilities_management_rm3830_procurement_edit_building_path(@procurement, building, section:)
       end
 
       def create_path
@@ -20,7 +20,7 @@ module FacilitiesManagement
       end
 
       def update_path
-        facilities_management_rm3830_procurement_edit_building_path(@procurement, @building, section: section)
+        facilities_management_rm3830_procurement_edit_building_path(@procurement, @building, section:)
       end
 
       def start_a_procurement_path

--- a/app/controllers/facilities_management/rm3830/procurement_buildings_services_controller.rb
+++ b/app/controllers/facilities_management/rm3830/procurement_buildings_services_controller.rb
@@ -31,7 +31,7 @@ module FacilitiesManagement
       def update_procurement_building_service(pbs_params, context)
         @building_service.assign_attributes(pbs_params)
 
-        if @building_service.save(context: context)
+        if @building_service.save(context:)
           redirect_to facilities_management_rm3830_procurement_building_path(@procurement_building)
         else
           params[:service_question] = params[:facilities_management_rm3830_procurement_building_service][:service_question]

--- a/app/controllers/facilities_management/rm3830/procurements_controller.rb
+++ b/app/controllers/facilities_management/rm3830/procurements_controller.rb
@@ -202,7 +202,7 @@ module FacilitiesManagement
       def download_da_spreadsheet(spreadsheet_creator, filename)
         spreadsheet_builder = spreadsheet_creator.new @procurement.first_unsent_contract.id
         spreadsheet_builder.build
-        send_data spreadsheet_builder.to_xlsx, filename: filename
+        send_data spreadsheet_builder.to_xlsx, filename:
       end
 
       def change_the_contract_value

--- a/app/controllers/facilities_management/rm6232/buildings_controller.rb
+++ b/app/controllers/facilities_management/rm6232/buildings_controller.rb
@@ -12,7 +12,7 @@ module FacilitiesManagement
       end
 
       def edit_path(building, section)
-        edit_facilities_management_rm6232_building_path(building, section: section)
+        edit_facilities_management_rm6232_building_path(building, section:)
       end
 
       def create_path
@@ -20,7 +20,7 @@ module FacilitiesManagement
       end
 
       def update_path
-        facilities_management_rm6232_building_path(@building, section: section)
+        facilities_management_rm6232_building_path(@building, section:)
       end
 
       def start_a_procurement_path

--- a/app/controllers/facilities_management/rm6232/edit_buildings_controller.rb
+++ b/app/controllers/facilities_management/rm6232/edit_buildings_controller.rb
@@ -12,7 +12,7 @@ module FacilitiesManagement
       end
 
       def edit_path(building, section)
-        edit_facilities_management_rm6232_procurement_edit_building_path(@procurement, building, section: section)
+        edit_facilities_management_rm6232_procurement_edit_building_path(@procurement, building, section:)
       end
 
       def create_path
@@ -20,7 +20,7 @@ module FacilitiesManagement
       end
 
       def update_path
-        facilities_management_rm6232_procurement_edit_building_path(@procurement, @building, section: section)
+        facilities_management_rm6232_procurement_edit_building_path(@procurement, @building, section:)
       end
 
       def start_a_procurement_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,22 +43,22 @@ module ApplicationHelper
     tag.label(text, class: 'govuk-label', for: form_object_name)
   end
 
-  def govuk_form_group_with_optional_error(journey, *attributes, &block)
+  def govuk_form_group_with_optional_error(journey, *attributes, &)
     attributes_with_errors = attributes.select { |a| journey.errors[a].any? }
 
     css_classes = ['govuk-form-group']
     css_classes += ['govuk-form-group--error'] if attributes_with_errors.any?
 
-    tag.div(class: css_classes, &block)
+    tag.div(class: css_classes, &)
   end
 
-  def govuk_fieldset_with_optional_error(journey, *attributes, &block)
+  def govuk_fieldset_with_optional_error(journey, *attributes, &)
     attributes_with_errors = attributes.select { |a| journey.errors[a].any? }
 
     options = { class: 'govuk-fieldset' }
     options['aria-describedby'] = attributes_with_errors.map { |a| error_id(a) } if attributes_with_errors.any?
 
-    tag.fieldset(**options, &block)
+    tag.fieldset(**options, &)
   end
 
   def list_potential_errors(model_object, attribute, form_object_name, error_lookup = nil, error_position = nil)
@@ -275,7 +275,7 @@ module ApplicationHelper
   end
 
   def search_box(placeholder_text, column = 0)
-    text_field_tag 'fm-table-filter-input', nil, class: 'govuk-input', placeholder: placeholder_text, data: { column: column }
+    text_field_tag 'fm-table-filter-input', nil, class: 'govuk-input', placeholder: placeholder_text, data: { column: }
   end
 
   def link_to_public_file_for_download(filename, file_type, text, show_doc_image, **html_options)

--- a/app/helpers/facilities_management/procurements_helper.rb
+++ b/app/helpers/facilities_management/procurements_helper.rb
@@ -3,7 +3,7 @@ module FacilitiesManagement
     def section_has_error?(section)
       return false unless @procurement.errors.any?
 
-      (requirements_errors_list.keys & section_errors(section)).any?
+      requirements_errors_list.keys.intersect?(section_errors(section))
     end
 
     def section_id(section)

--- a/app/helpers/gov_uk_helper/accordion.rb
+++ b/app/helpers/gov_uk_helper/accordion.rb
@@ -1,13 +1,13 @@
 # rubocop:disable Metrics/ModuleLength
 module GovUKHelper::Accordion
-  def govuk_accordion(name, sections, &block)
+  def govuk_accordion(name, sections, &)
     tag.div(class: 'govuk-accordion', id: "accordion-with-summary-sections-for-#{name}", data: { module: 'govuk-accordion' }) do
       capture do
         sections.each.with_index(1) do |section, index|
           concat(tag.div(class: 'govuk-accordion__section') do
             capture do
               concat(govuk_accordion_heading(index, section[:name]))
-              concat(govuk_accordion_content(index, name, section, &block))
+              concat(govuk_accordion_content(index, name, section, &))
             end
           end)
         end
@@ -15,7 +15,7 @@ module GovUKHelper::Accordion
     end
   end
 
-  def govuk_accordion_with_checkboxes(name, sections, model_name, attribute, &block)
+  def govuk_accordion_with_checkboxes(name, sections, model_name, attribute, &)
     tag.div(class: 'govuk-accordion', id: "accordion-with-summary-sections-for-#{name}", data: { module: 'govuk-accordion' }) do
       capture do
         sections.each.with_index(1) do |(section_id, section), index|
@@ -23,7 +23,7 @@ module GovUKHelper::Accordion
             capture do
               concat(govuk_accordion_heading(index, section[:name]))
               concat(govuk_accordion_content(index, section[:name], section) do
-                check_boxes_for_section(section_id, model_name, attribute, section[:name], section[:items], &block)
+                check_boxes_for_section(section_id, model_name, attribute, section[:name], section[:items], &)
               end)
             end
           end)
@@ -48,7 +48,7 @@ module GovUKHelper::Accordion
     end
   end
 
-  def check_boxes_for_section(section_id, model_name, attribute, section_name, items, &block)
+  def check_boxes_for_section(section_id, model_name, attribute, section_name, items, &)
     tag.div(class: 'govuk-form-group chooser-input', sectionname: section_name, section: section_id) do
       tag.div(class: 'govuk-checkboxes') do
         capture do
@@ -56,7 +56,7 @@ module GovUKHelper::Accordion
             concat(tag.div(class: 'govuk-checkboxes__item') do
               capture do
                 concat(check_box_item(section_id, model_name, attribute, item))
-                concat(check_box_label(section_id, model_name, item, &block))
+                concat(check_box_label(section_id, model_name, item, &))
               end
             end)
           end

--- a/app/helpers/gov_uk_helper/details.rb
+++ b/app/helpers/gov_uk_helper/details.rb
@@ -1,12 +1,12 @@
 module GovUKHelper::Details
-  def govuk_details(summary_text, **options, &block)
+  def govuk_details(summary_text, **options, &)
     govuk_details_class = ['govuk-details']
     govuk_details_class << options.delete(:class) if options[:class]
 
     tag.details(class: govuk_details_class, data: { module: 'govuk-details' }, **options) do
       capture do
         concat(tag.summary(tag.span(summary_text, class: 'govuk-details__summary-text'), class: 'govuk-details__summary'))
-        concat(tag.div(class: 'govuk-details__text', &block))
+        concat(tag.div(class: 'govuk-details__text', &))
       end
     end
   end

--- a/app/helpers/gov_uk_helper/notification_banner.rb
+++ b/app/helpers/gov_uk_helper/notification_banner.rb
@@ -1,5 +1,5 @@
 module GovUKHelper::NotificationBanner
-  def govuk_notification_banner(type, heading, &block)
+  def govuk_notification_banner(type, heading, &)
     tag.div(class: "govuk-notification-banner #{BANNER_TYPE[type][:class]}", role: 'region', aria: { labelledby: 'govuk-notification-banner-title' }, data: { module: 'govuk-notification-banner' }) do
       capture do
         concat(tag.div(class: 'govuk-notification-banner__header') do
@@ -8,7 +8,7 @@ module GovUKHelper::NotificationBanner
         concat(tag.div(class: 'govuk-notification-banner__content') do
           capture do
             concat(tag.p(heading, class: 'govuk-notification-banner__heading'))
-            concat(tag.p(class: 'govuk-body', &block)) if block_given?
+            concat(tag.p(class: 'govuk-body', &)) if block_given?
           end
         end)
       end

--- a/app/helpers/gov_uk_helper/radios.rb
+++ b/app/helpers/gov_uk_helper/radios.rb
@@ -1,6 +1,6 @@
 module GovUKHelper::Radios
-  def govuk_radios_conditional(&block)
-    tag.div(class: 'govuk-radios govuk-radios--conditional', data: { module: 'govuk-radios' }, &block)
+  def govuk_radios_conditional(&)
+    tag.div(class: 'govuk-radios govuk-radios--conditional', data: { module: 'govuk-radios' }, &)
   end
 
   def govuk_radios_conditional_item(form, attribute, value, label_text)
@@ -13,11 +13,11 @@ module GovUKHelper::Radios
     end
   end
 
-  def govuk_radios_conditional_area(attribute, value, **options, &block)
+  def govuk_radios_conditional_area(attribute, value, **options, &)
     class_list = ['govuk-radios__conditional govuk-radios__conditional--hidden']
     class_list << options.delete(:class)
 
-    tag.div(class: class_list.compact.join(' '), id: govuk_radios_conditional_id(attribute, value), **options, &block)
+    tag.div(class: class_list.compact.join(' '), id: govuk_radios_conditional_id(attribute, value), **options, &)
   end
 
   def govuk_radios_conditional_id(attribute, value)

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -140,7 +140,7 @@ module LayoutHelper
     end
   end
 
-  def govuk_grouped_field(form, caption, attribute, header_text = '', &block)
+  def govuk_grouped_field(form, caption, attribute, header_text = '', &)
     attribute_has_errors = form.object.errors[attribute].any?
 
     options         = {}
@@ -149,9 +149,9 @@ module LayoutHelper
     options[:class] = css_classes
 
     if attribute_has_errors
-      tag.div(fieldset_structure(form, caption, options, header_text, attribute, &block), class: 'govuk-form-group govuk-form-group--error')
+      tag.div(fieldset_structure(form, caption, options, header_text, attribute, &), class: 'govuk-form-group govuk-form-group--error')
     else
-      fieldset_structure(form, caption, options, header_text, attribute, &block)
+      fieldset_structure(form, caption, options, header_text, attribute, &)
     end
   end
 
@@ -225,21 +225,21 @@ module LayoutHelper
     end
   end
 
-  def numbered_list_helper(heading, &block)
+  def numbered_list_helper(heading, &)
     capture do
       concat(tag.h2(heading, class: 'govuk-heading-m govuk-!-font-weight-bold govuk-!-margin-bottom-2'))
-      concat(tag.div(class: 'govuk-body govuk-!-padding-left-5', &block))
+      concat(tag.div(class: 'govuk-body govuk-!-padding-left-5', &))
     end
   end
 
-  def ccs_account_panel_row(**options, &block)
+  def ccs_account_panel_row(**options, &)
     class_list = ['govuk-grid-row govuk-!-margin-bottom-6 fm-buyer-account-panel__container']
     class_list << options.delete(:class)
 
-    tag.div(class: class_list, **options, &block)
+    tag.div(class: class_list, **options, &)
   end
 
-  def ccs_account_panel(title, title_url, **options, &block)
+  def ccs_account_panel(title, title_url, **options, &)
     class_list = ['govuk-grid-column-one-third fm-buyer-account-panel']
     class_list << options.delete(:class)
 
@@ -248,7 +248,7 @@ module LayoutHelper
         concat(tag.p do
           link_to(title, title_url, class: 'ccs-font-weight-semi-bold fm-buyer-account-panel__title_no_link govuk-!-margin-bottom-2 govuk-link--no-visited-state')
         end)
-        concat(tag.p(class: 'govuk-!-top-padding-4', &block))
+        concat(tag.p(class: 'govuk-!-top-padding-4', &))
       end
     end
   end

--- a/app/models/concerns/facilities_management/procurement_concern.rb
+++ b/app/models/concerns/facilities_management/procurement_concern.rb
@@ -70,12 +70,12 @@ module FacilitiesManagement
     end
 
     def call_off_extension(extension)
-      call_off_extensions.find_by(extension: extension)
+      call_off_extensions.find_by(extension:)
     end
 
     def build_call_off_extensions
       4.times do |extension|
-        call_off_extensions.find_or_initialize_by(extension: extension)
+        call_off_extensions.find_or_initialize_by(extension:)
       end
     end
 

--- a/app/models/concerns/facilities_management/rm3830/common_rate.rb
+++ b/app/models/concerns/facilities_management/rm3830/common_rate.rb
@@ -25,7 +25,7 @@ module FacilitiesManagement::RM3830
       end
 
       def priced_at_framework(code, standard)
-        find_by(code: code, standard: standard)&.framework.present?
+        find_by(code:, standard:)&.framework.present?
       end
 
       # read in the benchmark and framework rates - these were taken from the Damolas spreadsheet and put in the postgres database numbers are to 15dp
@@ -41,8 +41,8 @@ module FacilitiesManagement::RM3830
           framework_rates[code_and_standard] = row['framework'].to_f
         end
         {
-          benchmark_rates: benchmark_rates,
-          framework_rates: framework_rates
+          benchmark_rates:,
+          framework_rates:
         }
       end
 

--- a/app/models/concerns/facilities_management/rm3830/procurement_validator.rb
+++ b/app/models/concerns/facilities_management/rm3830/procurement_validator.rb
@@ -115,7 +115,7 @@ module FacilitiesManagement::RM3830
     end
 
     def check_service_and_buildings_completed
-      if (error_list & %i[services_incomplete buildings_incomplete]).any? || !buildings_and_services_completed?
+      if error_list.intersect?(%i[services_incomplete buildings_incomplete]) || !buildings_and_services_completed?
         errors.add(:base, :buildings_and_services_incomplete)
         errors.add(:base, :service_requirements_incomplete)
       else

--- a/app/models/concerns/facilities_management/rm6232/procurement_validator.rb
+++ b/app/models/concerns/facilities_management/rm6232/procurement_validator.rb
@@ -26,7 +26,7 @@ module FacilitiesManagement::RM6232
     end
 
     def check_service_and_buildings_completed
-      errors.add(:base, :buildings_and_services_incomplete) if (error_list & %i[services_incomplete buildings_incomplete]).any? || !buildings_and_services_completed?
+      errors.add(:base, :buildings_and_services_incomplete) if error_list.intersect?(%i[services_incomplete buildings_incomplete]) || !buildings_and_services_completed?
     end
   end
 end

--- a/app/models/facilities_management/rm3830/admin/suppliers_admin.rb
+++ b/app/models/facilities_management/rm3830/admin/suppliers_admin.rb
@@ -47,7 +47,7 @@ module FacilitiesManagement
         end
 
         def user_unique?
-          self.class.where.not(supplier_id: supplier_id).pluck(:user_id).exclude? user.id
+          self.class.where.not(supplier_id:).pluck(:user_id).exclude? user.id
         end
       end
     end

--- a/app/models/facilities_management/rm3830/procurement.rb
+++ b/app/models/facilities_management/rm3830/procurement.rb
@@ -401,7 +401,7 @@ module FacilitiesManagement
       end
 
       def services_require_questions?
-        (procurement_building_service_codes & services_requiring_questions).any?
+        procurement_building_service_codes.intersect?(services_requiring_questions)
       end
 
       def can_be_deleted?

--- a/app/models/facilities_management/rm3830/procurement_building.rb
+++ b/app/models/facilities_management/rm3830/procurement_building.rb
@@ -60,11 +60,11 @@ module FacilitiesManagement
       end
 
       def validate_spreadsheet_gia(gia, building_name)
-        errors.add(:building, :gia_too_small, building_name: building_name) if requires_internal_area? && gia.to_i.zero?
+        errors.add(:building, :gia_too_small, building_name:) if requires_internal_area? && gia.to_i.zero?
       end
 
       def validate_spreadsheet_external_area(external_area, building_name)
-        errors.add(:building, :external_area_too_small, building_name: building_name) if requires_external_area? && external_area.to_i.zero?
+        errors.add(:building, :external_area_too_small, building_name:) if requires_external_area? && external_area.to_i.zero?
       end
 
       def missing_region?
@@ -87,7 +87,7 @@ module FacilitiesManagement
       end
 
       def requires_service_questions?
-        (service_codes & services_requiring_questions).any?
+        service_codes.intersect?(services_requiring_questions)
       end
 
       def building_internal_area
@@ -188,11 +188,11 @@ module FacilitiesManagement
       end
 
       def requires_external_area?
-        @requires_external_area ||= (services_requiring_external_area & service_codes).any?
+        @requires_external_area ||= services_requiring_external_area.intersect?(service_codes)
       end
 
       def requires_internal_area?
-        @requires_internal_area ||= (services_requiring_gia & service_codes).any?
+        @requires_internal_area ||= services_requiring_gia.intersect?(service_codes)
       end
 
       def area_complete?

--- a/app/models/facilities_management/rm3830/procurement_building_service.rb
+++ b/app/models/facilities_management/rm3830/procurement_building_service.rb
@@ -56,7 +56,7 @@ module FacilitiesManagement
       end
 
       def requires_service_standard?
-        (required_contexts.keys & STANDARD_TYPES).any?
+        required_contexts.keys.intersect?(STANDARD_TYPES)
       end
 
       def requires_lift_data?

--- a/app/models/facilities_management/rm3830/spreadsheet_import.rb
+++ b/app/models/facilities_management/rm3830/spreadsheet_import.rb
@@ -171,7 +171,7 @@ module FacilitiesManagement
       end
 
       def error_hash(building_name, service_name, attribute, errors)
-        { building_name: building_name, service_name: service_name, attribute: attribute, errors: errors }.compact
+        { building_name:, service_name:, attribute:, errors: }.compact
       end
 
       def errors_from_import

--- a/app/models/facilities_management/rm6232/admin/supplier_data/edit.rb
+++ b/app/models/facilities_management/rm6232/admin/supplier_data/edit.rb
@@ -29,7 +29,7 @@ module FacilitiesManagement
           @current_supplier_data ||= begin
             supplier = supplier_data.data.find { |supplier_item| supplier_item['id'] == supplier_id }.dup
 
-            supplier_data.edits.where(supplier_id: supplier_id).where('created_at <= ?', created_at).order(created_at: :asc).each do |edit|
+            supplier_data.edits.where(supplier_id:).where('created_at <= ?', created_at).order(created_at: :asc).each do |edit|
               if edit.change_type == 'lot_data'
                 supplier_lot_data = supplier['lot_data'].find { |lot_data| lot_data['lot_code'] == edit.data['lot_code'] }
 
@@ -50,7 +50,7 @@ module FacilitiesManagement
         end
 
         def previous_supplier_data
-          supplier_data.edits.where(supplier_id: supplier_id).where('created_at < ?', created_at).order(created_at: :desc).first&.current_supplier_data || supplier_data.data.find { |supplier_item| supplier_item['id'] == supplier_id }
+          supplier_data.edits.where(supplier_id:).where('created_at < ?', created_at).order(created_at: :desc).first&.current_supplier_data || supplier_data.data.find { |supplier_item| supplier_item['id'] == supplier_id }
         end
       end
     end

--- a/app/services/cognito/admin/user_client_interface.rb
+++ b/app/services/cognito/admin/user_client_interface.rb
@@ -6,7 +6,7 @@ module Cognito
         def find_user_from_cognito_uuid(cognito_uuid)
           client = new_client
 
-          attributes = { cognito_uuid: cognito_uuid }
+          attributes = { cognito_uuid: }
 
           attributes.merge(find_user_in_cognito(client, cognito_uuid))
         end

--- a/app/services/cognito/base_service.rb
+++ b/app/services/cognito/base_service.rb
@@ -3,8 +3,8 @@ module Cognito
     attr_accessor :error
 
     # Use Class.call(args) rather than Class.new(args).call
-    def self.call(*args, **kwargs, &block)
-      resp = new(*args, **kwargs, &block)
+    def self.call(*args, **kwargs, &)
+      resp = new(*args, **kwargs, &)
       resp.call
       resp
     end

--- a/app/services/cognito/confirm_password_reset.rb
+++ b/app/services/cognito/confirm_password_reset.rb
@@ -47,7 +47,7 @@ module Cognito
     end
 
     def create_user_if_needed
-      user = User.find_for_authentication(email: email)
+      user = User.find_for_authentication(email:)
       return user if user
 
       resp = CreateUserFromCognito.call(email)

--- a/app/services/cognito/confirm_sign_up.rb
+++ b/app/services/cognito/confirm_sign_up.rb
@@ -43,7 +43,7 @@ module Cognito
     end
 
     def confirm_user
-      @user = User.find_for_authentication(email: email)
+      @user = User.find_for_authentication(email:)
       @user.update(confirmed_at: Time.zone.now)
     end
   end

--- a/app/services/cognito/resend_confirmation_code.rb
+++ b/app/services/cognito/resend_confirmation_code.rb
@@ -21,7 +21,7 @@ module Cognito
     private
 
     def username
-      User.find_for_authentication(email: email).cognito_uuid
+      User.find_for_authentication(email:).cognito_uuid
     end
   end
 end

--- a/app/services/facilities_management/files_importer/data_uploader.rb
+++ b/app/services/facilities_management/files_importer/data_uploader.rb
@@ -1,7 +1,7 @@
 module FacilitiesManagement
   class FilesImporter::DataUploader
-    def self.upload!(modle, &block)
-      error = all_or_none(modle, &block)
+    def self.upload!(modle, &)
+      error = all_or_none(modle, &)
       raise error if error
     end
 

--- a/app/services/facilities_management/rake_modules/supplier_data.rb
+++ b/app/services/facilities_management/rake_modules/supplier_data.rb
@@ -63,7 +63,7 @@ module FacilitiesManagement::RakeModules::SupplierData
       s3_resource = Aws::S3::Resource.new(region: ENV.fetch('COGNITO_AWS_REGION', nil))
       object = s3_resource.bucket(ENV.fetch('CCS_APP_API_DATA_BUCKET', nil)).object(ENV.fetch('SUPPLIER_DETAILS_DATA_KEY', nil))
       response_target = 'data/facilities_management/rm3830/Supplier_details_data.xlsx'
-      object.get(response_target: response_target)
+      object.get(response_target:)
       response_target
     else
       Rails.root.join('data', 'facilities_management', 'rm3830', 'RM3830 Suppliers Details (for Dev & Test).xlsx')

--- a/app/services/facilities_management/rm3830/admin/files_importer.rb
+++ b/app/services/facilities_management/rm3830/admin/files_importer.rb
@@ -8,7 +8,7 @@ module FacilitiesManagement::RM3830
       private
 
       def other_data
-        { file_source: file_source }
+        { file_source: }
       end
 
       def file_source

--- a/app/services/facilities_management/rm3830/price_matrix_spreadsheet.rb
+++ b/app/services/facilities_management/rm3830/price_matrix_spreadsheet.rb
@@ -180,7 +180,7 @@ module FacilitiesManagement::RM3830
       selected_building_types = @active_procurement_buildings.pluck(:building_type).uniq
       @building_types_with_service_codes = selected_building_types.map do |building_type|
         service_codes = @active_procurement_buildings.select { |apb| apb.building_type == building_type }.pluck(:service_codes).flatten.uniq
-        { building_type: building_type, service_codes: service_codes }
+        { building_type:, service_codes: }
       end
     end
 

--- a/app/services/facilities_management/rm3830/spreadsheet_importer.rb
+++ b/app/services/facilities_management/rm3830/spreadsheet_importer.rb
@@ -244,7 +244,7 @@ module FacilitiesManagement::RM3830
     end
 
     def add_procurement_building_service(procurement_building_services, code, index)
-      procurement_building_service = ProcurementBuildingService.new(code: code)
+      procurement_building_service = ProcurementBuildingService.new(code:)
       procurement_building_service.service_standard = extract_standard(SERVICE_CODES[index]) if requires_service_standard?(SERVICE_CODES[index])
       procurement_building_services << { object: procurement_building_service }
     end
@@ -331,7 +331,7 @@ module FacilitiesManagement::RM3830
         number_of_floors = service_volume_column[row]
         break if number_of_floors.nil?
 
-        procurement_building_service.lifts.build(number_of_floors: number_of_floors)
+        procurement_building_service.lifts.build(number_of_floors:)
       end
     end
 
@@ -352,7 +352,7 @@ module FacilitiesManagement::RM3830
     end
 
     def skip_building?(procurement_building)
-      (procurement_building.service_codes & SERVICE_HOUR_CODES).empty?
+      !procurement_building.service_codes.intersect?(SERVICE_HOUR_CODES)
     end
 
     def get_service_hours_from_sheet(sheet, col)
@@ -475,7 +475,7 @@ module FacilitiesManagement::RM3830
         save_procurement_building_services(building)
       end
 
-      @procurement.update(service_codes: service_codes)
+      @procurement.update(service_codes:)
     end
 
     def delete_existing_procurement_buildings_and_services
@@ -523,7 +523,7 @@ module FacilitiesManagement::RM3830
 
     def save_lift_data(procurement_building_service, object)
       object.lift_data.each do |number_of_floors|
-        procurement_building_service.lifts.create(number_of_floors: number_of_floors)
+        procurement_building_service.lifts.create(number_of_floors:)
       end
     end
 

--- a/app/services/facilities_management/rm3830/summary_report.rb
+++ b/app/services/facilities_management/rm3830/summary_report.rb
@@ -223,10 +223,10 @@ module FacilitiesManagement
           sum_benchmark = uvals_remove_cafm_help.sum { |v| calc_fm.initialize_service_variables(v[:service_code], v[:service_standard], v[:uom_value], v[:occupants]).calculate_total }
         end
 
-        return { sum_uom: sum_uom, results: results } if supplier_id
+        return { sum_uom:, results: } if supplier_id
 
-        { sum_uom: sum_uom,
-          sum_benchmark: sum_benchmark }
+        { sum_uom:,
+          sum_benchmark: }
       end
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/CyclomaticComplexity

--- a/app/services/facilities_management/rm3830/supplier_shortlist_spreadsheet_creator.rb
+++ b/app/services/facilities_management/rm3830/supplier_shortlist_spreadsheet_creator.rb
@@ -11,7 +11,7 @@ module FacilitiesManagement
 
       def set_data
         @regions = FacilitiesManagement::Region.where(code: @region_codes)
-        @services = @service_codes.index_with { |code| Service.find_by(code: code).name }
+        @services = @service_codes.index_with { |code| Service.find_by(code:).name }
 
         @lot_1a_suppliers = suppliers_for_lot('1a')
         @lot_1b_suppliers = suppliers_for_lot('1b')

--- a/app/services/facilities_management/rm6232/admin/supplier_spreadsheet.rb
+++ b/app/services/facilities_management/rm6232/admin/supplier_spreadsheet.rb
@@ -26,10 +26,10 @@ module FacilitiesManagement::RM6232
 
       private
 
-      def add_styles(&block)
+      def add_styles(&)
         @styles = {}
 
-        @workbook.styles(&block)
+        @workbook.styles(&)
       end
 
       def lot_suppliers(lot_code)

--- a/config/initializers/cognito_authenticable.rb
+++ b/config/initializers/cognito_authenticable.rb
@@ -24,7 +24,7 @@ module Devise
       end
 
       def find_or_create_user
-        user = User.find_for_authentication(email: email)
+        user = User.find_for_authentication(email:)
         user ? update_if_needed(user) : create_user_in_database
       end
 

--- a/db/migrate/20201210141943_add_data_to_fm_suppliers.rb
+++ b/db/migrate/20201210141943_add_data_to_fm_suppliers.rb
@@ -13,7 +13,7 @@ class AddDataToFmSuppliers < ActiveRecord::Migration[5.2]
 
     SupplierDetail.all.each do |supplier_detail|
       contact_email = supplier_detail.contact_email
-      fm_supplier = FMSupplier.find_by(contact_email: contact_email)
+      fm_supplier = FMSupplier.find_by(contact_email:)
       next if fm_supplier.blank?
 
       fm_supplier.assign_attributes(

--- a/features/helpers/crown_marketplace/cognito_helper.rb
+++ b/features/helpers/crown_marketplace/cognito_helper.rb
@@ -27,7 +27,7 @@ end
 def stub_list_users(aws_client, **options)
   users = options[:resp_email] ? [options[:resp_email]] : []
 
-  allow(aws_client).to receive(:list_users).with(**list_users_params(options[:search_email])).and_return(COGNITO_RESPONSE_STRUCTS[:list_users].new(users: users))
+  allow(aws_client).to receive(:list_users).with(**list_users_params(options[:search_email])).and_return(COGNITO_RESPONSE_STRUCTS[:list_users].new(users:))
 end
 
 # rubocop:disable Metrics/AbcSize

--- a/features/helpers/facilities_management/step_helper.rb
+++ b/features/helpers/facilities_management/step_helper.rb
@@ -20,7 +20,7 @@ def format_date_period(start_date, end_date)
 end
 
 def find_building(building_name)
-  @user.buildings.find_by(building_name: building_name)
+  @user.buildings.find_by(building_name:)
 end
 
 def find_supplier

--- a/features/step_definitions/facilities_management/rm3830/framework_status_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/framework_status_steps.rb
@@ -1,5 +1,5 @@
 Given('the {string} framework has expired') do |framework|
-  Framework.find_by(framework: framework).update(expires_at: 1.day.ago)
+  Framework.find_by(framework:).update(expires_at: 1.day.ago)
 end
 
 Then('I should see the following warning text:') do |warning_text_table|

--- a/features/step_definitions/facilities_management/rm3830/procurement_steps.rb
+++ b/features/step_definitions/facilities_management/rm3830/procurement_steps.rb
@@ -32,11 +32,11 @@ Given('I have direct award procurements') do
 end
 
 Given('the GIA for {string} is {int}') do |building_name, gia|
-  find_building(building_name).update(gia: gia)
+  find_building(building_name).update(gia:)
 end
 
 Given('the external area for {string} is {int}') do |building_name, external_area|
-  find_building(building_name).update(external_area: external_area)
+  find_building(building_name).update(external_area:)
 end
 
 Given('I navigate to the service requirements page') do

--- a/features/step_definitions/facilities_management/rm6232/admin_steps.rb
+++ b/features/step_definitions/facilities_management/rm6232/admin_steps.rb
@@ -197,7 +197,7 @@ Then('I should see the following changes to the lot status:') do |changes_table|
 end
 
 Given('the user {string} has uploaded some data') do |email|
-  new_user = create(:user, email: email)
+  new_user = create(:user, email:)
   new_upload = create(:facilities_management_rm6232_admin_upload, user: new_user, aasm_state: 'published')
   FacilitiesManagement::RM6232::Admin::SupplierData.create(upload: new_upload)
 end

--- a/lib/tasks/ordnance_survey.rb
+++ b/lib/tasks/ordnance_survey.rb
@@ -291,7 +291,7 @@ module OrdnanceSurvey
 
     awd_credentials access_key, secret_key, bucket, region
 
-    object = Aws::S3::Resource.new(region: region)
+    object = Aws::S3::Resource.new(region:)
     beginning_time = Time.current
     object.bucket(bucket).objects.each do |obj|
       next if obj.key == "#{folder_root}/" || !obj.key.starts_with?(folder_root)

--- a/lib/tasks/os_data_processing.rb
+++ b/lib/tasks/os_data_processing.rb
@@ -125,7 +125,7 @@ module OrdnanceSurvey
     return upsert_csv_data(csv_stream) unless type == :dat
   end
 
-  def self.handle_tar_contents(tar, summary, &block)
+  def self.handle_tar_contents(tar, summary, &)
     tar.each do |entry|
       next unless entry.file?
 
@@ -138,11 +138,11 @@ module OrdnanceSurvey
       else
         :dat
       end)) and file_stream.rewind
-      summary[:md5] = chunk_file_data(file_stream, meta_type, &block)
+      summary[:md5] = chunk_file_data(file_stream, meta_type, &)
     end
   end
 
-  def self.handle_gzip_contents(gzip, summary, &block)
+  def self.handle_gzip_contents(gzip, summary, &)
     header_line = gzip.readline
     (meta_type = (
     if header_line.downcase.include?('uprn')
@@ -150,11 +150,11 @@ module OrdnanceSurvey
     else
       :dat
     end)) and gzip.rewind
-    summary[:md5]    = chunk_file_data(gzip, meta_type, &block)
+    summary[:md5]    = chunk_file_data(gzip, meta_type, &)
     summary[:length] = gzip.pos
   end
 
-  def self.handle_zip_contents(io, summary, &block)
+  def self.handle_zip_contents(io, summary, &)
     while (entry = io.get_next_entry)
       next if entry.name_is_directory?
 
@@ -166,7 +166,7 @@ module OrdnanceSurvey
         :dat
       end)) and io.rewind
       summary[:length] = entry.size
-      summary[:md5]    = chunk_file_data(io, meta_type, &block)
+      summary[:md5]    = chunk_file_data(io, meta_type, &)
     end
   end
 

--- a/lib/tasks/os_file_handler.rb
+++ b/lib/tasks/os_file_handler.rb
@@ -27,7 +27,7 @@ module OrdnanceSurvey
     block.call(data_summary)
   end
 
-  def self.stream_file(filename, data_summary, &block)
+  def self.stream_file(filename, data_summary, &)
     data_summary[:updated_time] = File.mtime(filename)
     data_summary[:length]       = File.size(filename)
     file_io                     = File.new(filename, 'r')
@@ -38,7 +38,7 @@ module OrdnanceSurvey
     else
       :dat
     end)) and file_io.rewind
-    data_summary[:md5] = chunk_file_data(file_io, meta_type, &block)
+    data_summary[:md5] = chunk_file_data(file_io, meta_type, &)
   rescue StandardError => e
     data_summary[:fail] = e.message
     raise e
@@ -46,24 +46,24 @@ module OrdnanceSurvey
     file_io&.try(&:close)
   end
 
-  def self.untar_file(filename, summary, &block)
+  def self.untar_file(filename, summary, &)
     summary[:updated_time] = File.mtime(filename)
     Gem::Package::TarReader.new(Zlib::GzipReader.open(filename)) do |tar|
-      handle_tar_contents(tar, summary, &block)
+      handle_tar_contents(tar, summary, &)
     end
   end
 
-  def self.gunzip_file(filename, summary, &block)
+  def self.gunzip_file(filename, summary, &)
     summary[:updated_time] = File.mtime(filename)
     Zlib::GzipReader.open(filename) do |gz|
-      handle_gzip_contents(gz, summary, &block)
+      handle_gzip_contents(gz, summary, &)
     end
   end
 
-  def self.unzip_file(filename, summary, &block)
+  def self.unzip_file(filename, summary, &)
     summary[:updated_time] = File.mtime(filename)
     Zip::InputStream.open(filename) do |io|
-      handle_zip_contents(io, summary, &block)
+      handle_zip_contents(io, summary, &)
     end
   end
 end

--- a/lib/tasks/os_stream_handler.rb
+++ b/lib/tasks/os_stream_handler.rb
@@ -32,7 +32,7 @@ module OrdnanceSurvey
   end
   # rubocop:enable  Metrics/AbcSize
 
-  def self.stream_url(obj, data_summary, &_block)
+  def self.stream_url(obj, data_summary, &)
     meta_type   = :dat
     chunk_count = -1
     chunks      = ''
@@ -52,21 +52,21 @@ module OrdnanceSurvey
     raise e
   end
 
-  def self.untar_stream(url, summary, &block)
+  def self.untar_stream(url, summary, &)
     Gem::Package::TarReader.new(Zlib::GzipReader.new(File.open(url))) do |tar|
-      handle_tar_contents(tar, summary, &block)
+      handle_tar_contents(tar, summary, &)
     end
   end
 
-  def self.gunzip_url(url, summary, &block)
+  def self.gunzip_url(url, summary, &)
     Zlib::GzipReader.open(File.open(url)) do |gz|
-      handle_gzip_contents(gz, summary, &block)
+      handle_gzip_contents(gz, summary, &)
     end
   end
 
-  def self.unzip_url(url, summary, &block)
+  def self.unzip_url(url, summary, &)
     Zip::InputStream.open(IO.popen(url)) do |io|
-      handle_zip_contents(io, summary, &block)
+      handle_zip_contents(io, summary, &)
     end
   end
 end

--- a/spec/calculators/facilities_management/rm3830/calculator_spec.rb
+++ b/spec/calculators/facilities_management/rm3830/calculator_spec.rb
@@ -507,7 +507,7 @@ RSpec.describe FacilitiesManagement::RM3830::Calculator do
   describe 'calculate total with different building types' do
     let(:supplier_id) { 'ef44b65d-de46-4297-8d2c-2c6130cecafc' }
     let(:calculator) { described_class.new(2.5, false, false, false, false, rates, rate_card, supplier_id, building) }
-    let(:building) { create(:facilities_management_building, building_type: building_type) }
+    let(:building) { create(:facilities_management_building, building_type:) }
     let(:service_standard) { 'A' }
     let(:occupants) { 0 }
 

--- a/spec/controllers/active_storage/blobs/redirect_controller_spec.rb
+++ b/spec/controllers/active_storage/blobs/redirect_controller_spec.rb
@@ -354,7 +354,7 @@ RSpec.describe ActiveStorage::Blobs::RedirectController do
       let(:filename) { procurement.security_policy_document_file.blob.filename }
       let(:object_id_key) { :procurement_id }
       let(:object_id) { procurement.id }
-      let(:procurement) { create(:facilities_management_rm3830_procurement_with_security_document, user: user) }
+      let(:procurement) { create(:facilities_management_rm3830_procurement_with_security_document, user:) }
       let(:user) { create(:user) }
 
       context 'when signed in as a buyer who created the procurement' do
@@ -452,7 +452,7 @@ RSpec.describe ActiveStorage::Blobs::RedirectController do
       let(:object_id_key) { :contract_id }
       let(:object_id) { contract.id }
       let(:contract) { create(:facilities_management_rm3830_procurement_supplier_with_contract_documents) }
-      let(:procurement) { create(:facilities_management_rm3830_procurement, user: user) }
+      let(:procurement) { create(:facilities_management_rm3830_procurement, user:) }
       let(:user) { create(:user) }
 
       context 'when signed in as a buyer who created the procurement' do

--- a/spec/controllers/crown_marketplace/allow_list_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/allow_list_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CrownMarketplace::AllowListController do
   describe 'POST create' do
     login_user_admin
 
-    before { post :create, params: { allowed_email_domain: { email_domain: email_domain } } }
+    before { post :create, params: { allowed_email_domain: { email_domain: } } }
 
     context 'when the email domain is not valid' do
       let(:email_domain) { 'Go Beyond Plus ULTRA!!!' }

--- a/spec/controllers/crown_marketplace/manage_users_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/manage_users_controller_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
 
       login_super_admin
 
-      before { get :add_user, params: { section: section, **additional_params } }
+      before { get :add_user, params: { section:, **additional_params } }
 
       context 'and the section is select-role' do
         let(:section) { 'select-role' }
@@ -344,7 +344,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
 
       context 'and the section is select-role' do
         let(:section) { 'select-role' }
-        let(:create_add_user_params) { { roles: roles } }
+        let(:create_add_user_params) { { roles: } }
 
         context 'and the data is valid' do
           let(:roles) { ['buyer'] }
@@ -476,7 +476,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
     before do
       allow(Cognito::Admin::User).to receive(:find).and_return(user)
 
-      get :show, params: { cognito_uuid: cognito_uuid }
+      get :show, params: { cognito_uuid: }
     end
 
     context 'when the current user has edit permissions and successfully looks up a user' do
@@ -538,7 +538,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
         before { get :edit, params: { cognito_uuid: cognito_uuid, section: :bank_account } }
 
         it 'redirects to the show page' do
-          expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid: cognito_uuid)
+          expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid:)
         end
       end
 
@@ -549,7 +549,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
           before { get :edit, params: { cognito_uuid: cognito_uuid, section: unpermitted_section } }
 
           it "redirects to the show page for #{unpermitted_section}" do
-            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid: cognito_uuid)
+            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid:)
           end
         end
       end
@@ -563,7 +563,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
       before do
         allow(Cognito::Admin::User).to receive(:find).and_return(user)
 
-        get :edit, params: { cognito_uuid: cognito_uuid, section: section }
+        get :edit, params: { cognito_uuid:, section: }
       end
 
       context 'and I edit the users email_verified' do
@@ -663,7 +663,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
         before { put :update, params: { cognito_uuid: cognito_uuid, section: :bank_account } }
 
         it 'redirects to the show page' do
-          expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid: cognito_uuid)
+          expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid:)
         end
       end
 
@@ -674,7 +674,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
           before { put :update, params: { cognito_uuid: cognito_uuid, section: unpermitted_section } }
 
           it "redirects to the show page for #{unpermitted_section}" do
-            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid: cognito_uuid)
+            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid:)
           end
         end
       end
@@ -705,7 +705,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
           end
 
           it 'redirects to the show page' do
-            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid: cognito_uuid)
+            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid:)
           end
         end
 
@@ -732,7 +732,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
           end
 
           it 'redirects to the show page' do
-            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid: cognito_uuid)
+            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid:)
           end
         end
 
@@ -759,7 +759,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
           end
 
           it 'redirects to the show page' do
-            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid: cognito_uuid)
+            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid:)
           end
         end
 
@@ -786,7 +786,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
           end
 
           it 'redirects to the show page' do
-            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid: cognito_uuid)
+            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid:)
           end
         end
 
@@ -813,7 +813,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
           end
 
           it 'redirects to the show page' do
-            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid: cognito_uuid)
+            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid:)
           end
         end
 
@@ -840,7 +840,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
           end
 
           it 'redirects to the show page' do
-            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid: cognito_uuid)
+            expect(response).to redirect_to crown_marketplace_manage_user_path(cognito_uuid:)
           end
         end
 
@@ -865,7 +865,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
 
       login_super_admin
 
-      before { put :resend_temporary_password, params: { cognito_uuid: cognito_uuid } }
+      before { put :resend_temporary_password, params: { cognito_uuid: } }
 
       it 'redirects to the crown marketplace home page and sets the flash message' do
         expect(response).to redirect_to crown_marketplace_path
@@ -879,7 +879,7 @@ RSpec.describe CrownMarketplace::ManageUsersController do
       before do
         allow(user).to receive(:resend_temporary_password).and_return(resend_temporary_password_response)
 
-        put :resend_temporary_password, params: { cognito_uuid: cognito_uuid }
+        put :resend_temporary_password, params: { cognito_uuid: }
       end
 
       context 'and there is an error' do

--- a/spec/controllers/crown_marketplace/passwords_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/passwords_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CrownMarketplace::PasswordsController do
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
         # rubocop:enable RSpec/AnyInstance
-        post :create, params: { email: email }
+        post :create, params: { email: }
         cookies.update(response.cookies)
       end
 

--- a/spec/controllers/crown_marketplace/sessions_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/sessions_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe CrownMarketplace::SessionsController do
       before do
         allow(aws_client).to receive(:initiate_auth).and_return(initiate_auth_resp_struct.new(challenge_name: challenge_name, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
         allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
         post :create, params: { user: { email: email, password: 'Password12345!' } }
         cookies.update(response.cookies)
@@ -91,7 +91,7 @@ RSpec.describe CrownMarketplace::SessionsController do
         let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
 
         it 'redirects to crown_marketplace_users_challenge_path' do
-          expect(response).to redirect_to crown_marketplace_users_challenge_path(challenge_name: challenge_name)
+          expect(response).to redirect_to crown_marketplace_users_challenge_path(challenge_name:)
         end
 
         it 'the cookies are updated correctly' do

--- a/spec/controllers/crown_marketplace/users_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/users_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CrownMarketplace::UsersController do
 
     before do
       cookies[:crown_marketplace_challenge_username] = user.cognito_uuid
-      get :challenge_new, params: { challenge_name: challenge_name }
+      get :challenge_new, params: { challenge_name: }
     end
 
     render_views
@@ -53,7 +53,7 @@ RSpec.describe CrownMarketplace::UsersController do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
         post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
         cookies.update(response.cookies)
@@ -107,9 +107,9 @@ RSpec.describe CrownMarketplace::UsersController do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
-        post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+        post :challenge, params: { challenge_name:, username:, session:, access_code: }
         cookies.update(response.cookies)
       end
 

--- a/spec/controllers/facilities_management/admin/frameworks_controller_spec.rb
+++ b/spec/controllers/facilities_management/admin/frameworks_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe FacilitiesManagement::Admin::FrameworksController do
     let(:live_at_mm) { framework.live_at.month.to_s }
     let(:live_at_dd) { framework.live_at.day.to_s }
 
-    before { post :update, params: { id: framework.id, framework: { live_at_dd: live_at_dd, live_at_mm: live_at_mm, live_at_yyyy: live_at_yyyy } } }
+    before { post :update, params: { id: framework.id, framework: { live_at_dd:, live_at_mm:, live_at_yyyy: } } }
 
     context 'when the data is valid' do
       it 'redirects to facilities_management_admin_frameworks_path' do

--- a/spec/controllers/facilities_management/admin/supplier_details_controller_rm3830_spec.rb
+++ b/spec/controllers/facilities_management/admin/supplier_details_controller_rm3830_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController do
 
       context 'when updating on the supplier name page' do
         let(:page) { :supplier_name }
-        let(:supplier_params) { { supplier_name: supplier_name } }
+        let(:supplier_params) { { supplier_name: } }
 
         context 'and the data is not valid' do
           let(:supplier_name) { '' }
@@ -305,7 +305,7 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController do
       context 'when updating on the supplier user page' do
         let(:user) { create(:user, roles: :supplier) }
         let(:page) { :supplier_user }
-        let(:supplier_params) { { user_email: user_email } }
+        let(:supplier_params) { { user_email: } }
 
         context 'and the data is not valid' do
           let(:user_email) { 'AAA111' }

--- a/spec/controllers/facilities_management/admin/supplier_details_controller_rm6232_spec.rb
+++ b/spec/controllers/facilities_management/admin/supplier_details_controller_rm6232_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsController do
 
       context 'when updating on the supplier name page' do
         let(:page) { :supplier_name }
-        let(:supplier_params) { { supplier_name: supplier_name } }
+        let(:supplier_params) { { supplier_name: } }
 
         context 'and the data is not valid' do
           let(:supplier_name) { '' }

--- a/spec/controllers/facilities_management/buyer_details_controller_spec.rb
+++ b/spec/controllers/facilities_management/buyer_details_controller_spec.rb
@@ -77,7 +77,7 @@ module FacilitiesManagement
       login_fm_buyer_with_details
 
       context 'when updating from the edit page' do
-        before { put :update, params: { id: subject.current_user.id, facilities_management_buyer_detail: { full_name: full_name } } }
+        before { put :update, params: { id: subject.current_user.id, facilities_management_buyer_detail: { full_name: } } }
 
         context 'when there are errors' do
           let(:full_name) { '' }
@@ -91,7 +91,7 @@ module FacilitiesManagement
           let(:full_name) { 'Fred Flintstone' }
 
           it 'redirects to facilities_management_index_path' do
-            expect(response).to redirect_to facilities_management_index_path(framework: framework)
+            expect(response).to redirect_to facilities_management_index_path(framework:)
           end
 
           it 'updates the buyer name' do
@@ -103,7 +103,7 @@ module FacilitiesManagement
       end
 
       context 'when updating from the edit_address page' do
-        before { put :update, params: { id: subject.current_user.id, context: :update_address, facilities_management_buyer_detail: { organisation_address_line_1: organisation_address_line_1 } } }
+        before { put :update, params: { id: subject.current_user.id, context: :update_address, facilities_management_buyer_detail: { organisation_address_line_1: } } }
 
         context 'when there are errors' do
           let(:organisation_address_line_1) { '' }

--- a/spec/controllers/facilities_management/rm3830/admin/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/passwords_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::PasswordsController do
     context 'when the framework is live' do
       context 'when no exception is raised' do
         before do
-          post :create, params: { email: email }
+          post :create, params: { email: }
           cookies.update(response.cookies)
         end
 
@@ -103,7 +103,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::PasswordsController do
       include_context 'and RM3830 has expired'
 
       before do
-        post :create, params: { email: email }
+        post :create, params: { email: }
         cookies.update(response.cookies)
       end
 

--- a/spec/controllers/facilities_management/rm3830/admin/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/sessions_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController do
       before do
         allow(aws_client).to receive(:initiate_auth).and_return(initiate_auth_resp_struct.new(challenge_name: challenge_name, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
         allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
       end
 
       # rubocop:disable RSpec/NestedGroups
@@ -107,7 +107,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SessionsController do
           let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
 
           it 'redirects to facilities_management_rm3830_admin_users_challenge_path' do
-            expect(response).to redirect_to facilities_management_rm3830_admin_users_challenge_path(challenge_name: challenge_name)
+            expect(response).to redirect_to facilities_management_rm3830_admin_users_challenge_path(challenge_name:)
           end
 
           it 'the cookies are updated correctly' do

--- a/spec/controllers/facilities_management/rm3830/admin/uploads_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/uploads_controller_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UploadsController do
     let(:file) { Tempfile.new(['valid_file', '.xlsx']) }
     let(:fake_file) { File.open(file.path) }
     let(:upload) do
-      create(:facilities_management_rm3830_admin_upload, aasm_state: aasm_state) do |admin_upload|
+      create(:facilities_management_rm3830_admin_upload, aasm_state:) do |admin_upload|
         admin_upload.supplier_data_file.attach(io: fake_file, filename: 'test_supplier_framework_data_file.xlsx')
       end
     end

--- a/spec/controllers/facilities_management/rm3830/admin/users_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/users_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController do
     before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
     context 'when the framework is live' do
-      before { get :challenge_new, params: { challenge_name: challenge_name } }
+      before { get :challenge_new, params: { challenge_name: } }
 
       render_views
 
@@ -33,7 +33,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController do
     context 'when the framework is not live' do
       include_context 'and RM3830 has expired'
 
-      before { get :challenge_new, params: { challenge_name: challenge_name } }
+      before { get :challenge_new, params: { challenge_name: } }
 
       render_views
 
@@ -78,7 +78,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
       end
 
       context 'when the framework is live' do
@@ -154,12 +154,12 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
       end
 
       context 'when the framework is live' do
         before do
-          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          post :challenge, params: { challenge_name:, username:, session:, access_code: }
           cookies.update(response.cookies)
         end
 
@@ -192,7 +192,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::UsersController do
         include_context 'and RM3830 has expired'
 
         before do
-          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          post :challenge, params: { challenge_name:, username:, session:, access_code: }
           cookies.update(response.cookies)
         end
 

--- a/spec/controllers/facilities_management/rm3830/buildings_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/buildings_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe FacilitiesManagement::RM3830::BuildingsController do
   let(:default_params) { { service: 'facilities_management', framework: framework } }
   let(:framework) { 'RM3830' }
-  let(:building) { create(:facilities_management_building, user: user) }
+  let(:building) { create(:facilities_management_building, user:) }
   let(:user) { controller.current_user }
 
   describe 'GET #index' do

--- a/spec/controllers/facilities_management/rm3830/edit_buildings_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/edit_buildings_controller_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe FacilitiesManagement::RM3830::EditBuildingsController do
   let(:default_params) { { service: 'facilities_management', framework: framework } }
   let(:framework) { 'RM3830' }
-  let(:building) { create(:facilities_management_building, user: user) }
-  let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, user: user) }
+  let(:building) { create(:facilities_management_building, user:) }
+  let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, user:) }
   let(:user) { controller.current_user }
 
   describe 'GET #show' do

--- a/spec/controllers/facilities_management/rm3830/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/passwords_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe FacilitiesManagement::RM3830::PasswordsController do
           # rubocop:disable RSpec/AnyInstance
           allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
           # rubocop:enable RSpec/AnyInstance
-          post :create, params: { email: email }
+          post :create, params: { email: }
           cookies.update(response.cookies)
         end
 

--- a/spec/controllers/facilities_management/rm3830/procurement_buildings_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/procurement_buildings_controller_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM3830::ProcurementBuildingsController do
   let(:default_params) { { service: 'facilities_management', framework: 'RM3830' } }
-  let(:procurement_building) { create(:facilities_management_rm3830_procurement_building, procurement: procurement) }
-  let(:procurement) { create(:facilities_management_rm3830_procurement, user: user) }
+  let(:procurement_building) { create(:facilities_management_rm3830_procurement_building, procurement:) }
+  let(:procurement) { create(:facilities_management_rm3830_procurement, user:) }
   let(:user) { controller.current_user }
 
   login_fm_buyer_with_details
@@ -195,8 +195,8 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuildingsController do
   end
 
   describe 'GET missing_regions' do
-    let(:building) { create(:facilities_management_building, user: user, **building_params) }
-    let(:procurement_building) { create(:facilities_management_rm3830_procurement_building_no_services, procurement: procurement, building: building) }
+    let(:building) { create(:facilities_management_building, user:, **building_params) }
+    let(:procurement_building) { create(:facilities_management_rm3830_procurement_building_no_services, procurement:, building:) }
     let(:procurement) { create(:facilities_management_rm3830_procurement_entering_requirements, user: user, procurement_buildings_attributes: { '0': { building_id: building.id, active: true } }) }
     let(:building_params) { {} }
 

--- a/spec/controllers/facilities_management/rm3830/procurement_buildings_services_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/procurement_buildings_services_controller_spec.rb
@@ -352,8 +352,8 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuildingsServicesControl
 
       before do
         procurement_building_service.procurement_building.update(service_codes: codes)
-        procurement_building_service.update(code: code)
-        patch :update, params: { id: procurement_building_service.id, facilities_management_rm3830_procurement_building_service: { service_question: 'area' }, facilities_management_building: { gia: gia, external_area: external_area } }
+        procurement_building_service.update(code:)
+        patch :update, params: { id: procurement_building_service.id, facilities_management_rm3830_procurement_building_service: { service_question: 'area' }, facilities_management_building: { gia:, external_area: } }
       end
 
       context 'when the area updated is invalid' do

--- a/spec/controllers/facilities_management/rm3830/procurement_details_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/procurement_details_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM3830::ProcurementDetailsController do
   let(:default_params) { { service: 'facilities_management', framework: 'RM3830' } }
-  let(:procurement) { create(:facilities_management_rm3830_procurement_entering_requirements, user: user) }
+  let(:procurement) { create(:facilities_management_rm3830_procurement_entering_requirements, user:) }
   let(:user) { controller.current_user }
 
   login_fm_buyer_with_details
@@ -78,7 +78,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementDetailsController do
 
     context 'when the user wants to edit services' do
       let(:section_name) { 'services' }
-      let(:procurement_options) { { service_codes: service_codes } }
+      let(:procurement_options) { { service_codes: } }
 
       context 'when the services are not complete' do
         let(:service_codes) { [] }
@@ -113,7 +113,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementDetailsController do
       end
 
       context 'when there are active_procurement_buildings' do
-        let(:building) { create(:facilities_management_building, user: user) }
+        let(:building) { create(:facilities_management_building, user:) }
         let(:procurement_options) { { procurement_buildings_attributes: { '0': { building_id: building.id, active: true } } } }
 
         render_views
@@ -135,7 +135,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementDetailsController do
 
     context 'when the user wants to assign services to buildings' do
       let(:section_name) { 'buildings-and-services' }
-      let(:building) { create(:facilities_management_building, user: user) }
+      let(:building) { create(:facilities_management_building, user:) }
       let(:procurement_options) { { procurement_buildings_attributes: { '0': { building_id: building.id, active: true } } } }
 
       render_views
@@ -156,7 +156,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementDetailsController do
 
     context 'when the user wants to view the service requirements' do
       let(:section_name) { 'service-requirements' }
-      let(:building) { create(:facilities_management_building, user: user) }
+      let(:building) { create(:facilities_management_building, user:) }
       let(:procurement_options) { { procurement_buildings_attributes: { '0': { building_id: building.id, active: true, service_codes: %w[E.1 E.2] } } } }
 
       render_views
@@ -258,7 +258,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementDetailsController do
       end
 
       context 'when the procurement already has extensions' do
-        let(:procurement) { create(:facilities_management_rm3830_procurement_with_extension_periods, user: user) }
+        let(:procurement) { create(:facilities_management_rm3830_procurement_with_extension_periods, user:) }
 
         it 'finds the extensions' do
           expect(assigns(:procurement).call_off_extensions.length).to eq 4
@@ -303,7 +303,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementDetailsController do
         before do
           allow(FacilitiesManagement::Building).to receive(:default_per_page).and_return(5)
 
-          ('aa'..'af').each { |building_name| create(:facilities_management_building, user: user, building_name: building_name) }
+          ('aa'..'af').each { |building_name| create(:facilities_management_building, user:, building_name:) }
         end
 
         context 'and none are active' do
@@ -701,9 +701,9 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementDetailsController do
 
     context 'when updating buildings' do
       let(:section_name) { 'buildings' }
-      let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, user: user) }
+      let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, user:) }
       let(:building) { procurement.procurement_buildings.first.building }
-      let(:new_building) { create(:facilities_management_building, user: user) }
+      let(:new_building) { create(:facilities_management_building, user:) }
 
       context 'and the data is valid' do
         let(:update_params) { { procurement_buildings_attributes: { '0': { active: '1', building_id: building.id }, '2': { active: '1', building_id: new_building.id } } } }
@@ -765,7 +765,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementDetailsController do
   end
 
   describe 'paginating the buildings page' do
-    let(:procurement) { create(:facilities_management_rm3830_procurement_entering_requirements_with_buildings, user: user) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_entering_requirements_with_buildings, user:) }
 
     let(:building1) { create(:facilities_management_building, user: procurement.user, building_name: 'Building 1') }
     let(:building2) { create(:facilities_management_building, user: procurement.user, building_name: 'Building 2') }

--- a/spec/controllers/facilities_management/rm3830/procurements/contract_details_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/procurements/contract_details_controller_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
       context 'when on the payment method page' do
         before do
-          put :update, params: { procurement_id: procurement.id, page: 'payment_method', facilities_management_rm3830_procurement: { payment_method: payment_method } }
+          put :update, params: { procurement_id: procurement.id, page: 'payment_method', facilities_management_rm3830_procurement: { payment_method: } }
         end
 
         context 'when nothing is selected' do
@@ -419,14 +419,14 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
         before do
           procurement.invoice_contact_detail = invoice_contact_detail
-          put :update, params: { procurement_id: procurement.id, page: 'invoicing_contact_details', facilities_management_rm3830_procurement: { using_buyer_detail_for_invoice_details: using_buyer_detail_for_invoice_details } }
+          put :update, params: { procurement_id: procurement.id, page: 'invoicing_contact_details', facilities_management_rm3830_procurement: { using_buyer_detail_for_invoice_details: } }
         end
 
         context 'when not using existing invoicing contact details' do
           let(:using_buyer_detail_for_invoice_details) { false }
 
           context 'and invoicing contact details exist' do
-            let(:invoice_contact_detail) { create(:facilities_management_rm3830_procurement_invoice_contact_detail, procurement: procurement) }
+            let(:invoice_contact_detail) { create(:facilities_management_rm3830_procurement_invoice_contact_detail, procurement:) }
 
             it 'will redirect to facilities_management_rm3830_procurement_contract_details_path if the invoice_contact_detail is not blank' do
               expect(response).to redirect_to facilities_management_rm3830_procurement_contract_details_path
@@ -466,14 +466,14 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
         before do
           procurement.authorised_contact_detail = authorised_contact_detail
-          put :update, params: { procurement_id: procurement.id, page: 'authorised_representative', facilities_management_rm3830_procurement: { using_buyer_detail_for_authorised_detail: using_buyer_detail_for_authorised_detail } }
+          put :update, params: { procurement_id: procurement.id, page: 'authorised_representative', facilities_management_rm3830_procurement: { using_buyer_detail_for_authorised_detail: } }
         end
 
         context 'when not using existing authorised contact details' do
           let(:using_buyer_detail_for_authorised_detail) { false }
 
           context 'and authorised contact details exist' do
-            let(:authorised_contact_detail) { create(:facilities_management_rm3830_procurement_authorised_contact_detail, procurement: procurement) }
+            let(:authorised_contact_detail) { create(:facilities_management_rm3830_procurement_authorised_contact_detail, procurement:) }
 
             it 'will redirect to facilities_management_rm3830_procurement_contract_details_path if the invoice_contact_detail is not blank' do
               expect(response).to redirect_to facilities_management_rm3830_procurement_contract_details_path
@@ -513,14 +513,14 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
         before do
           procurement.notices_contact_detail = notices_contact_detail
-          put :update, params: { procurement_id: procurement.id, page: 'notices_contact_details', facilities_management_rm3830_procurement: { using_buyer_detail_for_notices_detail: using_buyer_detail_for_notices_detail } }
+          put :update, params: { procurement_id: procurement.id, page: 'notices_contact_details', facilities_management_rm3830_procurement: { using_buyer_detail_for_notices_detail: } }
         end
 
         context 'when not using existing notices contact details' do
           let(:using_buyer_detail_for_notices_detail) { false }
 
           context 'and notices contact details exist' do
-            let(:notices_contact_detail) { create(:facilities_management_rm3830_procurement_notices_contact_detail, procurement: procurement) }
+            let(:notices_contact_detail) { create(:facilities_management_rm3830_procurement_notices_contact_detail, procurement:) }
 
             it 'will redirect to facilities_management_rm3830_procurement_contract_details_path if the invoice_contact_detail is not blank' do
               expect(response).to redirect_to facilities_management_rm3830_procurement_contract_details_path
@@ -560,7 +560,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
       end
 
       context 'when continuing to invoicing contact details from the new invoicing contact details page' do
-        let(:empty_invoice_contact_detail) { create(:facilities_management_rm3830_procurement_invoice_contact_detail_empty, procurement: procurement) }
+        let(:empty_invoice_contact_detail) { create(:facilities_management_rm3830_procurement_invoice_contact_detail_empty, procurement:) }
         let(:invoice_contact_detail) { create(:facilities_management_rm3830_procurement_invoice_contact_detail) }
 
         before do
@@ -598,7 +598,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
       end
 
       context 'when continuing to authorised representative details from the new authorised representative details page' do
-        let(:empty_authorised_contact_detail) { create(:facilities_management_rm3830_procurement_authorised_contact_detail_empty, procurement: procurement) }
+        let(:empty_authorised_contact_detail) { create(:facilities_management_rm3830_procurement_authorised_contact_detail_empty, procurement:) }
         let(:authorised_contact_detail) { create(:facilities_management_rm3830_procurement_authorised_contact_detail) }
 
         before do
@@ -636,7 +636,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
       end
 
       context 'when continuing to notices contact details from the new notices contact details page' do
-        let(:empty_notices_contact_detail) { create(:facilities_management_rm3830_procurement_notices_contact_detail_empty, procurement: procurement) }
+        let(:empty_notices_contact_detail) { create(:facilities_management_rm3830_procurement_notices_contact_detail_empty, procurement:) }
         let(:notices_contact_detail) { create(:facilities_management_rm3830_procurement_notices_contact_detail) }
 
         before do
@@ -678,7 +678,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
       end
 
       context 'when continuing to new invoicing contact details from the add address page' do
-        let(:empty_invoice_contact_detail) { create(:facilities_management_rm3830_procurement_invoice_contact_detail_empty, procurement: procurement) }
+        let(:empty_invoice_contact_detail) { create(:facilities_management_rm3830_procurement_invoice_contact_detail_empty, procurement:) }
         let(:invoice_contact_detail) { create(:facilities_management_rm3830_procurement_invoice_contact_detail) }
 
         before do
@@ -713,7 +713,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
       end
 
       context 'when continuing to new authorised representative details from the add address page' do
-        let(:empty_authorised_contact_detail) { create(:facilities_management_rm3830_procurement_authorised_contact_detail_empty, procurement: procurement) }
+        let(:empty_authorised_contact_detail) { create(:facilities_management_rm3830_procurement_authorised_contact_detail_empty, procurement:) }
         let(:authorised_contact_detail) { create(:facilities_management_rm3830_procurement_authorised_contact_detail) }
 
         before do
@@ -748,7 +748,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
       end
 
       context 'when continuing to new notices details from the add address page' do
-        let(:empty_notices_contact_detail) { create(:facilities_management_rm3830_procurement_notices_contact_detail_empty, procurement: procurement) }
+        let(:empty_notices_contact_detail) { create(:facilities_management_rm3830_procurement_notices_contact_detail_empty, procurement:) }
         let(:notices_contact_detail) { create(:facilities_management_rm3830_procurement_notices_contact_detail) }
 
         before do
@@ -844,7 +844,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
       context 'when on the Local Government Pension Scheme page' do
         before do
-          put :update, params: { procurement_id: procurement.id, page: 'local_government_pension_scheme', facilities_management_rm3830_procurement: { local_government_pension_scheme: local_government_pension_scheme } }
+          put :update, params: { procurement_id: procurement.id, page: 'local_government_pension_scheme', facilities_management_rm3830_procurement: { local_government_pension_scheme: } }
         end
 
         context 'when nothing is selected' do
@@ -878,7 +878,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
       context 'when adding new pensions' do
         before do
-          put :update, params: { procurement_id: procurement.id, page: 'pension_funds', facilities_management_rm3830_procurement: { procurement_pension_funds_attributes: procurement_pension_funds_attributes } }
+          put :update, params: { procurement_id: procurement.id, page: 'pension_funds', facilities_management_rm3830_procurement: { procurement_pension_funds_attributes: } }
         end
 
         context 'when valid pensions are entered' do
@@ -925,7 +925,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
       context 'when on the governing law page' do
         before do
-          put :update, params: { procurement_id: procurement.id, page: 'governing_law', facilities_management_rm3830_procurement: { governing_law: governing_law } }
+          put :update, params: { procurement_id: procurement.id, page: 'governing_law', facilities_management_rm3830_procurement: { governing_law: } }
         end
 
         context 'when nothing is selected' do
@@ -1256,7 +1256,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
     context 'when moving on and leaving invoicing contact details incomplete' do
       before do
-        create(:facilities_management_rm3830_procurement_invoice_contact_detail_empty, procurement: procurement)
+        create(:facilities_management_rm3830_procurement_invoice_contact_detail_empty, procurement:)
         procurement.update(using_buyer_detail_for_invoice_details: false)
       end
 
@@ -1323,7 +1323,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
     context 'when invoicing contact details are complete' do
       before do
-        create(:facilities_management_rm3830_procurement_invoice_contact_detail, procurement: procurement)
+        create(:facilities_management_rm3830_procurement_invoice_contact_detail, procurement:)
         procurement.update(using_buyer_detail_for_invoice_details: false)
       end
 
@@ -1354,7 +1354,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
     context 'when moving on and leaving authorised representative details incomplete' do
       before do
-        create(:facilities_management_rm3830_procurement_authorised_contact_detail_empty, procurement: procurement)
+        create(:facilities_management_rm3830_procurement_authorised_contact_detail_empty, procurement:)
         procurement.update(using_buyer_detail_for_authorised_detail: false)
       end
 
@@ -1421,7 +1421,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
     context 'when authorised representative details are complete' do
       before do
-        create(:facilities_management_rm3830_procurement_authorised_contact_detail, procurement: procurement)
+        create(:facilities_management_rm3830_procurement_authorised_contact_detail, procurement:)
         procurement.update(using_buyer_detail_for_authorised_detail: false)
       end
 
@@ -1452,7 +1452,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
     context 'when moving on and leaving notices contact details incomplete' do
       before do
-        create(:facilities_management_rm3830_procurement_notices_contact_detail_empty, procurement: procurement)
+        create(:facilities_management_rm3830_procurement_notices_contact_detail_empty, procurement:)
         procurement.update(using_buyer_detail_for_notices_detail: false)
       end
 
@@ -1519,7 +1519,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
     context 'when notices contact details are complete' do
       before do
-        create(:facilities_management_rm3830_procurement_notices_contact_detail, procurement: procurement)
+        create(:facilities_management_rm3830_procurement_notices_contact_detail, procurement:)
         procurement.update(using_buyer_detail_for_notices_detail: false)
       end
 
@@ -1600,7 +1600,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
       context 'when the pension funds are not empty' do
         before do
           procurement.update(local_government_pension_scheme: true)
-          create_list(:facilities_management_rm3830_procurement_pension_fund, 3, procurement: procurement)
+          create_list(:facilities_management_rm3830_procurement_pension_fund, 3, procurement:)
           get :show, params: { procurement_id: procurement.id }
         end
 
@@ -1632,7 +1632,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
         context 'when invoicing contact details already exist' do
           before do
-            procurement.update(invoice_contact_detail: invoice_contact_detail)
+            procurement.update(invoice_contact_detail:)
             get :edit, params: { procurement_id: procurement.id, page: 'new_invoicing_contact_details' }
           end
 
@@ -1665,7 +1665,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
         context 'when invoicing contact details already exist' do
           before do
-            procurement.update(authorised_contact_detail: authorised_contact_detail)
+            procurement.update(authorised_contact_detail:)
             get :edit, params: { procurement_id: procurement.id, page: 'new_invoicing_contact_details' }
           end
 
@@ -1698,7 +1698,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractDetailsContro
 
         context 'when notices contact details already exist' do
           before do
-            procurement.update(notices_contact_detail: notices_contact_detail)
+            procurement.update(notices_contact_detail:)
             get :edit, params: { procurement_id: procurement.id, page: 'new_notices_contact_details' }
           end
 

--- a/spec/controllers/facilities_management/rm3830/procurements/contracts_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/procurements/contracts_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractsController d
 
       before do
         first_contract.update(aasm_state: 'declined')
-        put :update, params: { procurement_id: procurement.id, id: first_contract.id, name: 'withdraw', facilities_management_rm3830_procurement_supplier: { reason_for_closing: reason_for_closing } }
+        put :update, params: { procurement_id: procurement.id, id: first_contract.id, name: 'withdraw', facilities_management_rm3830_procurement_supplier: { reason_for_closing: } }
       end
 
       context 'when a reason for closing is given' do
@@ -187,7 +187,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractsController d
 
   describe '.authorize_user' do
     let(:contract) { create(:facilities_management_rm3830_procurement_supplier) }
-    let(:procurement) { create(:facilities_management_rm3830_procurement, user: user) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement, user:) }
     let(:user) { create(:user, :with_detail, confirmed_at: Time.zone.now, roles: %i[buyer fm_access]) }
     let(:wrong_user) { create(:user, :with_detail, confirmed_at: Time.zone.now, roles: %i[buyer fm_access]) }
 
@@ -261,7 +261,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractsController d
 
   describe 'GET edit' do
     let(:procurement) { create(:facilities_management_rm3830_procurement, user: controller.current_user) }
-    let(:contract) { create(:facilities_management_rm3830_procurement_supplier_da_with_supplier, procurement: procurement) }
+    let(:contract) { create(:facilities_management_rm3830_procurement_supplier_da_with_supplier, procurement:) }
 
     login_fm_buyer_with_details
 

--- a/spec/controllers/facilities_management/rm3830/procurements/spreadsheet_imports_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/procurements/spreadsheet_imports_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe FacilitiesManagement::RM3830::Procurements::SpreadsheetImportsController do
   let(:default_params) { { service: 'facilities_management', framework: framework } }
   let(:framework) { 'RM3830' }
-  let(:spreadsheet_import) { create(:facilities_management_rm3830_procurement_spreadsheet_import, procurement: procurement) }
+  let(:spreadsheet_import) { create(:facilities_management_rm3830_procurement_spreadsheet_import, procurement:) }
   let(:procurement) { create(:facilities_management_rm3830_procurement, aasm_state: 'detailed_search_bulk_upload', user: subject.current_user) }
 
   login_fm_buyer_with_details

--- a/spec/controllers/facilities_management/rm3830/procurements_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/procurements_controller_spec.rb
@@ -766,7 +766,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementsController do
     login_fm_buyer_with_details
 
     before do
-      procurement.update(aasm_state: aasm_state)
+      procurement.update(aasm_state:)
       get :quick_view_results_spreadsheet, params: { procurement_id: procurement.id }
     end
 

--- a/spec/controllers/facilities_management/rm3830/registrations_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/registrations_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe FacilitiesManagement::RM3830::RegistrationsController do
           allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
           allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
           # rubocop:enable RSpec/AnyInstance
-          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          post :create, params: { user: { email:, password:, password_confirmation: } }
           cookies.update(response.cookies)
         end
 
@@ -82,7 +82,7 @@ RSpec.describe FacilitiesManagement::RM3830::RegistrationsController do
           allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
           allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
           # rubocop:enable RSpec/AnyInstance
-          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          post :create, params: { user: { email:, password:, password_confirmation: } }
           cookies.update(response.cookies)
         end
 
@@ -112,7 +112,7 @@ RSpec.describe FacilitiesManagement::RM3830::RegistrationsController do
       include_context 'and RM3830 has expired'
 
       it 'renders the unrecognised framework page with the right http status' do
-        post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+        post :create, params: { user: { email:, password:, password_confirmation: } }
 
         expect(response).to render_template('home/unrecognised_framework')
         expect(response).to have_http_status(:bad_request)

--- a/spec/controllers/facilities_management/rm3830/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/sessions_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe FacilitiesManagement::RM3830::SessionsController do
       before do
         allow(aws_client).to receive(:initiate_auth).and_return(initiate_auth_resp_struct.new(challenge_name: challenge_name, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
         allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
         post :create, params: { user: { email: email, password: 'Password12345!' } }
         cookies.update(response.cookies)
@@ -116,7 +116,7 @@ RSpec.describe FacilitiesManagement::RM3830::SessionsController do
         let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
 
         it 'redirects to facilities_management_rm3830_users_challenge_path' do
-          expect(response).to redirect_to facilities_management_rm3830_users_challenge_path(challenge_name: challenge_name)
+          expect(response).to redirect_to facilities_management_rm3830_users_challenge_path(challenge_name:)
         end
 
         it 'the cookies are updated correctly' do

--- a/spec/controllers/facilities_management/rm3830/supplier/contracts_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/supplier/contracts_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::ContractsController do
 
   describe 'PUT update' do
     let(:user) { create(:user, :with_detail, confirmed_at: Time.zone.now, roles: %i[supplier fm_access]) }
-    let(:procurement) { create(:facilities_management_rm3830_procurement_with_contact_details, user: user) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_with_contact_details, user:) }
     let(:contract) { create(:facilities_management_rm3830_procurement_supplier_da_with_supplier, facilities_management_rm3830_procurement_id: procurement.id, aasm_state: 'sent', offer_sent_date: Time.zone.now, supplier: supplier) }
     let(:supplier) { create(:facilities_management_rm3830_supplier_detail, user: controller.current_user) }
 
@@ -69,11 +69,11 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::ContractsController do
   end
 
   describe '.authorize_user' do
-    let(:contract) { create(:facilities_management_rm3830_procurement_supplier, supplier: supplier) }
-    let(:procurement) { create(:facilities_management_rm3830_procurement, user: user) }
+    let(:contract) { create(:facilities_management_rm3830_procurement_supplier, supplier:) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement, user:) }
     let(:user) { create(:user, :without_detail, confirmed_at: Time.zone.now, roles: %i[supplier fm_access]) }
     let(:wrong_user) { create(:user, :without_detail, confirmed_at: Time.zone.now, roles: %i[supplier fm_access]) }
-    let(:supplier) { create(:facilities_management_rm3830_supplier_detail, user: user) }
+    let(:supplier) { create(:facilities_management_rm3830_supplier_detail, user:) }
 
     before do
       allow(FacilitiesManagement::RM3830::SupplierDetail).to receive(:find).and_return(supplier)

--- a/spec/controllers/facilities_management/rm3830/supplier/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/supplier/passwords_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::PasswordsController do
           # rubocop:disable RSpec/AnyInstance
           allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
           # rubocop:enable RSpec/AnyInstance
-          post :create, params: { email: email }
+          post :create, params: { email: }
           cookies.update(response.cookies)
         end
 

--- a/spec/controllers/facilities_management/rm3830/supplier/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/supplier/sessions_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::SessionsController do
       before do
         allow(aws_client).to receive(:initiate_auth).and_return(initiate_auth_resp_struct.new(challenge_name: challenge_name, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
         allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
         post :create, params: { user: { email: email, password: 'Password12345!' } }
         cookies.update(response.cookies)
@@ -103,7 +103,7 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::SessionsController do
         let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
 
         it 'redirects to facilities_management_rm3830_supplier_users_challenge_path' do
-          expect(response).to redirect_to facilities_management_rm3830_supplier_users_challenge_path(challenge_name: challenge_name)
+          expect(response).to redirect_to facilities_management_rm3830_supplier_users_challenge_path(challenge_name:)
         end
 
         it 'the cookies are updated correctly' do

--- a/spec/controllers/facilities_management/rm3830/supplier/users_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/supplier/users_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::UsersController do
     before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
     context 'when the framework is live' do
-      before { get :challenge_new, params: { challenge_name: challenge_name } }
+      before { get :challenge_new, params: { challenge_name: } }
 
       render_views
 
@@ -65,7 +65,7 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::UsersController do
         before do
           allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
           allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
-          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
           post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
           cookies.update(response.cookies)
@@ -119,9 +119,9 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::UsersController do
         before do
           allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
           allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
-          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
-          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          post :challenge, params: { challenge_name:, username:, session:, access_code: }
           cookies.update(response.cookies)
         end
 

--- a/spec/controllers/facilities_management/rm3830/users_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/users_controller_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe FacilitiesManagement::RM3830::UsersController do
     context 'when the framework is live' do
       before do
         allow(Cognito::ResendConfirmationCode).to receive(:call).with(email).and_return(Cognito::ResendConfirmationCode.new(email))
-        post :resend_confirmation_email, params: { email: email }
+        post :resend_confirmation_email, params: { email: }
       end
 
       it 'redirects to facilities_management_rm3830_users_confirm_path' do
@@ -131,7 +131,7 @@ RSpec.describe FacilitiesManagement::RM3830::UsersController do
       include_context 'and RM3830 has expired'
 
       it 'renders the unrecognised framework page with the right http status' do
-        post :resend_confirmation_email, params: { email: email }
+        post :resend_confirmation_email, params: { email: }
 
         expect(response).to render_template('home/unrecognised_framework')
         expect(response).to have_http_status(:bad_request)
@@ -145,7 +145,7 @@ RSpec.describe FacilitiesManagement::RM3830::UsersController do
     before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
     context 'when the framework is live' do
-      before { get :challenge_new, params: { challenge_name: challenge_name } }
+      before { get :challenge_new, params: { challenge_name: } }
 
       render_views
 
@@ -202,7 +202,7 @@ RSpec.describe FacilitiesManagement::RM3830::UsersController do
         before do
           allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
           allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
-          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
           post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
           cookies.update(response.cookies)
@@ -256,9 +256,9 @@ RSpec.describe FacilitiesManagement::RM3830::UsersController do
         before do
           allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
           allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
-          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
-          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          post :challenge, params: { challenge_name:, username:, session:, access_code: }
           cookies.update(response.cookies)
         end
 

--- a/spec/controllers/facilities_management/rm6232/admin/change_logs_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/change_logs_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::ChangeLogsController do
 
     render_views
 
-    before { get :show, params: { change_log_id: change_log_id, change_type: change_type } }
+    before { get :show, params: { change_log_id:, change_type: } }
 
     context 'when there are change_type is upload' do
       let(:change_type) { 'upload' }

--- a/spec/controllers/facilities_management/rm6232/admin/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/passwords_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::PasswordsController do
     context 'when the framework is live' do
       context 'when no exception is raised' do
         before do
-          post :create, params: { email: email }
+          post :create, params: { email: }
           cookies.update(response.cookies)
         end
 
@@ -103,7 +103,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::PasswordsController do
       include_context 'and RM6232 has expired'
 
       before do
-        post :create, params: { email: email }
+        post :create, params: { email: }
         cookies.update(response.cookies)
       end
 

--- a/spec/controllers/facilities_management/rm6232/admin/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/sessions_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SessionsController do
       before do
         allow(aws_client).to receive(:initiate_auth).and_return(initiate_auth_resp_struct.new(challenge_name: challenge_name, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
         allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
       end
 
       # rubocop:disable RSpec/NestedGroups
@@ -107,7 +107,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SessionsController do
           let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
 
           it 'redirects to facilities_management_rm6232_admin_users_challenge_path' do
-            expect(response).to redirect_to facilities_management_rm6232_admin_users_challenge_path(challenge_name: challenge_name)
+            expect(response).to redirect_to facilities_management_rm6232_admin_users_challenge_path(challenge_name:)
           end
 
           it 'the cookies are updated correctly' do

--- a/spec/controllers/facilities_management/rm6232/admin/uploads_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/uploads_controller_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::UploadsController do
   end
 
   describe 'GET show' do
-    let(:upload) { create(:facilities_management_rm6232_admin_upload, aasm_state: aasm_state) }
+    let(:upload) { create(:facilities_management_rm6232_admin_upload, aasm_state:) }
 
     login_fm_admin
 

--- a/spec/controllers/facilities_management/rm6232/admin/users_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/users_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::UsersController do
     before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
     context 'when the framework is live' do
-      before { get :challenge_new, params: { challenge_name: challenge_name } }
+      before { get :challenge_new, params: { challenge_name: } }
 
       render_views
 
@@ -33,7 +33,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::UsersController do
     context 'when the framework is not live' do
       include_context 'and RM6232 has expired'
 
-      before { get :challenge_new, params: { challenge_name: challenge_name } }
+      before { get :challenge_new, params: { challenge_name: } }
 
       render_views
 
@@ -78,7 +78,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::UsersController do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
       end
 
       context 'when the framework is live' do
@@ -154,12 +154,12 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::UsersController do
       before do
         allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
       end
 
       context 'when the framework is live' do
         before do
-          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          post :challenge, params: { challenge_name:, username:, session:, access_code: }
           cookies.update(response.cookies)
         end
 
@@ -192,7 +192,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::UsersController do
         include_context 'and RM6232 has expired'
 
         before do
-          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          post :challenge, params: { challenge_name:, username:, session:, access_code: }
           cookies.update(response.cookies)
         end
 

--- a/spec/controllers/facilities_management/rm6232/passwords_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/passwords_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe FacilitiesManagement::RM6232::PasswordsController do
           # rubocop:disable RSpec/AnyInstance
           allow_any_instance_of(Cognito::ForgotPassword).to receive(:forgot_password).and_return(true)
           # rubocop:enable RSpec/AnyInstance
-          post :create, params: { email: email }
+          post :create, params: { email: }
           cookies.update(response.cookies)
         end
 

--- a/spec/controllers/facilities_management/rm6232/procurements_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/procurements_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementsController do
     render_views
 
     context 'when the user did create the procurement' do
-      let(:procurement) { create(:facilities_management_rm6232_procurement_what_happens_next, user: user) }
+      let(:procurement) { create(:facilities_management_rm6232_procurement_what_happens_next, user:) }
 
       it 'renders the show page' do
         expect(response).to render_template(:show)

--- a/spec/controllers/facilities_management/rm6232/registrations_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/registrations_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe FacilitiesManagement::RM6232::RegistrationsController do
           allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
           allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
           # rubocop:enable RSpec/AnyInstance
-          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          post :create, params: { user: { email:, password:, password_confirmation: } }
           cookies.update(response.cookies)
         end
 
@@ -82,7 +82,7 @@ RSpec.describe FacilitiesManagement::RM6232::RegistrationsController do
           allow_any_instance_of(Cognito::SignUpUser).to receive(:add_user_to_groups).and_return(true)
           allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list).and_return(['testemail.com'])
           # rubocop:enable RSpec/AnyInstance
-          post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+          post :create, params: { user: { email:, password:, password_confirmation: } }
           cookies.update(response.cookies)
         end
 
@@ -112,7 +112,7 @@ RSpec.describe FacilitiesManagement::RM6232::RegistrationsController do
       include_context 'and RM6232 has expired'
 
       it 'renders the unrecognised framework page with the right http status' do
-        post :create, params: { user: { email: email, password: password, password_confirmation: password_confirmation } }
+        post :create, params: { user: { email:, password:, password_confirmation: } }
 
         expect(response).to render_template('home/unrecognised_framework')
         expect(response).to have_http_status(:bad_request)

--- a/spec/controllers/facilities_management/rm6232/service_specification_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/service_specification_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe FacilitiesManagement::RM6232::ServiceSpecificationController do
 
       service_codes.each do |service_code|
         context "and the service code is #{service_code}" do
-          before { get :show, params: { service_code: service_code } }
+          before { get :show, params: { service_code: } }
 
           it 'renders the show page successfully' do
             expect(response).to render_template(:show)

--- a/spec/controllers/facilities_management/rm6232/sessions_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/sessions_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe FacilitiesManagement::RM6232::SessionsController do
       before do
         allow(aws_client).to receive(:initiate_auth).and_return(initiate_auth_resp_struct.new(challenge_name: challenge_name, session: session, challenge_parameters: { 'USER_ID_FOR_SRP' => username }))
         allow(aws_client).to receive(:admin_list_groups_for_user).and_return(cognito_groups)
-        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+        allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
         post :create, params: { user: { email: email, password: 'Password12345!' } }
         cookies.update(response.cookies)
@@ -116,7 +116,7 @@ RSpec.describe FacilitiesManagement::RM6232::SessionsController do
         let(:challenge_name) { 'NEW_PASSWORD_REQUIRED' }
 
         it 'redirects to facilities_management_rm6232_users_challenge_path' do
-          expect(response).to redirect_to facilities_management_rm6232_users_challenge_path(challenge_name: challenge_name)
+          expect(response).to redirect_to facilities_management_rm6232_users_challenge_path(challenge_name:)
         end
 
         it 'the cookies are updated correctly' do

--- a/spec/controllers/facilities_management/rm6232/users_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/users_controller_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe FacilitiesManagement::RM6232::UsersController do
     context 'when the framework is live' do
       before do
         allow(Cognito::ResendConfirmationCode).to receive(:call).with(email).and_return(Cognito::ResendConfirmationCode.new(email))
-        post :resend_confirmation_email, params: { email: email }
+        post :resend_confirmation_email, params: { email: }
       end
 
       it 'redirects to facilities_management_rm6232_users_confirm_path' do
@@ -131,7 +131,7 @@ RSpec.describe FacilitiesManagement::RM6232::UsersController do
       include_context 'and RM6232 has expired'
 
       it 'renders the unrecognised framework page with the right http status' do
-        post :resend_confirmation_email, params: { email: email }
+        post :resend_confirmation_email, params: { email: }
 
         expect(response).to render_template('home/unrecognised_framework')
         expect(response).to have_http_status(:bad_request)
@@ -145,7 +145,7 @@ RSpec.describe FacilitiesManagement::RM6232::UsersController do
     before { cookies[:crown_marketplace_challenge_username] = user.cognito_uuid }
 
     context 'when the framework is live' do
-      before { get :challenge_new, params: { challenge_name: challenge_name } }
+      before { get :challenge_new, params: { challenge_name: } }
 
       render_views
 
@@ -202,7 +202,7 @@ RSpec.describe FacilitiesManagement::RM6232::UsersController do
         before do
           allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
           allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
-          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
           post :challenge, params: { challenge_name: challenge_name, username: username, session: session, new_password: password, new_password_confirmation: password }
           cookies.update(response.cookies)
@@ -256,9 +256,9 @@ RSpec.describe FacilitiesManagement::RM6232::UsersController do
         before do
           allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
           allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new)
-          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user: user))
+          allow(Cognito::CreateUserFromCognito).to receive(:call).and_return(admin_create_user_resp_struct.new(user:))
 
-          post :challenge, params: { challenge_name: challenge_name, username: username, session: session, access_code: access_code }
+          post :challenge, params: { challenge_name:, username:, session:, access_code: }
           cookies.update(response.cookies)
         end
 

--- a/spec/helpers/crown_marketplace/manage_users_helper_spec.rb
+++ b/spec/helpers/crown_marketplace/manage_users_helper_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe CrownMarketplace::ManageUsersHelper do
 
     let(:attributes) do
       {
-        email: email,
-        telephone_number: telephone_number,
-        roles: roles,
-        service_access: service_access,
+        email:,
+        telephone_number:,
+        roles:,
+        service_access:,
       }
     end
 

--- a/spec/helpers/facilities_management/admin/supplier_details_helper_rm3830_spec.rb
+++ b/spec/helpers/facilities_management/admin/supplier_details_helper_rm3830_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe FacilitiesManagement::Admin::SupplierDetailsHelper do
     before { @supplier = supplier }
 
     context 'and the supplier has a user' do
-      let(:attributes) { { user: user } }
+      let(:attributes) { { user: } }
       let(:user) { create(:user) }
 
       it 'returns the supplier user email' do

--- a/spec/helpers/facilities_management/buildings_helper_spec.rb
+++ b/spec/helpers/facilities_management/buildings_helper_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe FacilitiesManagement::BuildingsHelper do
 
   describe '.should_building_details_be_open?' do
     let(:page_data) { {} }
-    let(:building_options) { { building_type: building_type } }
+    let(:building_options) { { building_type: } }
     let(:result) { helper.should_building_details_be_open? }
 
     before { @building = building }
@@ -240,7 +240,7 @@ RSpec.describe FacilitiesManagement::BuildingsHelper do
   end
 
   describe '.select_a_region_visible?' do
-    let(:building_options) { { address_line_1: address_line_1, address_region: address_region } }
+    let(:building_options) { { address_line_1:, address_region: } }
     let(:result) { helper.select_a_region_visible? }
 
     before { @building = building }
@@ -288,7 +288,7 @@ RSpec.describe FacilitiesManagement::BuildingsHelper do
 
   describe '.full_region_visible?' do
     let(:result) { helper.full_region_visible? }
-    let(:building_options) { { address_region: address_region } }
+    let(:building_options) { { address_region: } }
 
     before { @building = building }
 

--- a/spec/helpers/facilities_management/procurement_buildings_helper_rm3830_spec.rb
+++ b/spec/helpers/facilities_management/procurement_buildings_helper_rm3830_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::ProcurementBuildingsHelper do
-  let(:building) { create(:facilities_management_building, user: user) }
-  let(:procurement) { create(:facilities_management_rm3830_procurement_entering_requirements, user: user) }
-  let(:procurement_building) { create(:facilities_management_rm3830_procurement_building_no_services, procurement: procurement, building: building) }
+  let(:building) { create(:facilities_management_building, user:) }
+  let(:procurement) { create(:facilities_management_rm3830_procurement_entering_requirements, user:) }
+  let(:procurement_building) { create(:facilities_management_rm3830_procurement_building_no_services, procurement:, building:) }
   let(:user) { create(:user) }
 
   before do
@@ -35,7 +35,7 @@ RSpec.describe FacilitiesManagement::ProcurementBuildingsHelper do
   end
 
   describe '.building_name' do
-    before { procurement_building.update(building_name: building_name) }
+    before { procurement_building.update(building_name:) }
 
     context 'when no procurement_building is provided' do
       let(:result) { helper.building_name }

--- a/spec/helpers/facilities_management/procurement_buildings_helper_rm6232_spec.rb
+++ b/spec/helpers/facilities_management/procurement_buildings_helper_rm6232_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::ProcurementBuildingsHelper do
-  let(:building) { create(:facilities_management_building, user: user) }
-  let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, user: user) }
-  let(:procurement_building) { create(:facilities_management_rm6232_procurement_building_no_services, procurement: procurement, building: building) }
+  let(:building) { create(:facilities_management_building, user:) }
+  let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, user:) }
+  let(:procurement_building) { create(:facilities_management_rm6232_procurement_building_no_services, procurement:, building:) }
   let(:user) { create(:user) }
 
   before do

--- a/spec/helpers/facilities_management/procurement_details_helper_rm3830_spec.rb
+++ b/spec/helpers/facilities_management/procurement_details_helper_rm3830_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe FacilitiesManagement::ProcurementDetailsHelper do
 
   describe '.call_off_extension_visible?' do
     let(:extensions_required) { true }
-    let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, extensions_required: extensions_required) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, extensions_required:) }
     let(:result) { helper.call_off_extension_visible?(0) }
 
     before { @procurement = procurement }
@@ -253,7 +253,7 @@ RSpec.describe FacilitiesManagement::ProcurementDetailsHelper do
       let(:extension_required) { nil }
       let(:years) { nil }
       let(:months) { nil }
-      let(:call_off_extension) { create(:facilities_management_rm3830_procurement_call_off_extension, years: years, months: months, extension_required: extension_required) }
+      let(:call_off_extension) { create(:facilities_management_rm3830_procurement_call_off_extension, years:, months:, extension_required:) }
 
       before { procurement.update(call_off_extensions: [call_off_extension]) }
 

--- a/spec/helpers/facilities_management/procurement_details_helper_rm6232_spec.rb
+++ b/spec/helpers/facilities_management/procurement_details_helper_rm6232_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe FacilitiesManagement::ProcurementDetailsHelper do
 
   describe '.call_off_extension_visible?' do
     let(:extensions_required) { true }
-    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, extensions_required: extensions_required) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, extensions_required:) }
     let(:result) { helper.call_off_extension_visible?(0) }
 
     before { @procurement = procurement }
@@ -253,7 +253,7 @@ RSpec.describe FacilitiesManagement::ProcurementDetailsHelper do
       let(:extension_required) { nil }
       let(:years) { nil }
       let(:months) { nil }
-      let(:call_off_extension) { create(:facilities_management_rm6232_procurement_call_off_extension, years: years, months: months, extension_required: extension_required) }
+      let(:call_off_extension) { create(:facilities_management_rm6232_procurement_call_off_extension, years:, months:, extension_required:) }
 
       before { procurement.update(call_off_extensions: [call_off_extension]) }
 

--- a/spec/helpers/facilities_management/rm3830/procurement_buildings_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm3830/procurement_buildings_helper_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuildingsHelper do
   end
 
   describe '#procurement_building_status' do
-    let(:procurement_building) { create(:facilities_management_rm3830_procurement_building, procurement: procurement) }
-    let(:procurement) { create(:facilities_management_rm3830_procurement, user: user) }
+    let(:procurement_building) { create(:facilities_management_rm3830_procurement_building, procurement:) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement, user:) }
     let(:user) { create(:user) }
 
     before do
@@ -142,7 +142,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuildingsHelper do
   describe 'service_has_errors?' do
     let(:gia) { 56 }
     let(:external_area) { 45 }
-    let(:building) { create(:facilities_management_building, gia: gia, external_area: external_area) }
+    let(:building) { create(:facilities_management_building, gia:, external_area:) }
     let(:procurement_building) { create(:facilities_management_rm3830_procurement_building, service_codes: ['C.1', 'G.5'], building: building, procurement: create(:facilities_management_rm3830_procurement)) }
     let(:result) { helper.service_has_errors?(context) }
 

--- a/spec/helpers/facilities_management/rm3830/procurement_buildings_services_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm3830/procurement_buildings_services_helper_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM3830::ProcurementBuildingsServicesHelper do
-  let(:procurement_building_service) { create(:facilities_management_rm3830_procurement_building_service, code: code, procurement_building: procurement_building) }
-  let(:procurement_building) { create(:facilities_management_rm3830_procurement_building, procurement: procurement) }
+  let(:procurement_building_service) { create(:facilities_management_rm3830_procurement_building_service, code:, procurement_building:) }
+  let(:procurement_building) { create(:facilities_management_rm3830_procurement_building, procurement:) }
   let(:procurement) { create(:facilities_management_rm3830_procurement) }
 
   describe 'volume_question' do

--- a/spec/helpers/facilities_management/rm3830/procurement_details_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm3830/procurement_details_helper_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementDetailsHelper do
 
   describe '.building_name' do
     let(:building) { create(:facilities_management_building, user: user, building_name: 'Super building name') }
-    let(:procurement) { create(:facilities_management_rm3830_procurement_entering_requirements, user: user) }
-    let(:procurement_building) { create(:facilities_management_rm3830_procurement_building_no_services, procurement: procurement, building: building) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_entering_requirements, user:) }
+    let(:procurement_building) { create(:facilities_management_rm3830_procurement_building_no_services, procurement:, building:) }
     let(:user) { create(:user) }
 
     it 'returns the building name' do

--- a/spec/helpers/facilities_management/rm3830/procurements/contracts_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm3830/procurements/contracts_helper_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractsHelper do
 
     context 'when the state is declined' do
       let(:aasm_state) { :declined }
-      let(:attributes) { { supplier_response_date: supplier_response_date } }
+      let(:attributes) { { supplier_response_date: } }
       let(:supplier_response_date) { Time.new(2021, 7, 7, 20, 29, 0).in_time_zone('London') }
 
       it 'has the correct warning' do
@@ -84,7 +84,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractsHelper do
 
     context 'when the state is not_signed' do
       let(:aasm_state) { :not_signed }
-      let(:attributes) { { contract_signed_date: contract_signed_date } }
+      let(:attributes) { { contract_signed_date: } }
       let(:contract_signed_date) { Time.new(2021, 7, 7, 20, 39, 0).in_time_zone('London') }
 
       it 'has the correct warning' do
@@ -113,7 +113,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurements::ContractsHelper do
 
     context 'when the contract is closed' do
       let(:aasm_state) { :declined }
-      let(:attributes) { { contract_closed_date: contract_closed_date } }
+      let(:attributes) { { contract_closed_date: } }
       let(:contract_closed_date) { Time.new(2021, 7, 7, 22, 35, 0).in_time_zone('London') }
 
       context 'with it being the last offer' do

--- a/spec/helpers/facilities_management/rm3830/procurements_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm3830/procurements_helper_spec.rb
@@ -554,7 +554,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementsHelper do
   describe 'methods relating to suppliers' do
     let(:service_codes) { FacilitiesManagement::RM3830::StaticData.work_packages.reject { |wp| ['A', 'B'].include? wp['work_package_code'] }.pluck('code') }
     let(:region_codes) { FacilitiesManagement::Region.all.reject { |region| region.code == 'OS01' }.map(&:code) }
-    let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, region_codes: region_codes, service_codes: service_codes) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, region_codes:, service_codes:) }
 
     before { @procurement = procurement }
 
@@ -596,7 +596,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementsHelper do
   end
 
   describe '.further_competition_saved_date' do
-    let(:procurement) { create(:facilities_management_rm3830_procurement, contract_datetime: contract_datetime) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement, contract_datetime:) }
 
     context 'when the contract_datetime is 01/02/2019 - 2:53pm' do
       let(:contract_datetime) { '01/02/2019 -  2:53pm' }

--- a/spec/helpers/facilities_management/rm3830/supplier/contracts_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm3830/supplier/contracts_helper_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::ContractsHelper do
 
     context 'when the state is declined' do
       let(:aasm_state) { :declined }
-      let(:attributes) { { supplier_response_date: supplier_response_date } }
+      let(:attributes) { { supplier_response_date: } }
       let(:supplier_response_date) { Time.new(2021, 7, 7, 20, 29, 0).in_time_zone('London') }
 
       it 'has the correct warning' do
@@ -142,7 +142,7 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::ContractsHelper do
 
     context 'when the state is not_signed' do
       let(:aasm_state) { :not_signed }
-      let(:attributes) { { contract_signed_date: contract_signed_date } }
+      let(:attributes) { { contract_signed_date: } }
       let(:contract_signed_date) { Time.new(2021, 7, 7, 20, 39, 0).in_time_zone('London') }
 
       it 'has the correct warning' do
@@ -156,7 +156,7 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::ContractsHelper do
 
     context 'when the state is withdrawn' do
       let(:aasm_state) { :withdrawn }
-      let(:attributes) { { contract_closed_date: contract_closed_date } }
+      let(:attributes) { { contract_closed_date: } }
       let(:contract_closed_date) { Time.new(2021, 7, 7, 22, 13, 0).in_time_zone('London') }
 
       it 'has the correct warning' do

--- a/spec/helpers/facilities_management/rm6232/procurement_details_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm6232/procurement_details_helper_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementDetailsHelper do
 
   describe '.building_name' do
     let(:building) { create(:facilities_management_building, user: user, building_name: 'Super building name') }
-    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, user: user) }
-    let(:procurement_building) { create(:facilities_management_rm6232_procurement_building_no_services, procurement: procurement, building: building) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, user:) }
+    let(:procurement_building) { create(:facilities_management_rm6232_procurement_building_no_services, procurement:, building:) }
     let(:user) { create(:user) }
 
     it 'returns the building name' do

--- a/spec/helpers/facilities_management/rm6232/procurements_helper_spec.rb
+++ b/spec/helpers/facilities_management/rm6232/procurements_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementsHelper do
     let(:service_codes) { ['E.1', 'F.1', 'G.1'] }
     let(:region_codes) { ['UKI3', 'UKI4'] }
     let(:annual_contract_value) { 500_000 }
-    let(:result) { helper.journey_step_url_former(journey_slug: journey_slug, annual_contract_value: annual_contract_value, region_codes: region_codes, service_codes: service_codes) }
+    let(:result) { helper.journey_step_url_former(journey_slug:, annual_contract_value:, region_codes:, service_codes:) }
 
     context 'when the journey_slug is choose-services' do
       let(:journey_slug) { 'choose-services' }
@@ -222,7 +222,7 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementsHelper do
   end
 
   describe '.procurement_service_names' do
-    let(:procurement) { create(:facilities_management_rm6232_procurement_results, service_codes: service_codes, lot_number: lot_number) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_results, service_codes:, lot_number:) }
     let(:base_service_codes) { ['E.1', 'E.2', 'E.3', 'E.4', 'E.5'] }
     let(:service_codes) { base_service_codes }
     let(:lot_number) { '1a' }

--- a/spec/models/allowed_email_domain_spec.rb
+++ b/spec/models/allowed_email_domain_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AllowedEmailDomain do
-  let(:allowed_email_domain) { described_class.new(email_domain: email_domain) }
+  let(:allowed_email_domain) { described_class.new(email_domain:) }
   let(:email_list) { ['cheemail.com', 'cmail.com', 'crowncommercial.gov.uk', 'email.com', 'jmail.com', 'kmail.com', 'tmail.com'] }
   let(:allow_list_file) { Tempfile.new('allow_list.txt') }
 

--- a/spec/models/facilities_management/building_spec.rb
+++ b/spec/models/facilities_management/building_spec.rb
@@ -914,7 +914,7 @@ RSpec.describe FacilitiesManagement::Building do
   end
 
   describe '.standard_building_type?' do
-    let(:building) { create(:facilities_management_building, building_type: building_type) }
+    let(:building) { create(:facilities_management_building, building_type:) }
 
     described_class::BUILDING_TYPES[0..11].pluck(:id).each do |type|
       context "when the building type is #{type}" do
@@ -962,7 +962,7 @@ RSpec.describe FacilitiesManagement::Building do
 
     before do
       allow(Postcode::PostcodeCheckerV2).to receive(:find_region).and_return(returned_regions)
-      building.assign_attributes(address_postcode: address_postcode)
+      building.assign_attributes(address_postcode:)
     end
 
     context 'when there are errors' do

--- a/spec/models/facilities_management/buyer_detail_spec.rb
+++ b/spec/models/facilities_management/buyer_detail_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe FacilitiesManagement::BuyerDetail do
       let(:organisation_address_line_1) { 'The Globe Theatre' }
       let(:organisation_address_town) { 'London Town' }
 
-      before { buyer_detail.assign_attributes(organisation_address_postcode: organisation_address_postcode, organisation_address_line_1: organisation_address_line_1, organisation_address_town: organisation_address_town) }
+      before { buyer_detail.assign_attributes(organisation_address_postcode:, organisation_address_line_1:, organisation_address_town:) }
 
       context 'when the postcode is not valid' do
         let(:organisation_address_postcode) { '' }

--- a/spec/models/facilities_management/rm3830/admin/management_report_spec.rb
+++ b/spec/models/facilities_management/rm3830/admin/management_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM3830::Admin::ManagementReport do
-  subject(:management_report) { build(:facilities_management_rm3830_admin_management_report, user: user) }
+  subject(:management_report) { build(:facilities_management_rm3830_admin_management_report, user:) }
 
   let(:user) { create(:user) }
 

--- a/spec/models/facilities_management/rm3830/admin/suppliers_admin_spec.rb
+++ b/spec/models/facilities_management/rm3830/admin/suppliers_admin_spec.rb
@@ -874,7 +874,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SuppliersAdmin do
         let(:user) { create(:user, roles: :supplier) }
         let(:user_email) { user.email }
 
-        before { described_class.find('ef44b65d-de46-4297-8d2c-2c6130cecafc').update(user: user) }
+        before { described_class.find('ef44b65d-de46-4297-8d2c-2c6130cecafc').update(user:) }
 
         it 'is not valid' do
           expect(supplier.valid?(:supplier_user)).to be false
@@ -891,7 +891,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SuppliersAdmin do
         let(:user_email) { user.email }
 
         before do
-          supplier.update(user: user)
+          supplier.update(user:)
           supplier.user_email = user_email
         end
 

--- a/spec/models/facilities_management/rm3830/frozen_rate_card_spec.rb
+++ b/spec/models/facilities_management/rm3830/frozen_rate_card_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe FacilitiesManagement::RM3830::FrozenRateCard do
   subject(:frozen_date_card) { described_class.new(facilities_management_rm3830_procurement_id: procurement.id, data: { 'foo' => 'bar', 'level1' => { 'level2' => 'baz' } }, source_file: 'path') }
 
-  let(:procurement) { create(:facilities_management_rm3830_procurement, user: user) }
+  let(:procurement) { create(:facilities_management_rm3830_procurement, user:) }
   let(:user) { create(:user) }
 
   before { frozen_date_card.save }

--- a/spec/models/facilities_management/rm3830/frozen_rate_spec.rb
+++ b/spec/models/facilities_management/rm3830/frozen_rate_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FacilitiesManagement::RM3830::FrozenRate do
 
   before { frozen_rate.save }
 
-  let(:procurement) { create(:facilities_management_rm3830_procurement, user: user) }
+  let(:procurement) { create(:facilities_management_rm3830_procurement, user:) }
   let(:user) { create(:user) }
 
   it 'has no benchmark rates' do

--- a/spec/models/facilities_management/rm3830/procurement_building_service_lift_spec.rb
+++ b/spec/models/facilities_management/rm3830/procurement_building_service_lift_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM3830::ProcurementBuildingServiceLift do
   describe '#valid?' do
-    let(:lift) { create(:facilities_management_rm3830_lift, procurement_building_service: procurement_building_service) }
-    let(:procurement_building_service) { create(:facilities_management_rm3830_procurement_building_service, procurement_building: procurement_building) }
-    let(:procurement_building) { create(:facilities_management_rm3830_procurement_building, procurement: procurement) }
+    let(:lift) { create(:facilities_management_rm3830_lift, procurement_building_service:) }
+    let(:procurement_building_service) { create(:facilities_management_rm3830_procurement_building_service, procurement_building:) }
+    let(:procurement_building) { create(:facilities_management_rm3830_procurement_building, procurement:) }
     let(:procurement) { create(:facilities_management_rm3830_procurement, user: create(:user)) }
 
     before do

--- a/spec/models/facilities_management/rm3830/procurement_building_service_spec.rb
+++ b/spec/models/facilities_management/rm3830/procurement_building_service_spec.rb
@@ -589,7 +589,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuildingService do
       context 'when lift_data has elements are zero or 100 in value' do
         it 'validates to false' do
           [0, 99, 3, 4, 5, 6, 7, 8, 9, 10].each do |number_of_floors|
-            procurement_building_service.lifts.build(number_of_floors: number_of_floors)
+            procurement_building_service.lifts.build(number_of_floors:)
           end
 
           expect(procurement_building_service.valid?(:lifts)).to be false
@@ -597,7 +597,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuildingService do
 
         it 'has an error collection containing corresponding index positions' do
           [3, 300, 4, 0, 5, 6, 7, 8, 9, 10].each do |number_of_floors|
-            procurement_building_service.lifts.build(number_of_floors: number_of_floors)
+            procurement_building_service.lifts.build(number_of_floors:)
           end
 
           expect(procurement_building_service.valid?(:lifts)).to be false
@@ -689,7 +689,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuildingService do
       before do
         procurement_building_service.code = 'C.5'
         lift_data.each do |number_of_floors|
-          procurement_building_service.lifts.build(number_of_floors: number_of_floors)
+          procurement_building_service.lifts.build(number_of_floors:)
         end
       end
 
@@ -849,7 +849,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuildingService do
 
     before do
       lift_data.each do |number_of_floors|
-        procurement_building_service.lifts.create(number_of_floors: number_of_floors)
+        procurement_building_service.lifts.create(number_of_floors:)
       end
     end
 

--- a/spec/models/facilities_management/rm3830/procurement_building_spec.rb
+++ b/spec/models/facilities_management/rm3830/procurement_building_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuilding do
     before do
       procurement_building.procurement.update(aasm_state: 'detailed_search')
       procurement_building.procurement_building_services = [build(:facilities_management_rm3830_procurement_building_service, code: service_code, service_standard: 'A', procurement_building: procurement_building)]
-      procurement_building.building = build(:facilities_management_building, gia: gia, external_area: external_area)
+      procurement_building.building = build(:facilities_management_building, gia:, external_area:)
       procurement_building.service_codes = [service_code]
       procurement_building.save
     end
@@ -341,7 +341,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuilding do
       before do
         pbs = procurement_building.procurement_building_services.first
         [1, 2, 3, 4].each do |number_of_floors|
-          pbs.lifts.create(number_of_floors: number_of_floors)
+          pbs.lifts.create(number_of_floors:)
         end
         procurement_building.reload
       end
@@ -571,7 +571,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuilding do
 
   describe '#missing_region?' do
     before do
-      procurement_building.building.update(address_region: address_region, address_region_code: address_region_code)
+      procurement_building.building.update(address_region:, address_region_code:)
     end
 
     let(:address_region) { procurement_building.building.address_region }
@@ -625,7 +625,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuilding do
   end
 
   describe '#service_selection_complete?' do
-    before { procurement_building.update(service_codes: service_codes) }
+    before { procurement_building.update(service_codes:) }
 
     context 'when there are no service codes' do
       let(:service_codes) { [] }
@@ -688,16 +688,16 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuilding do
       before do
         procurement_building.procurement.update(aasm_state: 'detailed_search')
         service_codes = codes_with_values.map { |key, _| key.to_s } << 'C.5'
-        procurement_building.update(service_codes: service_codes)
+        procurement_building.update(service_codes:)
         procurement_building.reload
         procurement_building.procurement_building_services.each do |pbs|
           pbs.update(codes_with_values[pbs.code.to_sym])
         end
         pbs = procurement_building.procurement_building_services.find_by(code: 'C.5')
         lift_data.each do |number_of_floors|
-          pbs.lifts.create(number_of_floors: number_of_floors)
+          pbs.lifts.create(number_of_floors:)
         end
-        procurement_building.building.update(gia: gia, external_area: external_area)
+        procurement_building.building.update(gia:, external_area:)
       end
 
       context 'when a service requires gia and gia is zero' do
@@ -804,7 +804,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementBuilding do
   describe '#requires_service_questions?' do
     before do
       procurement_building.procurement.update(aasm_state: 'detailed_search')
-      procurement_building.update(service_codes: service_codes)
+      procurement_building.update(service_codes:)
       procurement_building.reload
     end
 

--- a/spec/models/facilities_management/rm3830/procurement_contact_detail_spec.rb
+++ b/spec/models/facilities_management/rm3830/procurement_contact_detail_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementContactDetail do
       let(:organisation_address_line_1) { 'The Globe Theatre' }
       let(:organisation_address_town) { 'London Town' }
 
-      before { procurement_contact_detail.assign_attributes(organisation_address_postcode: organisation_address_postcode, organisation_address_line_1: organisation_address_line_1, organisation_address_town: organisation_address_town) }
+      before { procurement_contact_detail.assign_attributes(organisation_address_postcode:, organisation_address_line_1:, organisation_address_town:) }
 
       context 'when the postcode is not valid' do
         let(:organisation_address_postcode) { '' }

--- a/spec/models/facilities_management/rm3830/procurement_copy_spec.rb
+++ b/spec/models/facilities_management/rm3830/procurement_copy_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM3830::Procurement do
-  subject(:procurement) { create(:facilities_management_rm3830_procurement_with_contact_details, user: user) }
+  subject(:procurement) { create(:facilities_management_rm3830_procurement_with_contact_details, user:) }
 
   let(:user) { create(:user) }
   let(:security_policy_document_file) { Tempfile.new(['security_policy_document_file', '.txt']) }
@@ -123,7 +123,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
     end
 
     context 'when considering lifts' do
-      let(:procurement) { create(:facilities_management_rm3830_procurement_with_lifts, user: user) }
+      let(:procurement) { create(:facilities_management_rm3830_procurement_with_lifts, user:) }
 
       it 'will have the same lift data' do
         procurement_lift_data = procurement.procurement_buildings.first.procurement_building_services.first.lift_data
@@ -134,7 +134,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
     end
 
     context 'when a copy has been made of a procurement without full use of contact details' do
-      let(:second_procurement) { create(:facilities_management_rm3830_procurement, user: user) }
+      let(:second_procurement) { create(:facilities_management_rm3830_procurement, user:) }
       let(:second_procurement_copy) { second_procurement.create_procurement_copy }
 
       it 'will have the same attributes as the procurement' do

--- a/spec/models/facilities_management/rm3830/procurement_spec.rb
+++ b/spec/models/facilities_management/rm3830/procurement_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM3830::Procurement do
-  subject(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, user: user) }
+  subject(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, user:) }
 
   let(:user) { create(:user) }
 
@@ -205,12 +205,12 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
   end
 
   describe 'validations on :continue' do
-    let(:procurement) { create(:facilities_management_rm3830_procurement_without_procurement_buildings, user: user) }
-    let(:building) { create(:facilities_management_building, user: user) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_without_procurement_buildings, user:) }
+    let(:building) { create(:facilities_management_building, user:) }
 
     context 'with valid scenarios' do
       before do
-        procurement.update(service_codes: service_codes)
+        procurement.update(service_codes:)
         procurement.procurement_buildings.create(building_id: building.id, service_codes: service_codes, active: true)
       end
 
@@ -503,7 +503,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
     end
 
     describe 'changing state' do
-      let(:procurement_building) { create(:facilities_management_rm3830_procurement_building_no_services, procurement: procurement) }
+      let(:procurement_building) { create(:facilities_management_rm3830_procurement_building_no_services, procurement:) }
       let(:estimated_cost_known) { nil }
       let(:services_standard) { nil }
 
@@ -1120,14 +1120,14 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
   end
 
   describe 'services missing prices' do
-    let(:procurement_building) { create(:facilities_management_rm3830_procurement_building_no_services, procurement: procurement) }
+    let(:procurement_building) { create(:facilities_management_rm3830_procurement_building_no_services, procurement:) }
 
     before do
       procurement.procurement_buildings.destroy_all
       codes.each do |code|
-        create(:facilities_management_rm3830_procurement_building_service, code: code, procurement_building: procurement_building)
+        create(:facilities_management_rm3830_procurement_building_service, code:, procurement_building:)
       end
-      procurement.update(estimated_cost_known: estimated_cost_known)
+      procurement.update(estimated_cost_known:)
     end
 
     context 'when buyer input not present' do
@@ -1357,7 +1357,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
   describe '.contract_name_status' do
     subject(:status) { procurement.contract_name_status }
 
-    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, contract_name: contract_name) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, contract_name:) }
 
     context 'when the contract name section has not been completed' do
       let(:contract_name) { '' }
@@ -1379,7 +1379,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
   describe '.estimated_annual_cost_status' do
     subject(:status) { procurement.estimated_annual_cost_status }
 
-    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, estimated_cost_known: estimated_cost_known) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, estimated_cost_known:) }
 
     context 'when the estimated cost section has not been completed' do
       let(:estimated_cost_known) { nil }
@@ -1401,7 +1401,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
   describe '.tupe_status' do
     subject(:status) { procurement.tupe_status }
 
-    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, tupe: tupe) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, tupe:) }
 
     context 'when the tupe section has not been completed' do
       let(:tupe) { nil }
@@ -1451,7 +1451,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
   describe '.services_status' do
     subject(:status) { procurement.services_status }
 
-    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, service_codes: service_codes) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, service_codes:) }
 
     context 'when user has not yet selected services' do
       let(:service_codes) { [] }
@@ -1492,7 +1492,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
 
   shared_context 'with buildings and services' do
     let(:procurement) do
-      create(:facilities_management_rm3830_procurement_detailed_search, procurement_buildings: procurement_buildings)
+      create(:facilities_management_rm3830_procurement_detailed_search, procurement_buildings:)
     end
 
     let(:procurement_buildings) { [procurement_building1, procurement_building2] }
@@ -1509,7 +1509,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
     include_context 'with buildings and services'
 
     before do
-      procurement_building1.update(service_codes: service_codes)
+      procurement_building1.update(service_codes:)
       procurement_building2.update(service_codes: %w[C.1 C.2])
     end
 
@@ -1858,7 +1858,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
       end
 
       context 'when there is invoice_contact_detail and it is complete' do
-        before { create(:facilities_management_rm3830_procurement_invoice_contact_detail, procurement: procurement) }
+        before { create(:facilities_management_rm3830_procurement_invoice_contact_detail, procurement:) }
 
         it 'returns false' do
           expect(result).to be false
@@ -1866,7 +1866,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
       end
 
       context 'when there is invoice_contact_detail and it is incomplete' do
-        before { create(:facilities_management_rm3830_procurement_invoice_contact_detail_empty, procurement: procurement) }
+        before { create(:facilities_management_rm3830_procurement_invoice_contact_detail_empty, procurement:) }
 
         it 'returns true' do
           expect(result).to be true
@@ -1884,7 +1884,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
       end
 
       context 'when there is authorised_contact_detail and it is complete' do
-        before { create(:facilities_management_rm3830_procurement_authorised_contact_detail, procurement: procurement) }
+        before { create(:facilities_management_rm3830_procurement_authorised_contact_detail, procurement:) }
 
         it 'returns false' do
           expect(result).to be false
@@ -1892,7 +1892,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
       end
 
       context 'when there is authorised_contact_detail and it is incomplete' do
-        before { create(:facilities_management_rm3830_procurement_authorised_contact_detail_empty, procurement: procurement) }
+        before { create(:facilities_management_rm3830_procurement_authorised_contact_detail_empty, procurement:) }
 
         it 'returns true' do
           expect(result).to be true
@@ -1910,7 +1910,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
       end
 
       context 'when there is notices_contact_detail and it is complete' do
-        before { create(:facilities_management_rm3830_procurement_notices_contact_detail, procurement: procurement) }
+        before { create(:facilities_management_rm3830_procurement_notices_contact_detail, procurement:) }
 
         it 'returns false' do
           expect(result).to be false
@@ -1918,7 +1918,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
       end
 
       context 'when there is notices_contact_detail and it is incomplete' do
-        before { create(:facilities_management_rm3830_procurement_notices_contact_detail_empty, procurement: procurement) }
+        before { create(:facilities_management_rm3830_procurement_notices_contact_detail_empty, procurement:) }
 
         it 'returns true' do
           expect(result).to be true

--- a/spec/models/facilities_management/rm3830/procurement_supplier_spec.rb
+++ b/spec/models/facilities_management/rm3830/procurement_supplier_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementSupplier do
   end
 
   describe 'contract methods' do
-    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, user: user) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, user:) }
     let(:user) { create(:user) }
     let(:contract) { procurement.procurement_suppliers.create(direct_award_value: 123456, supplier: FacilitiesManagement::RM3830::SupplierDetail.first) }
 
@@ -735,7 +735,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementSupplier do
   # rubocop:enable RSpec/NestedGroups
 
   describe '.closed_date' do
-    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, user: user) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement_detailed_search, user:) }
     let(:user) { create(:user) }
     let(:contract_signed_date) { Time.now.in_time_zone('London') }
     let(:supplier_response_date) { Time.now.in_time_zone('London') - 1.week }

--- a/spec/models/facilities_management/rm3830/procurement_validations_spec.rb
+++ b/spec/models/facilities_management/rm3830/procurement_validations_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM3830::Procurement do
-  subject(:procurement) { build(:facilities_management_rm3830_procurement, user: user) }
+  subject(:procurement) { build(:facilities_management_rm3830_procurement, user:) }
 
   let(:user) { build(:user) }
 
@@ -288,7 +288,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
 
   describe '.contract_period_in_past?' do
     before do
-      procurement.update(initial_call_off_start_date: initial_call_off_start_date)
+      procurement.update(initial_call_off_start_date:)
     end
 
     context 'when initial call off period is in the past' do
@@ -312,7 +312,7 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
     before do
       procurement.update(initial_call_off_start_date: Time.now.in_time_zone('London') + 5.weeks)
       procurement.update(mobilisation_period_required: true)
-      procurement.update(mobilisation_period: mobilisation_period)
+      procurement.update(mobilisation_period:)
     end
 
     context 'when mobilisation period is in the past' do
@@ -337,9 +337,9 @@ RSpec.describe FacilitiesManagement::RM3830::Procurement do
     let(:mobilisation_period) { 4 }
 
     before do
-      procurement.update(tupe: tupe)
-      procurement.update(mobilisation_period_required: mobilisation_period_required)
-      procurement.update(mobilisation_period: mobilisation_period)
+      procurement.update(tupe:)
+      procurement.update(mobilisation_period_required:)
+      procurement.update(mobilisation_period:)
     end
 
     context 'when tupe is true' do

--- a/spec/models/facilities_management/rm3830/rate_spec.rb
+++ b/spec/models/facilities_management/rm3830/rate_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe FacilitiesManagement::RM3830::Rate do
       let(:standard) { 'A' }
 
       it 'returns standard A framework rate' do
-        expect(described_class.framework_rate_for(code, standard)).to eq(described_class.find_by(code: code, standard: standard).framework)
+        expect(described_class.framework_rate_for(code, standard)).to eq(described_class.find_by(code:, standard:).framework)
       end
 
       it 'returns standard A benchmark rate' do
-        expect(described_class.benchmark_rate_for(code, standard)).to eq(described_class.find_by(code: code, standard: standard).benchmark)
+        expect(described_class.benchmark_rate_for(code, standard)).to eq(described_class.find_by(code:, standard:).benchmark)
       end
     end
 
@@ -40,11 +40,11 @@ RSpec.describe FacilitiesManagement::RM3830::Rate do
       let(:standard) { 'B' }
 
       it 'returns standard B framework rate' do
-        expect(described_class.framework_rate_for(code, standard)).to eq(described_class.find_by(code: code, standard: standard).framework)
+        expect(described_class.framework_rate_for(code, standard)).to eq(described_class.find_by(code:, standard:).framework)
       end
 
       it 'returns standard B benchmark rate' do
-        expect(described_class.benchmark_rate_for(code, standard)).to eq(described_class.find_by(code: code, standard: standard).benchmark)
+        expect(described_class.benchmark_rate_for(code, standard)).to eq(described_class.find_by(code:, standard:).benchmark)
       end
     end
 
@@ -53,11 +53,11 @@ RSpec.describe FacilitiesManagement::RM3830::Rate do
       let(:standard) { 'C' }
 
       it 'returns standard C framework rate' do
-        expect(described_class.framework_rate_for(code, standard)).to eq(described_class.find_by(code: code, standard: standard).framework)
+        expect(described_class.framework_rate_for(code, standard)).to eq(described_class.find_by(code:, standard:).framework)
       end
 
       it 'returns standard C benchmark rate' do
-        expect(described_class.benchmark_rate_for(code, standard)).to eq(described_class.find_by(code: code, standard: standard).benchmark)
+        expect(described_class.benchmark_rate_for(code, standard)).to eq(described_class.find_by(code:, standard:).benchmark)
       end
     end
 
@@ -65,11 +65,11 @@ RSpec.describe FacilitiesManagement::RM3830::Rate do
       let(:code) { 'G.9' }
 
       it 'returns framework rate' do
-        expect(described_class.framework_rate_for(code)).to eq(described_class.find_by(code: code).framework)
+        expect(described_class.framework_rate_for(code)).to eq(described_class.find_by(code:).framework)
       end
 
       it 'returns benchmark rate' do
-        expect(described_class.benchmark_rate_for(code)).to eq(described_class.find_by(code: code).benchmark)
+        expect(described_class.benchmark_rate_for(code)).to eq(described_class.find_by(code:).benchmark)
       end
     end
   end

--- a/spec/models/facilities_management/rm3830/service_spec.rb
+++ b/spec/models/facilities_management/rm3830/service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe FacilitiesManagement::RM3830::Service do
 
   it 'DA contains an example service using a frozen rate' do
     user = create(:user)
-    procurement = create(:facilities_management_rm3830_procurement, user: user)
+    procurement = create(:facilities_management_rm3830_procurement, user:)
 
     frozen_rate = FacilitiesManagement::RM3830::FrozenRate.new(facilities_management_rm3830_procurement_id: procurement.id, code: 'C.1', framework: 1.2, benchmark: 2.2, standard: 'Y', direct_award: true)
     frozen_rate.save!
@@ -56,7 +56,7 @@ RSpec.describe FacilitiesManagement::RM3830::Service do
   end
 
   describe '#mandatory?' do
-    let(:service) { described_class.new(mandatory: mandatory) }
+    let(:service) { described_class.new(mandatory:) }
 
     context 'when mandatory is "true"' do
       let(:mandatory) { 'true' }

--- a/spec/models/facilities_management/rm3830/spreadsheet_import_spec.rb
+++ b/spec/models/facilities_management/rm3830/spreadsheet_import_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe FacilitiesManagement::RM3830::SpreadsheetImport do
 
   describe 'methods for processing errors' do
     before do
-      import.update(import_errors: import_errors)
+      import.update(import_errors:)
     end
 
     describe '.building_error' do

--- a/spec/models/facilities_management/rm3830/supplier_detail_spec.rb
+++ b/spec/models/facilities_management/rm3830/supplier_detail_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FacilitiesManagement::RM3830::SupplierDetail do
         { lot => { regions: %w[r0 r2], services: %w[s0 s2] } },
         { lot => { regions: %w[r0 r3], services: %w[s0 s3] } }
       ].each do |lot_data|
-        create(:facilities_management_rm3830_supplier_detail, lot_data: lot_data)
+        create(:facilities_management_rm3830_supplier_detail, lot_data:)
       end
     end
 

--- a/spec/models/facilities_management/rm6232/admin/management_report_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/management_report_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM6232::Admin::ManagementReport do
-  subject(:management_report) { build(:facilities_management_rm6232_admin_management_report, user: user) }
+  subject(:management_report) { build(:facilities_management_rm6232_admin_management_report, user:) }
 
   let(:user) { create(:user) }
 

--- a/spec/models/facilities_management/rm6232/admin/supplier_data/edit_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/supplier_data/edit_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData::Edit do
 
     context 'when the model is supplier lot data' do
       let(:model) { lot_data }
-      let(:atrributes) { { service_codes: service_codes } }
+      let(:atrributes) { { service_codes: } }
 
       context 'and there are changes' do
         let(:service_codes) { %w[E.16 H.6 P.11 F.4] }

--- a/spec/models/facilities_management/rm6232/admin/supplier_data/snapshot_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/supplier_data/snapshot_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData::Snapshot do
   let(:snapshot) do
     described_class.new(
-      snapshot_date_yyyy: snapshot_date_yyyy,
-      snapshot_date_mm: snapshot_date_mm,
-      snapshot_date_dd: snapshot_date_dd,
-      snapshot_time_hh: snapshot_time_hh,
-      snapshot_time_mm: snapshot_time_mm
+      snapshot_date_yyyy:,
+      snapshot_date_mm:,
+      snapshot_date_dd:,
+      snapshot_time_hh:,
+      snapshot_time_mm:
     )
   end
   let(:snapshot_date) { 1.day.from_now }
@@ -190,7 +190,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData::Snapshot do
       let(:created_at) { DateTime.new(2022, 7, 5, 12, 45, 30).in_time_zone('London') }
       let(:snapshot_date) { created_at }
 
-      before { FacilitiesManagement::RM6232::Admin::SupplierData.latest_data.update(created_at: created_at) }
+      before { FacilitiesManagement::RM6232::Admin::SupplierData.latest_data.update(created_at:) }
 
       context 'and the date and time entered is before the oldest supplier data' do
         let(:snapshot_time_mm) { '44' }

--- a/spec/models/facilities_management/rm6232/admin/supplier_data_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/supplier_data_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData do
   describe '.oldest_data_created_at' do
     let(:created_at) { Time.zone.local(2022, 7, 5, 13, 45) }
 
-    before { described_class.latest_data.update(created_at: created_at) }
+    before { described_class.latest_data.update(created_at:) }
 
     it 'returns the 5th of July 2022' do
       expect(described_class.oldest_data_created_at).to eq(created_at)
@@ -27,7 +27,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SupplierData do
   describe '.oldest_data_created_at_string' do
     let(:created_at) { Time.zone.local(2022, 7, 5, 12, 45) }
 
-    before { described_class.latest_data.update(created_at: created_at) }
+    before { described_class.latest_data.update(created_at:) }
 
     it 'returns 5 July 2022, 13:45' do
       expect(described_class.oldest_data_created_at_string).to eq(' 5 July 2022, 13:45')

--- a/spec/models/facilities_management/rm6232/admin/suppliers_admin_spec.rb
+++ b/spec/models/facilities_management/rm6232/admin/suppliers_admin_spec.rb
@@ -574,7 +574,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::SuppliersAdmin do
   end
 
   describe '.current_status' do
-    let(:supplier) { create(:facilities_management_rm6232_admin_suppliers_admin, active: active) }
+    let(:supplier) { create(:facilities_management_rm6232_admin_suppliers_admin, active:) }
 
     context 'when the supplier is active' do
       let(:active) { true }

--- a/spec/models/facilities_management/rm6232/journey/choose_locations_spec.rb
+++ b/spec/models/facilities_management/rm6232/journey/choose_locations_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM6232::Journey::ChooseLocations do
-  let(:choose_locations) { described_class.new(region_codes: region_codes, annual_contract_value: annual_contract_value) }
+  let(:choose_locations) { described_class.new(region_codes:, annual_contract_value:) }
   let(:region_codes) { ['UKC1', 'UKC2'] }
   let(:annual_contract_value) { 123_456 }
 

--- a/spec/models/facilities_management/rm6232/journey/choose_services_spec.rb
+++ b/spec/models/facilities_management/rm6232/journey/choose_services_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM6232::Journey::ChooseServices do
-  let(:choose_services) { described_class.new(service_codes: service_codes, region_codes: region_codes, annual_contract_value: annual_contract_value) }
+  let(:choose_services) { described_class.new(service_codes:, region_codes:, annual_contract_value:) }
   let(:service_codes) { %w[E.1 E.2] }
   let(:region_codes) {  %w[UKC1 UKC2] }
   let(:annual_contract_value) { 123_456 }

--- a/spec/models/facilities_management/rm6232/procurement_building_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_building_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM6232::ProcurementBuilding do
-  subject(:procurement_building) { build(:facilities_management_rm6232_procurement_building_no_services, procurement: procurement, service_codes: service_codes) }
+  subject(:procurement_building) { build(:facilities_management_rm6232_procurement_building_no_services, procurement:, service_codes:) }
 
   let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements) }
   let(:service_codes) { [] }
@@ -202,7 +202,7 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementBuilding do
   end
 
   describe '.missing_region?' do
-    before { procurement_building.building.update(address_region_code: address_region_code, address_region: address_region) }
+    before { procurement_building.building.update(address_region_code:, address_region:) }
 
     let(:result) { procurement_building.missing_region? }
 
@@ -295,7 +295,7 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementBuilding do
     let(:frozen_building_attributes) { %w[building_name description address_town address_line_1 address_line_2 address_postcode address_region address_region_code gia external_area building_type other_building_type security_type other_security_type] }
 
     context 'when there is no data there already' do
-      let(:procurement_building) { create(:facilities_management_rm6232_procurement_building, procurement: procurement) }
+      let(:procurement_building) { create(:facilities_management_rm6232_procurement_building, procurement:) }
       let(:building_attributes) { procurement_building.building.attributes.slice(*frozen_building_attributes) }
 
       it 'updates the frozen data to match the the building attributes' do
@@ -310,7 +310,7 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementBuilding do
       let(:building) { create(:facilities_management_building, building_name: 'Yuzuriha', description: 'A brand new description', gia: 106) }
       let(:procurement_building_attributes) { building.attributes.slice(*frozen_building_attributes) }
 
-      before { procurement_building.update(building: building) }
+      before { procurement_building.update(building:) }
 
       it 'updates the frozen data to match the changes to the building' do
         expect { procurement_building.freeze_building_data }.to change(procurement_building, :frozen_building_data).from(inital_procurement_building_attributes).to(procurement_building_attributes)
@@ -319,7 +319,7 @@ RSpec.describe FacilitiesManagement::RM6232::ProcurementBuilding do
   end
 
   describe '.get_frozen_attribute' do
-    let(:procurement_building) { create(:facilities_management_rm6232_procurement_building_with_frozen_data, procurement: procurement, building: building) }
+    let(:procurement_building) { create(:facilities_management_rm6232_procurement_building_with_frozen_data, procurement:, building:) }
     let(:building) { create(:facilities_management_building, building_name: 'Yuzuriha', other_building_type: 'Some other building type', other_security_type: 'Some other security type') }
     let(:result) { procurement_building.get_frozen_attribute(attribute) }
 

--- a/spec/models/facilities_management/rm6232/procurement_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   it { is_expected.to belong_to(:user) }
 
   describe '.quick_view_suppliers' do
-    let(:procurement) { build(:facilities_management_rm6232_procurement_no_procurement_buildings, service_codes: service_codes) }
+    let(:procurement) { build(:facilities_management_rm6232_procurement_no_procurement_buildings, service_codes:) }
     let(:base_service_codes) { ['E.1', 'E.2'] }
     let(:service_codes) { base_service_codes }
 
@@ -26,7 +26,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   end
 
   describe '.supplier_names' do
-    let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, service_codes: service_codes) }
+    let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, service_codes:) }
     let(:base_service_codes) { ['E.1', 'E.2'] }
     let(:service_codes) { base_service_codes }
 
@@ -88,7 +88,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   end
 
   describe '.services' do
-    let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, service_codes: service_codes, lot_number: lot_number) }
+    let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, service_codes:, lot_number:) }
     let(:base_service_codes) { ['E.1', 'E.2'] }
     let(:service_codes) { base_service_codes }
     let(:lot_number) { '1a' }
@@ -135,7 +135,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   end
 
   describe '.procurement_services' do
-    let(:procurement) { create(:facilities_management_rm6232_procurement_results, service_codes: service_codes, lot_number: lot_number) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_results, service_codes:, lot_number:) }
     let(:base_service_codes) { ['E.1', 'E.2', 'E.3', 'E.4', 'E.5'] }
     let(:service_codes) { base_service_codes }
     let(:lot_number) { '1a' }
@@ -184,7 +184,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   end
 
   describe '.services_without_lot_consideration' do
-    let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, service_codes: service_codes, lot_number: lot_number) }
+    let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, service_codes:, lot_number:) }
     let(:base_service_codes) { ['E.1', 'E.2'] }
     let(:service_codes) { base_service_codes }
     let(:lot_number) { '1a' }
@@ -239,7 +239,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   end
 
   describe '.service_codes_without_cafm' do
-    let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, service_codes: service_codes) }
+    let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, service_codes:) }
     let(:base_service_codes) { ['E.1', 'E.2', 'F.1', 'F.2', 'H.1'] }
 
     context 'when the service codes contain Q.3' do
@@ -262,7 +262,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   end
 
   describe '.true_service_codes' do
-    let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, service_codes: service_codes, lot_number: lot_number) }
+    let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, service_codes:, lot_number:) }
     let(:base_service_codes) { ['E.1', 'E.2', 'F.1', 'F.2', 'H.1'] }
     let(:lot_number) { '1a' }
 
@@ -594,7 +594,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   describe '.contract_name_status' do
     subject(:status) { procurement.contract_name_status }
 
-    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, contract_name: contract_name) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, contract_name:) }
 
     context 'when the contract name section has not been completed' do
       let(:contract_name) { '' }
@@ -616,7 +616,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   describe '.annual_contract_value_status' do
     subject(:status) { procurement.annual_contract_value_status }
 
-    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, annual_contract_value: annual_contract_value) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, annual_contract_value:) }
 
     context 'when the annual contract cost section has not been completed' do
       let(:annual_contract_value) { nil }
@@ -638,7 +638,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   describe '.tupe_status' do
     subject(:status) { procurement.tupe_status }
 
-    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, tupe: tupe) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, tupe:) }
 
     context 'when the tupe section has not been completed' do
       let(:tupe) { nil }
@@ -688,7 +688,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   describe '.services_status' do
     subject(:status) { procurement.services_status }
 
-    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, service_codes: service_codes) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, service_codes:) }
 
     context 'when user has not yet selected services' do
       let(:service_codes) { [] }
@@ -729,7 +729,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
 
   shared_context 'with buildings and services' do
     let(:procurement) do
-      create(:facilities_management_rm6232_procurement_entering_requirements, procurement_buildings: procurement_buildings)
+      create(:facilities_management_rm6232_procurement_entering_requirements, procurement_buildings:)
     end
 
     let(:procurement_buildings) { [procurement_building1, procurement_building2] }
@@ -742,7 +742,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
     include_context 'with buildings and services'
 
     before do
-      procurement_building1.update(service_codes: service_codes)
+      procurement_building1.update(service_codes:)
       procurement_building2.update(service_codes: %w[E.1 E.2])
     end
 
@@ -818,7 +818,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   end
 
   describe '.initial_call_off_period' do
-    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, initial_call_off_period_years: initial_call_off_period_years, initial_call_off_period_months: initial_call_off_period_months) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, initial_call_off_period_years:, initial_call_off_period_months:) }
 
     context 'when the years are 0 and months 3' do
       let(:initial_call_off_period_years) { 0 }
@@ -849,7 +849,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   end
 
   describe '.initial_call_off_end_date' do
-    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, initial_call_off_period_years: initial_call_off_period_years, initial_call_off_period_months: initial_call_off_period_months, initial_call_off_start_date: initial_call_off_start_date) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, initial_call_off_period_years:, initial_call_off_period_months:, initial_call_off_start_date:) }
 
     context 'when the start date is 2022/03/01 and the period is 3 years and 4 months' do
       let(:initial_call_off_start_date) { Time.new(2022, 3, 1).in_time_zone('London') }
@@ -1164,7 +1164,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   end
 
   describe '.procurement_buildings_service_codes' do
-    let(:procurement) { create(:facilities_management_rm6232_procurement_results, service_codes: service_codes) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_results, service_codes:) }
     let(:service_codes) { ['E.1', 'E.2', 'E.3', 'E.4'] }
 
     before do
@@ -1179,7 +1179,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
   end
 
   describe '.true_procurement_buildings_service_codes' do
-    let(:procurement) { create(:facilities_management_rm6232_procurement_results, service_codes: service_codes, lot_number: lot_number) }
+    let(:procurement) { create(:facilities_management_rm6232_procurement_results, service_codes:, lot_number:) }
     let(:base_service_codes) { ['E.1', 'E.2', 'F.1', 'F.2', 'H.1'] }
     let(:base_procurement_buildings_service_codes) { ['E.1', 'F.1', 'H.1'] }
     let(:lot_number) { '1a' }

--- a/spec/models/facilities_management/rm6232/procurement_validations_spec.rb
+++ b/spec/models/facilities_management/rm6232/procurement_validations_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe FacilitiesManagement::RM6232::Procurement do
   describe 'validations' do
     describe 'contract_name' do
-      let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, user: user) }
+      let(:procurement) { build(:facilities_management_rm6232_procurement_what_happens_next, user:) }
       let(:user) { create(:user) }
 
       before { procurement.contract_name = contract_name }
@@ -39,7 +39,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
         let(:contract_name) { 'My taken name' }
 
         it 'is expected to not be valid and has the correct error message' do
-          create(:facilities_management_rm6232_procurement_what_happens_next, user: user, contract_name: contract_name)
+          create(:facilities_management_rm6232_procurement_what_happens_next, user:, contract_name:)
 
           expect(procurement.valid?(:contract_name)).to be false
           expect(procurement.errors[:contract_name].first).to eq 'This contract name is already in use'
@@ -66,7 +66,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
     end
 
     describe 'annual_contract_value' do
-      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, annual_contract_value: annual_contract_value) }
+      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, annual_contract_value:) }
 
       context 'when no annual contract cost is present' do
         let(:annual_contract_value) { nil }
@@ -123,7 +123,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
     end
 
     describe 'tupe' do
-      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, tupe: tupe) }
+      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, tupe:) }
 
       context 'when it is blank' do
         let(:tupe) { '' }
@@ -169,7 +169,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
     end
 
     describe 'services' do
-      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, service_codes: service_codes) }
+      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, service_codes:) }
 
       context 'when no service codes are present' do
         let(:service_codes) { [] }
@@ -285,7 +285,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
     end
 
     describe '.contract_period_in_past?' do
-      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, initial_call_off_start_date: initial_call_off_start_date) }
+      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, initial_call_off_start_date:) }
 
       context 'when initial call off period is in the past' do
         let(:initial_call_off_start_date) { Time.now.in_time_zone('London') - 10.days }
@@ -326,7 +326,7 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
 
     # rubocop:disable RSpec/NestedGroups
     describe '.mobilisation_period_valid_when_tupe_required?' do
-      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, tupe: tupe, mobilisation_period_required: mobilisation_period_required, mobilisation_period: mobilisation_period) }
+      let(:procurement) { build(:facilities_management_rm6232_procurement_entering_requirements, tupe:, mobilisation_period_required:, mobilisation_period:) }
       let(:mobilisation_period_required) { false }
       let(:mobilisation_period) { 4 }
 
@@ -369,8 +369,8 @@ RSpec.describe FacilitiesManagement::RM6232::Procurement do
     end
 
     describe 'validations on entering_requirements' do
-      let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, user: user) }
-      let(:building) { create(:facilities_management_building, user: user) }
+      let(:procurement) { create(:facilities_management_rm6232_procurement_entering_requirements, user:) }
+      let(:building) { create(:facilities_management_building, user:) }
       let(:user) { create(:user) }
 
       context 'with valid scenarios' do

--- a/spec/models/facilities_management/rm6232/supplier/lot_data_spec.rb
+++ b/spec/models/facilities_management/rm6232/supplier/lot_data_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData do
-  let(:lot_data) { described_class.where(facilities_management_rm6232_supplier_id: supplier_id).find_by(lot_code: lot_code) }
+  let(:lot_data) { described_class.where(facilities_management_rm6232_supplier_id: supplier_id).find_by(lot_code:) }
   let(:random_lot_data) { described_class.order(Arel.sql('RANDOM()')).first }
 
   describe '.supplier_name' do
@@ -14,7 +14,7 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData do
 
   describe '.services' do
     let(:lot_code) { '1a' }
-    let(:random_lot_data) { described_class.where(lot_code: lot_code).order(Arel.sql('RANDOM()')).first }
+    let(:random_lot_data) { described_class.where(lot_code:).order(Arel.sql('RANDOM()')).first }
 
     it 'returns a collection of services' do
       expect(random_lot_data.services.class.to_s).to eq 'FacilitiesManagement::RM6232::Service::ActiveRecord_Relation'
@@ -63,7 +63,7 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData do
 
   describe 'validations' do
     context 'when validating the lot status' do
-      let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier, active: active) }
+      let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier, active:) }
 
       context 'and active is nil' do
         let(:active) { nil }
@@ -101,7 +101,7 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData do
     end
 
     context 'when validating the region codes' do
-      let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier, region_codes: region_codes) }
+      let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier, region_codes:) }
 
       context 'and there are none' do
         let(:region_codes) { [] }
@@ -146,7 +146,7 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData do
     end
 
     context 'when changing the services' do
-      let(:attributes) { { service_codes: service_codes } }
+      let(:attributes) { { service_codes: } }
 
       context 'and a service is added' do
         let(:service_codes) { %w[E.16 H.6 P.11 F.4] }
@@ -198,7 +198,7 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData do
     end
 
     context 'when changing the regions' do
-      let(:attributes) { { region_codes: region_codes } }
+      let(:attributes) { { region_codes: } }
 
       context 'and a region is added' do
         let(:region_codes) { %w[UKC1 UKD1 UKE1 UKF1] }
@@ -251,7 +251,7 @@ RSpec.describe FacilitiesManagement::RM6232::Supplier::LotData do
   end
 
   describe '.current_status' do
-    let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier, active: active) }
+    let(:lot_data) { create(:facilities_management_rm6232_supplier_lot_data, :with_supplier, active:) }
 
     context 'when the lot data is active' do
       let(:active) { true }

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe Framework do
   end
 
   describe '.status' do
-    let(:result) { described_class.find_by(framework: framework).status }
+    let(:result) { described_class.find_by(framework:).status }
 
     context 'when considering facilities_management frameworks' do
       context 'when the framework passed is RM3830' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  subject(:user) { build(:user, :without_detail, confirmed_at: confirmed_at) }
+  subject(:user) { build(:user, :without_detail, confirmed_at:) }
 
   describe '#confirmed?' do
     context 'when confirmed_at blank' do

--- a/spec/services/cognito/admin/user_spec.rb
+++ b/spec/services/cognito/admin/user_spec.rb
@@ -19,22 +19,22 @@ RSpec.describe Cognito::Admin::User do
 
   let(:attributes) do
     {
-      cognito_uuid: cognito_uuid,
-      email: email,
-      email_verified: email_verified,
-      telephone_number: telephone_number,
-      roles: roles,
-      service_access: service_access,
-      account_status: account_status,
-      confirmation_status: confirmation_status,
-      mfa_enabled: mfa_enabled
+      cognito_uuid:,
+      email:,
+      email_verified:,
+      telephone_number:,
+      roles:,
+      service_access:,
+      account_status:,
+      confirmation_status:,
+      mfa_enabled:
     }
   end
 
   describe '#validations on select_role' do
     let(:attributes) do
       {
-        roles: roles,
+        roles:,
       }
     end
 
@@ -78,8 +78,8 @@ RSpec.describe Cognito::Admin::User do
   describe '#validations on select_service_access' do
     let(:attributes) do
       {
-        roles: roles,
-        service_access: service_access
+        roles:,
+        service_access:
       }
     end
     let(:roles) { %w[buyer] }
@@ -114,10 +114,10 @@ RSpec.describe Cognito::Admin::User do
   describe '#validations on enter_user_details' do
     let(:attributes) do
       {
-        email: email,
-        telephone_number: telephone_number,
-        roles: roles,
-        service_access: service_access
+        email:,
+        telephone_number:,
+        roles:,
+        service_access:
       }
     end
     let(:allow_list_file) { Tempfile.new('allow_list.txt') }
@@ -132,7 +132,7 @@ RSpec.describe Cognito::Admin::User do
       allow_any_instance_of(AllowedEmailDomain).to receive(:allow_list_file_path).and_return(allow_list_file.path)
       # rubocop:enable RSpec/AnyInstance
       allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client)
-      allow(aws_client).to receive(:list_users).and_return(list_users_resp_struct.new(users: users))
+      allow(aws_client).to receive(:list_users).and_return(list_users_resp_struct.new(users:))
     end
 
     after do
@@ -262,10 +262,10 @@ RSpec.describe Cognito::Admin::User do
   describe '#validations on create' do
     let(:attributes) do
       {
-        email: email,
-        telephone_number: telephone_number,
-        roles: roles,
-        service_access: service_access
+        email:,
+        telephone_number:,
+        roles:,
+        service_access:
       }
     end
     let(:allow_list_file) { Tempfile.new('allow_list.txt') }

--- a/spec/services/cognito/respond_to_challenge_spec.rb
+++ b/spec/services/cognito/respond_to_challenge_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Cognito::RespondToChallenge do
   before { allow(Aws::CognitoIdentityProvider::Client).to receive(:new).and_return(aws_client) }
 
   describe '#validations' do
-    let(:response) { described_class.new(challenge_name, username, session, new_password: new_password, new_password_confirmation: new_password_confirmation) }
+    let(:response) { described_class.new(challenge_name, username, session, new_password:, new_password_confirmation:) }
 
     before do
       allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
@@ -62,7 +62,7 @@ RSpec.describe Cognito::RespondToChallenge do
 
   describe '#call' do
     context 'when NEW_PASSWORD_REQUIRED challenge success' do
-      let(:response) { described_class.call(challenge_name, username, session, new_password: new_password, new_password_confirmation: new_password_confirmation) }
+      let(:response) { described_class.call(challenge_name, username, session, new_password:, new_password_confirmation:) }
 
       before do
         allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session))
@@ -92,7 +92,7 @@ RSpec.describe Cognito::RespondToChallenge do
 
     context 'when SMS_MFA challenge success' do
       let(:challenge_name) { 'SMS_MFA' }
-      let(:response) { described_class.call(challenge_name, username, session, access_code: access_code) }
+      let(:response) { described_class.call(challenge_name, username, session, access_code:) }
 
       before { allow(aws_client).to receive(:respond_to_auth_challenge).and_return(respond_to_auth_challenge_resp_struct.new(challenge_name: new_challenge_name, session: new_session)) }
 
@@ -118,7 +118,7 @@ RSpec.describe Cognito::RespondToChallenge do
     end
 
     context 'when cognito error' do
-      let(:response) { described_class.call(challenge_name, username, session, new_password: new_password, new_password_confirmation: new_password_confirmation) }
+      let(:response) { described_class.call(challenge_name, username, session, new_password:, new_password_confirmation:) }
 
       before { allow(aws_client).to receive(:respond_to_auth_challenge).and_raise(Aws::CognitoIdentityProvider::Errors::ServiceError.new('oops', 'Oops')) }
 

--- a/spec/services/facilities_management/rm3830/admin/sublot_services_validator_spec.rb
+++ b/spec/services/facilities_management/rm3830/admin/sublot_services_validator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::SublotServicesValidator do
   let(:supplier_id) { FacilitiesManagement::RM3830::Admin::SuppliersAdmin.find_by(supplier_name: 'Abernathy and Sons').supplier_id.to_sym }
 
   describe '.save' do
-    let(:params) { ActionController::Parameters.new(data: data, rate: rate) }
+    let(:params) { ActionController::Parameters.new(data:, rate:) }
     let(:latest_rate_card) { FacilitiesManagement::RM3830::RateCard.latest }
     let(:prices) { latest_rate_card[:data][:Prices][supplier_id].deep_stringify_keys! }
     let(:discounts) { latest_rate_card[:data][:Discounts][supplier_id].deep_stringify_keys! }

--- a/spec/services/facilities_management/rm3830/assessed_value_calculator_scenario_0_spec.rb
+++ b/spec/services/facilities_management/rm3830/assessed_value_calculator_scenario_0_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
   let(:lot_number) { assessed_value_calulator.lot_number }
 
   let(:user) { create(:user) }
-  let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, user: user, service_codes: service_codes, **additional_params) }
+  let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, user:, service_codes:, **additional_params) }
 
   describe 'when all services have framework and beanchmaek rates' do
     context 'when CAFM Helpdesk and TUPE are not required' do
       let(:service_codes) { %w[C.1 G.1 I.1 K.2] }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: 34)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 6240)
@@ -42,7 +42,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:service_codes) { %w[C.1 G.1 I.1 K.2 M.1 N.1] }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: 34)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 6240)
@@ -71,12 +71,12 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { estimated_annual_cost: estimated_annual_cost, tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: initial_call_off_period_years, initial_call_off_period_months: 0 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
-        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
+        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
         procurement.procurement_building_services.where(code: %w[C.2 C.5 G.1]).each { |pbs| pbs.update(service_standard: 'A') }
         procurement.procurement_building_services.where(code: 'G.1').each { |pbs| pbs.update(no_of_building_occupants: volume) }
         procurement.procurement_building_services.where(code: 'E.4').each { |pbs| pbs.update(no_of_appliances_for_testing: volume) }
-        procurement.procurement_building_services.where(code: 'C.5').each { |pbs| no_of_lifts.times { pbs.lifts.create(number_of_floors: number_of_floors) } }
+        procurement.procurement_building_services.where(code: 'C.5').each { |pbs| no_of_lifts.times { pbs.lifts.create(number_of_floors:) } }
       end
 
       context 'and the lot is 1a' do

--- a/spec/services/facilities_management/rm3830/assessed_value_calculator_scenario_1a_spec.rb
+++ b/spec/services/facilities_management/rm3830/assessed_value_calculator_scenario_1a_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
   let(:lot_number) { assessed_value_calulator.lot_number }
 
   let(:user) { create(:user) }
-  let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, user: user, estimated_annual_cost: estimated_annual_cost, service_codes: service_codes, **additional_params) }
+  let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, user:, estimated_annual_cost:, service_codes:, **additional_params) }
 
   describe 'when the buyer input is known and any service is missing framework rate' do
     context 'when CAFM Helpdesk and TUPE are not required' do
@@ -15,7 +15,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: false, mobilisation_period_required: false, extensions_required: false, initial_call_off_period_years: 1, initial_call_off_period_months: 0 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: 34)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 6240)
@@ -60,7 +60,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: 1, initial_call_off_period_months: 0 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: 34)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 6240)
@@ -105,7 +105,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: false, mobilisation_period_required: false, extensions_required: false, initial_call_off_period_years: 4, initial_call_off_period_months: 8 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: 18000)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 8736)
@@ -155,7 +155,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: false, mobilisation_period_required: false, extensions_required: false, initial_call_off_period_years: 6, initial_call_off_period_months: 9 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: 88000)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 8736)
@@ -205,7 +205,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: false, mobilisation_period_required: false, extensions_required: false, initial_call_off_period_years: 7, initial_call_off_period_months: 0 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: 88000)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 8736)
@@ -251,8 +251,8 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: 5, initial_call_off_period_months: 7 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
-        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
+        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
         procurement.procurement_building_services.where(code: 'C.1').each { |pbs| pbs.update(service_standard: 'A') }
         procurement.procurement_building_services.where(code: 'G.1').each { |pbs| pbs.update(service_standard: 'A', no_of_building_occupants: 88000) }
         procurement.procurement_building_services.where(code: 'I.1').each { |pbs| pbs.update(service_hours: 8736) }

--- a/spec/services/facilities_management/rm3830/assessed_value_calculator_scenario_1b_spec.rb
+++ b/spec/services/facilities_management/rm3830/assessed_value_calculator_scenario_1b_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
   let(:lot_number) { assessed_value_calulator.lot_number }
 
   let(:user) { create(:user) }
-  let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, user: user, estimated_annual_cost: estimated_annual_cost, service_codes: service_codes, **additional_params) }
+  let(:procurement) { create(:facilities_management_rm3830_procurement_no_procurement_buildings, user:, estimated_annual_cost:, service_codes:, **additional_params) }
 
   describe 'when the buyer input is known and any service is missing framework and benchmark rate' do
     context 'when CAFM Helpdesk and TUPE are not required' do
@@ -15,7 +15,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: false, mobilisation_period_required: false, extensions_required: false, initial_call_off_period_years: 1, initial_call_off_period_months: 0 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: 34)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 6240)
@@ -60,7 +60,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: 1, initial_call_off_period_months: 0 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: 34)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 6240)
@@ -105,7 +105,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: 2, initial_call_off_period_months: 4 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: 3400)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 6240)
@@ -154,8 +154,8 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: 7, initial_call_off_period_months: 0 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
-        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
+        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
         procurement.procurement_building_services.where(code: 'C.1').each { |pbs| pbs.update(service_standard: 'A') }
         procurement.procurement_building_services.where(code: 'G.1').each { |pbs| pbs.update(service_standard: 'A', no_of_building_occupants: 3400) }
         procurement.procurement_building_services.where(code: 'I.1').each { |pbs| pbs.update(service_hours: 6240) }

--- a/spec/services/facilities_management/rm3830/assessed_value_calculator_scenario_3_spec.rb
+++ b/spec/services/facilities_management/rm3830/assessed_value_calculator_scenario_3_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
         let(:additional_params) { { tupe: false, mobilisation_period_required: false, extensions_required: false, initial_call_off_period_years: 1, initial_call_off_period_months: 6 } }
 
         before do
-          create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
+          create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
           procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         end
 
@@ -31,7 +31,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
         let(:additional_params) { { tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: 1, initial_call_off_period_months: 6 } }
 
         before do
-          create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+          create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
           procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         end
 
@@ -48,7 +48,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
         let(:additional_params) { { tupe: false, mobilisation_period_required: false, extensions_required: false, initial_call_off_period_years: 1, initial_call_off_period_months: 6 } }
 
         before do
-          create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
+          create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
           procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
           procurement.procurement_building_services.find_by(code: 'C.2').update(service_standard: 'A')
           procurement.procurement_building_services.find_by(code: 'G.3').update(service_standard: 'A', no_of_building_occupants: 10000)
@@ -68,7 +68,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
         let(:additional_params) { { tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: 1, initial_call_off_period_months: 6 } }
 
         before do
-          create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+          create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
           procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
           procurement.procurement_building_services.find_by(code: 'C.2').update(service_standard: 'A')
           procurement.procurement_building_services.find_by(code: 'G.3').update(service_standard: 'A', no_of_building_occupants: 10000)
@@ -90,7 +90,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
         let(:additional_params) { { tupe: false, mobilisation_period_required: false, extensions_required: false, initial_call_off_period_years: 3, initial_call_off_period_months: 1 } }
 
         before do
-          create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
+          create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
           procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
           procurement.procurement_building_services.find_by(code: 'C.2').update(service_standard: 'A')
           procurement.procurement_building_services.find_by(code: 'G.3').update(service_standard: 'A', no_of_building_occupants: 10000)
@@ -110,7 +110,7 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
         let(:additional_params) { { tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: 3, initial_call_off_period_months: 1 } }
 
         before do
-          create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+          create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
           procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
           procurement.procurement_building_services.find_by(code: 'C.2').update(service_standard: 'A')
           procurement.procurement_building_services.find_by(code: 'G.3').update(service_standard: 'A', no_of_building_occupants: 10000)

--- a/spec/services/facilities_management/rm3830/assessed_value_calculator_scenario_4_spec.rb
+++ b/spec/services/facilities_management/rm3830/assessed_value_calculator_scenario_4_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: false, mobilisation_period_required: false, extensions_required: false, initial_call_off_period_years: 0, initial_call_off_period_months: 6 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: no_of_building_occupants)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 6240)
-        procurement.procurement_building_services.find_by(code: 'K.2').update(tones_to_be_collected_and_removed: tones_to_be_collected_and_removed)
+        procurement.procurement_building_services.find_by(code: 'K.2').update(tones_to_be_collected_and_removed:)
       end
 
       context 'and the variance is just below 30%' do
@@ -46,11 +46,11 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: 0, initial_call_off_period_months: 6 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: no_of_building_occupants)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 6240)
-        procurement.procurement_building_services.find_by(code: 'K.2').update(tones_to_be_collected_and_removed: tones_to_be_collected_and_removed)
+        procurement.procurement_building_services.find_by(code: 'K.2').update(tones_to_be_collected_and_removed:)
       end
 
       context 'and the variance is just below 30%' do
@@ -77,11 +77,11 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: 3, initial_call_off_period_months: 8 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
         procurement.procurement_building_services.find_by(code: 'C.1').update(service_standard: 'A')
         procurement.procurement_building_services.find_by(code: 'G.1').update(service_standard: 'A', no_of_building_occupants: no_of_building_occupants)
         procurement.procurement_building_services.find_by(code: 'I.1').update(service_hours: 6240)
-        procurement.procurement_building_services.find_by(code: 'K.2').update(tones_to_be_collected_and_removed: tones_to_be_collected_and_removed)
+        procurement.procurement_building_services.find_by(code: 'K.2').update(tones_to_be_collected_and_removed:)
       end
 
       context 'and the variance is just below 30%' do
@@ -110,12 +110,12 @@ RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
       let(:additional_params) { { tupe: true, mobilisation_period_required: true, mobilisation_period: 4, extensions_required: false, initial_call_off_period_years: 7, initial_call_off_period_months: 0 } }
 
       before do
-        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement: procurement, service_codes: service_codes)
-        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement: procurement, service_codes: service_codes)
+        create(:facilities_management_rm3830_procurement_building_av_normal_building, procurement:, service_codes:)
+        create(:facilities_management_rm3830_procurement_building_av_london_building, procurement:, service_codes:)
         procurement.procurement_building_services.where(code: %w[C.1 C.2 C.3]).each { |pbs| pbs.update(service_standard: 'A') }
         procurement.procurement_building_services.where(code: 'G.1').each { |pbs| pbs.update(service_standard: 'A', no_of_building_occupants: no_of_building_occupants) }
         procurement.procurement_building_services.where(code: 'I.1').each { |pbs| pbs.update(service_hours: 6240) }
-        procurement.procurement_building_services.where(code: %w[K.2 K.3]).each { |pbs| pbs.update(tones_to_be_collected_and_removed: tones_to_be_collected_and_removed) }
+        procurement.procurement_building_services.where(code: %w[K.2 K.3]).each { |pbs| pbs.update(tones_to_be_collected_and_removed:) }
       end
 
       context 'and the variance is just below 30%' do

--- a/spec/services/facilities_management/rm3830/assessed_value_calculator_spec.rb
+++ b/spec/services/facilities_management/rm3830/assessed_value_calculator_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM3830::AssessedValueCalculator do
   let(:user) { create(:user, :with_detail, email: 'test@example.com', id: 'dGFyaXEuaGFtaWRAY3Jvd25jb21tZXJjaWFsLmdvdi51aw==\n') }
-  let(:procurement_lot1a) { create(:facilities_management_rm3830_procurement_with_contact_details_with_buildings, user: user) }
+  let(:procurement_lot1a) { create(:facilities_management_rm3830_procurement_with_contact_details_with_buildings, user:) }
   let(:procurement_lot1c) { create(:facilities_management_rm3830_procurement_with_contact_details_with_buildings, user: user, lot_number: '1c', lot_number_selected_by_customer: true) }
 
   describe '.sorted_list' do

--- a/spec/services/facilities_management/rm3830/delete_procurement_spec.rb
+++ b/spec/services/facilities_management/rm3830/delete_procurement_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe FacilitiesManagement::RM3830::DeleteProcurement do
         procurement.update(aasm_state: 'results')
         procurement.send(:copy_fm_rates_to_frozen)
         procurement.send(:copy_fm_rate_cards_to_frozen)
-        create(:facilities_management_rm3830_procurement_supplier, procurement: procurement)
+        create(:facilities_management_rm3830_procurement_supplier, procurement:)
       end
 
       context 'when the procurement has not been deleted' do

--- a/spec/services/facilities_management/rm3830/direct_award_deliverables_matrix_spec.rb
+++ b/spec/services/facilities_management/rm3830/direct_award_deliverables_matrix_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe FacilitiesManagement::RM3830::DirectAwardDeliverablesMatrix do
   let(:detail_of_requirement) { 'Details of the requirement' }
   let(:no_of_appliances_for_testing) { 506 }
   let(:user) { create(:user, :with_detail, email: 'test@example.com', id: 'dGFyaXEuaGFtaWRAY3Jvd25jb21tZXJjaWFsLmdvdi51aw==\n') }
-  let(:procurement) { create(:facilities_management_rm3830_procurement_with_contact_details_with_buildings, user: user) }
+  let(:procurement) { create(:facilities_management_rm3830_procurement_with_contact_details_with_buildings, user:) }
   let(:supplier) { create(:facilities_management_rm3830_supplier_detail) }
   let(:contract) { create(:facilities_management_rm3830_procurement_supplier_da, procurement: procurement, supplier_id: supplier.id) }
 
@@ -27,7 +27,7 @@ RSpec.describe FacilitiesManagement::RM3830::DirectAwardDeliverablesMatrix do
     procurement.active_procurement_buildings.each do |building|
       service_codes = building.procurement_building_services.map(&:code)
 
-      building.update(service_codes: service_codes)
+      building.update(service_codes:)
     end
   end
 

--- a/spec/services/facilities_management/rm3830/price_matrix_spreadsheet_spec.rb
+++ b/spec/services/facilities_management/rm3830/price_matrix_spreadsheet_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe FacilitiesManagement::RM3830::PriceMatrixSpreadsheet do
   end
 
   let(:user) { create(:user, :with_detail, email: 'test@example.com', id: 'dGFyaXEuaGFtaWRAY3Jvd25jb21tZXJjaWFsLmdvdi51aw==\n') }
-  let(:procurement) { create(:facilities_management_rm3830_procurement_with_contact_details_with_buildings, user: user) }
+  let(:procurement) { create(:facilities_management_rm3830_procurement_with_contact_details_with_buildings, user:) }
   let(:supplier_name) { 'Bogan-Koch' }
   let(:supplier_details) { create(:facilities_management_rm3830_supplier_detail_with_lots) }
-  let(:supplier) { FacilitiesManagement::RM3830::SupplierDetail.find_by(supplier_name: supplier_name) }
+  let(:supplier) { FacilitiesManagement::RM3830::SupplierDetail.find_by(supplier_name:) }
   let(:contract) { create(:facilities_management_rm3830_procurement_supplier_da, procurement: procurement, supplier_id: supplier.id) }
 
   before { supplier.update(lot_data: supplier_details.lot_data) }

--- a/spec/services/facilities_management/rm3830/procurement_router_spec.rb
+++ b/spec/services/facilities_management/rm3830/procurement_router_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FacilitiesManagement::RM3830::ProcurementRouter do
-  let(:procurement_router) { described_class.new(1, state, step: step) }
+  let(:procurement_router) { described_class.new(1, state, step:) }
   let(:step) { nil }
 
   describe '.route' do
@@ -76,7 +76,7 @@ RSpec.describe FacilitiesManagement::RM3830::ProcurementRouter do
 
       context 'when on the last step' do
         let(:procurement_building) { create(:facilities_management_rm3830_procurement_building, procurement: create(:facilities_management_rm3830_procurement, id: 1, procurement_buildings: [])) }
-        let(:procurement_router) { described_class.new(procurement_building.procurement.id, state, step: step) }
+        let(:procurement_router) { described_class.new(procurement_building.procurement.id, state, step:) }
         let(:step) { 'building_services' }
 
         it 'returns a route for the show procurement_building page' do

--- a/spec/services/facilities_management/rm3830/spreadsheet_importer_spec.rb
+++ b/spec/services/facilities_management/rm3830/spreadsheet_importer_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe FacilitiesManagement::RM3830::SpreadsheetImporter, type: :service
       spreadsheet_importer.import_data
     end
 
-    let(:procurement) { create(:facilities_management_rm3830_procurement, user: user) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement, user:) }
     let(:user) { create(:user) }
     let(:spreadsheet_building) { create(:facilities_management_building) }
     let(:spreadsheet_building_2) { create(:facilities_management_building, building_name: spreadsheet_building.building_name) }
@@ -207,7 +207,7 @@ RSpec.describe FacilitiesManagement::RM3830::SpreadsheetImporter, type: :service
       end
 
       describe 'address_line_2' do
-        let(:spreadsheet_building) { create(:facilities_management_building, address_line_2: address_line_2) }
+        let(:spreadsheet_building) { create(:facilities_management_building, address_line_2:) }
         let(:building_data) { [[spreadsheet_building, 'Complete']] }
 
         context 'when the address_line_2 is blank' do
@@ -488,7 +488,7 @@ RSpec.describe FacilitiesManagement::RM3830::SpreadsheetImporter, type: :service
           let(:building_data) do
             FacilitiesManagement::Building::BUILDING_TYPES.pluck(:spreadsheet_title).map do |building_type|
               [
-                create(:facilities_management_building, building_type: building_type),
+                create(:facilities_management_building, building_type:),
                 'Complete'
               ]
             end
@@ -583,7 +583,7 @@ RSpec.describe FacilitiesManagement::RM3830::SpreadsheetImporter, type: :service
     end
 
     describe 'import with valid data and missing region' do
-      let(:user_building) { create(:facilities_management_building, user: user) }
+      let(:user_building) { create(:facilities_management_building, user:) }
 
       # rubocop:disable RSpec/AnyInstance
       before do
@@ -1331,7 +1331,7 @@ RSpec.describe FacilitiesManagement::RM3830::SpreadsheetImporter, type: :service
       procurement.reload
     end
 
-    let(:procurement) { create(:facilities_management_rm3830_procurement, user: user) }
+    let(:procurement) { create(:facilities_management_rm3830_procurement, user:) }
     let(:user) { create(:user) }
 
     let(:name1) { 'The TARDIS' }

--- a/spec/services/facilities_management/rm3830/summary_report_contract_length_spec.rb
+++ b/spec/services/facilities_management/rm3830/summary_report_contract_length_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe FacilitiesManagement::RM3830::SummaryReport, type: :model do
 
   let(:procurement) do
     create(:facilities_management_rm3830_procurement_with_contact_details_with_buildings,
-           initial_call_off_period_years: initial_call_off_period_years,
-           initial_call_off_period_months: initial_call_off_period_months)
+           initial_call_off_period_years:,
+           initial_call_off_period_months:)
   end
 
   let(:supplier_id) { '24bde4cf-6ccc-4367-ba16-77deb593d3c3' }

--- a/spec/services/facilities_management/rm3830/summary_report_futher_competition_spec.rb
+++ b/spec/services/facilities_management/rm3830/summary_report_futher_competition_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe FacilitiesManagement::RM3830::SummaryReport, type: :model do
              procurement_building: create(:facilities_management_rm3830_procurement_building_no_services,
                                           building_id: create(:facilities_management_building_london).id,
                                           procurement: create(:facilities_management_rm3830_procurement_no_procurement_buildings,
-                                                              estimated_annual_cost: estimated_annual_cost,
-                                                              estimated_cost_known: estimated_cost_known)))
+                                                              estimated_annual_cost:,
+                                                              estimated_cost_known:)))
     end
     let(:procurement_building_service_1) do
       create(:facilities_management_rm3830_procurement_building_service,
@@ -56,7 +56,7 @@ RSpec.describe FacilitiesManagement::RM3830::SummaryReport, type: :model do
 
     before do
       lift_data.each do |number_of_floors|
-        procurement_building_service.lifts.create(number_of_floors: number_of_floors)
+        procurement_building_service.lifts.create(number_of_floors:)
       end
 
       report.calculate_services_for_buildings

--- a/spec/services/facilities_management/rm3830/summary_report_procurements_spec.rb
+++ b/spec/services/facilities_management/rm3830/summary_report_procurements_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FacilitiesManagement::RM3830::SummaryReport, type: :model do
   before do
     procurement.send(:copy_procurement_buildings_data)
     lift_data&.each do |number_of_floors|
-      procurement_building_service.lifts.create(number_of_floors: number_of_floors)
+      procurement_building_service.lifts.create(number_of_floors:)
     end
     report.calculate_services_for_buildings
   end
@@ -39,7 +39,7 @@ RSpec.describe FacilitiesManagement::RM3830::SummaryReport, type: :model do
              no_of_units_to_be_serviced: no_of_units_to_be_serviced,
              service_hours: service_hours,
              procurement_building: create(:facilities_management_rm3830_procurement_building_no_services,
-                                          procurement: create(:facilities_management_rm3830_procurement_no_procurement_buildings, estimated_annual_cost: estimated_annual_cost, estimated_cost_known: estimated_cost_known)))
+                                          procurement: create(:facilities_management_rm3830_procurement_no_procurement_buildings, estimated_annual_cost:, estimated_cost_known:)))
     end
 
     context 'when one building and one service' do
@@ -1558,7 +1558,7 @@ RSpec.describe FacilitiesManagement::RM3830::SummaryReport, type: :model do
       before do
         procurement_building_service.procurement_building.freeze_building_data
         lift_data.each do |number_of_floors|
-          procurement_building_service.lifts.create(number_of_floors: number_of_floors)
+          procurement_building_service.lifts.create(number_of_floors:)
         end
       end
 

--- a/spec/services/facilities_management/rm6232/admin/files_importer_spec.rb
+++ b/spec/services/facilities_management/rm6232/admin/files_importer_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::FilesImporter do
 
       it 'has the correct data for the suppliers' do
         expected_supplier_results.each do |supplier_name, expected_results|
-          supplier = FacilitiesManagement::RM6232::Supplier.find_by(supplier_name: supplier_name)
+          supplier = FacilitiesManagement::RM6232::Supplier.find_by(supplier_name:)
 
           expect(supplier.lot_data.pluck(:lot_code)).to match_array(expected_results[:lot_codes])
         end
@@ -172,7 +172,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::FilesImporter do
 
       it 'imports the supplier data with the correct status' do
         expected_supplier_results.each do |supplier_name, expected_result|
-          supplier = FacilitiesManagement::RM6232::Supplier.find_by(supplier_name: supplier_name)
+          supplier = FacilitiesManagement::RM6232::Supplier.find_by(supplier_name:)
 
           expect(supplier.active).to be expected_result
         end

--- a/spec/support/spreadsheet_import_helper.rb
+++ b/spec/support/spreadsheet_import_helper.rb
@@ -20,7 +20,7 @@ module SpreadsheetImportHelper
       name = 'Building Information'
       @sheets_added << name
       buildings = buildings_details.map(&:first)
-      @package.workbook.add_worksheet(name: name) do |sheet|
+      @package.workbook.add_worksheet(name:) do |sheet|
         sheet.add_row(['Building Number'] + buildings.map.with_index { |_, i| "Building #{i + 1}" })
         sheet.add_row(['Building Name'] + buildings.map(&:building_name))
         sheet.add_row(['Building Description (optional)'] + buildings.map(&:description))
@@ -45,7 +45,7 @@ module SpreadsheetImportHelper
       template_sheet = template_spreadsheet.sheet(name)
       template_sheet_row_count = template_sheet.parse.size + 1
 
-      @package.workbook.add_worksheet(name: name) do |sheet|
+      @package.workbook.add_worksheet(name:) do |sheet|
         status_indicators = data.pluck(:status)
         sheet.add_row(template_sheet.row(1) + status_indicators)
 
@@ -66,7 +66,7 @@ module SpreadsheetImportHelper
     def add_service_volumes_1(service_details)
       name = 'Service Volumes 1'
       @sheets_added << name
-      @package.workbook.add_worksheet(name: name) do |sheet|
+      @package.workbook.add_worksheet(name:) do |sheet|
         sheet.add_row(['', '', '', 'Service status indicator'] + service_details.pluck(2))
         sheet.add_row([])
         sheet.add_row(['Service Reference', 'Service Name', 'Service required within this estate?', 'Metric per Annum'] + service_details.pluck(0))
@@ -92,7 +92,7 @@ module SpreadsheetImportHelper
     def add_service_volumes_2(service_details)
       name = 'Service Volumes 2'
       @sheets_added << name
-      @package.workbook.add_worksheet(name: name) do |sheet|
+      @package.workbook.add_worksheet(name:) do |sheet|
         sheet.add_row(['', '', '', '', 'Service status indicator'] + service_details.pluck(2))
         sheet.add_row(['', '', '', '', 'Building name'] + service_details.pluck(0))
         sheet.add_row(['', '', '', '', 'Service required within this building?'] + service_details.map { |pb| pb[1].any? ? 'Yes' : 'No' })
@@ -115,7 +115,7 @@ module SpreadsheetImportHelper
     def add_service_hours_sheet(data)
       name = 'Service Volumes 3'
       @sheets_added << name
-      @package.workbook.add_worksheet(name: name) do |sheet|
+      @package.workbook.add_worksheet(name:) do |sheet|
         sheet.add_row([nil, nil, nil, 'Service status indicator'] + data.pluck(:status))
         sheet.add_row([])
         sheet.add_row(['Service Reference', 'Service Name', 'Service required within this estate?', 'Metric per Annum'] + data.pluck(:building_name))

--- a/spec/views/shared/_error_summary.html.erb_spec.rb
+++ b/spec/views/shared/_error_summary.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'shared/_error_summary.html.erb' do
 
   context 'when errors are empty' do
     before do
-      render partial: 'shared/error_summary', locals: { errors: errors }
+      render partial: 'shared/error_summary', locals: { errors: }
     end
 
     it 'does not render error summary' do
@@ -37,7 +37,7 @@ RSpec.describe 'shared/_error_summary.html.erb' do
     before do
       errors.add(:attribute_name, 'error-message-1')
       errors.add(:attribute_name, 'error-message-2')
-      render partial: 'shared/error_summary', locals: { errors: errors }
+      render partial: 'shared/error_summary', locals: { errors: }
     end
 
     it 'displays the first error message in the summary' do
@@ -55,7 +55,7 @@ RSpec.describe 'shared/_error_summary.html.erb' do
       errors.add(:attribute_name, 'error-message-2')
       errors.add(:attribute_name_2, 'error-message-3')
       errors.add(:attribute_name_2, 'error-message-4')
-      render partial: 'shared/error_summary', locals: { errors: errors }
+      render partial: 'shared/error_summary', locals: { errors: }
     end
 
     it 'displays the first error message for the first attribute in the summary' do


### PR DESCRIPTION
Part of ticket: [FMFR-1355](https://crowncommercialservice.atlassian.net/browse/FMFR-1355)

I’ve run rubocop so we are using the latest ruby syntax where changes have been made for ruby v3.

[FMFR-1355]: https://crowncommercialservice.atlassian.net/browse/FMFR-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ