### PR TITLE
FMFR-1365 - Make sure auto timeout goes to the correct location

### DIFF
--- a/app/controllers/base/sessions_controller.rb
+++ b/app/controllers/base/sessions_controller.rb
@@ -41,9 +41,9 @@ module Base
       session[:return_to] = params[:url]
 
       begin
-        redirect_to session_expired_sign_in_path
+        redirect_to "#{params[:service_path_base]}/sign-in?expired=true"
       rescue ActionController::RoutingError
-        redirect_to default_sign_in_path
+        redirect_to "#{service_path_base}/sign-in?expired=true"
       end
     end
 
@@ -51,10 +51,6 @@ module Base
 
     def after_sign_out_path_for(_resource)
       sign_in_url
-    end
-
-    def session_expired_sign_in_path
-      "#{service_path_base}/sign-in?expired=true"
     end
 
     def result_unsuccessful_path

--- a/app/views/base/sessions/new.html.erb
+++ b/app/views/base/sessions/new.html.erb
@@ -1,16 +1,24 @@
-<%= warning_text(t('.session_expired')) if params[:expired] == 'true' %>
-
-<% unless local_header_text.nil? %>
-  <%= content_for :page_title, local_header_text %>
-  <h1 class="govuk-heading-xl">
-    <%= local_header_text %>
-  </h1>
-<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= warning_text(t('.session_expired')) if params[:expired] == 'true' %>
 
     <%= render partial: 'shared/error_summary', locals: { errors: @result.errors } %>
+  </div>
+</div>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <% unless local_header_text.nil? %>
+      <%= content_for :page_title, local_header_text %>
+      <h1 class="govuk-heading-xl">
+        <%= local_header_text %>
+      </h1>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= form_for resource, as: resource_name, url: new_user_session_path, method: :post, html: { specialvalidation: true, novalidate: true, class: 'ccs-form', id: 'cop_sign_in_form'} do |f| %>
       <input type="hidden" name="expired" value="<%= params[:expired]%>"/>
       <div class="govuk-form-group govuk-!-margin-bottom-4 <%= 'govuk-form-group--error' if @result.errors[:email].any? %>">
@@ -62,6 +70,3 @@
     </ul>
   </div>
 </div>
-
-
-

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
-    <% if Rails.env.production? && current_user %>
+    <% if Rails.env.production? && user_signed_in? %>
       <%= auto_session_timeout_js %>
     <% end %>
 

--- a/lib/ext/ruby/auto_session_timeout_helper.rb
+++ b/lib/ext/ruby/auto_session_timeout_helper.rb
@@ -18,8 +18,10 @@ module AutoSessionTimeoutHelper
           setTimeout(PeriodicalQuery, (#{frequency} * 1000));
         }
 
-      var current_url = encodeURIComponent(window.location.pathname +  window.location.search)
-      var timout_url = '#{timeout_path}' + '?url=' + current_url;
+      var current_url = encodeURIComponent(window.location.pathname +  window.location.search);
+      var service_path_base = encodeURIComponent('#{service_path_base}');
+
+      var timout_url = `#{timeout_path}?url=${current_url}&service_path_base=${service_path_base}`;
 
       setTimeout(PeriodicalQuery, (#{frequency} * 1000));
     JS

--- a/spec/controllers/base/sessions_controller_spec.rb
+++ b/spec/controllers/base/sessions_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe Base::SessionsController do
+  before { request.env['devise.mapping'] = Devise.mappings[:user] }
+
+  describe 'GET active' do
+    context 'when the user is signed in' do
+      login_fm_buyer
+
+      before { get :active }
+
+      it 'returns the 200 status and a body of true' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq('true')
+      end
+    end
+
+    context 'when the user is signed out' do
+      before { get :active }
+
+      it 'returns the 200 status and a body of false' do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq('false')
+      end
+    end
+  end
+
+  describe 'GET timeout' do
+    context 'when there is no error' do
+      before { get :timeout, params: { url: '/crown-marketplace/allow-list', service_path_base: service_path_base } }
+
+      context 'and service_path_base is provided' do
+        let(:service_path_base) { '/crown-marketplace' }
+
+        it 'redirects to the service base path param sign in path' do
+          expect(response).to redirect_to('/crown-marketplace/sign-in?expired=true')
+        end
+      end
+
+      context 'and service_path_base is not provided' do
+        let(:service_path_base) { nil }
+
+        it 'redirects to just the sign in path' do
+          expect(response).to redirect_to('/sign-in?expired=true')
+        end
+      end
+    end
+
+    context 'when the service_path_base would raise to a routing error' do
+      before do
+        allow(controller).to receive(:redirect_to).with('/facilities-management/RM7007/admin/sign-in?expired=true').and_raise(ActionController::RoutingError.new('Some error', 'Some Message'))
+        allow(controller).to receive(:redirect_to).with('/facilities-management/RM6232/sign-in?expired=true').and_call_original
+
+        get :timeout, params: { url: '/facilities-management/RM7007/admin', service_path_base: '/facilities-management/RM7007/admin' }
+      end
+
+      it 'redirects to the default sign in path' do
+        expect(controller).to have_received(:redirect_to).with('/facilities-management/RM7007/admin/sign-in?expired=true')
+        expect(controller).to have_received(:redirect_to).with('/facilities-management/RM6232/sign-in?expired=true')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: [FMFR-1365](https://crowncommercialservice.atlassian.net/browse/FMFR-1365)

I have updated the `timeout` path in the sessions controller so that we can determine the sign in url from the current page URL

[FMFR-1365]: https://crowncommercialservice.atlassian.net/browse/FMFR-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ