### PR TITLE
FMFR-1368 - Add question to opt into being contacted

### DIFF
--- a/app/controllers/facilities_management/buyer_details_controller.rb
+++ b/app/controllers/facilities_management/buyer_details_controller.rb
@@ -55,7 +55,8 @@ module FacilitiesManagement
               :organisation_address_town,
               :organisation_address_county,
               :organisation_address_postcode,
-              :central_government
+              :central_government,
+              :contact_opt_in
             )
     end
 

--- a/app/javascript/src/facilitiesManagement/contactDetailsInStorage.ts
+++ b/app/javascript/src/facilitiesManagement/contactDetailsInStorage.ts
@@ -43,6 +43,16 @@ const initContactDetailsInStorage = (): void => {
       name: 'contactDetailsSectorFalse',
       $element: $(`#${modelName}_central_government_false`),
       type: ContactDetailType.RadioInput
+    },
+    {
+      name: 'contactDetailsContactOptInTrue',
+      $element: $(`#${modelName}_contact_opt_in_true`),
+      type: ContactDetailType.RadioInput
+    },
+    {
+      name: 'contactDetailsContactOptInFalse',
+      $element: $(`#${modelName}_contact_opt_in_false`),
+      type: ContactDetailType.RadioInput
     }
   ]
 

--- a/app/models/facilities_management/buyer_detail.rb
+++ b/app/models/facilities_management/buyer_detail.rb
@@ -18,7 +18,8 @@ module FacilitiesManagement
 
     include AddressValidator
 
-    validates :central_government, length: { maximum: MAX_FIELD_LENGTH }, inclusion: { in: [true, false], message: :blank }, on: :update
+    validates :central_government, inclusion: { in: [true, false] }, on: :update
+    validates :contact_opt_in, inclusion: { in: [true, false] }, on: :update
 
     delegate :email, to: :user
 

--- a/app/views/facilities_management/buyer_details/edit.html.erb
+++ b/app/views/facilities_management/buyer_details/edit.html.erb
@@ -97,31 +97,50 @@
           address_title: t('.organisation_address')
         } %>
 
-        <h2 class="govuk-heading-m">
-          <%= t('.sector') %>
-        </h2>
+        <hr class="govuk-section-break govuk-section-break--m">
+
         <%= form_group_with_error(f.object, :central_government) do |displayed_error| %>
-
-          <div class="govuk-heading-s govuk-!-margin-bottom-0">
-            <%= t('.which_type_of_public_sector_org') %>
-          </div>
-
-          <div class="govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-            <span class="govuk-caption-m"><%= t('.search_html', url: 'https://www.gov.uk/government/organisations') %></span>
-          </div>
-          <%= displayed_error %>
-          <div class="govuk-radios govuk-radios--inline govuk-!-margin-bottom-6 govuk-!-margin-top-6">
-            <div class="govuk-radios govuk-radios--inline">
+          <fieldset class="govuk-fieldset" aria-describedby="central_government-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <%= t('.central_government.legend') %>
+            </legend>
+            <div id="central_government-hint" class="govuk-hint">
+              <%= t('.search_html', url: 'https://www.gov.uk/government/organisations') %>
+            </div>
+            <%= displayed_error %>
+            <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
               <div class="govuk-radios__item">
-                <%= f.radio_button :central_government, true, value: true, class: 'govuk-radios__input', required: true %>
-                <%= f.label :central_government, t('.central_gov'), value: true, class: 'govuk-label govuk-radios__label' %>
+                <%= f.radio_button :central_government, true, class: 'govuk-radios__input' %>
+                <%= f.label :central_government, t('.central_government.options.true'), value: true, class: 'govuk-label govuk-radios__label' %>
               </div>
               <div class="govuk-radios__item">
-                <%= f.radio_button :central_government, false, value: false, class: 'govuk-radios__input', required: true %>
-                <%= f.label :central_government, t('.wider_public_sector'), value: false, class: 'govuk-label govuk-radios__label' %>
+                <%= f.radio_button :central_government, false, class: 'govuk-radios__input' %>
+                <%= f.label :central_government, t('.central_government.options.false'), value: false, class: 'govuk-label govuk-radios__label' %>
               </div>
             </div>
-          </div>
+          </fieldset>
+        <% end %>
+
+        <%= form_group_with_error(f.object, :contact_opt_in) do |displayed_error| %>
+          <fieldset class="govuk-fieldset" aria-describedby="contact_opt_in-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <%= t('.contact_opt_in.legend') %>
+            </legend>
+            <div id="contact_opt_in-hint" class="govuk-hint">
+              <%= t('.contact_opt_in.hint') %>
+            </div>
+            <%= displayed_error %>
+            <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <%= f.radio_button :contact_opt_in, true, class: 'govuk-radios__input' %>
+                <%= f.label :contact_opt_in, t('.contact_opt_in.options.true'), value: true, class: 'govuk-label govuk-radios__label' %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= f.radio_button :contact_opt_in, false, class: 'govuk-radios__input' %>
+                <%= f.label :contact_opt_in, t('.contact_opt_in.options.false'), value: false, class: 'govuk-label govuk-radios__label' %>
+              </div>
+            </div>
+          </fieldset>
         <% end %>
 
         <div>

--- a/config/locales/views/facilities_management.en.yml
+++ b/config/locales/views/facilities_management.en.yml
@@ -72,8 +72,9 @@ en:
             base:
               not_selected: You must select an address to save your details
             central_government:
-              blank: Select the type of public sector organisation you’re buying for
               inclusion: Select the type of public sector organisation you’re buying for
+            contact_opt_in:
+              inclusion: You must select an option
             full_name:
               blank: Enter your full name
               invalid: Enter your full name
@@ -310,18 +311,25 @@ en:
         back: Return to your account
         buyer_details: Manage your details
         cant_find_address: Enter address manually, if you can’t find address
-        central_gov: Central government
+        central_government:
+          legend: Which type of public sector organisation are you buying for?
+          options:
+            'false': Wider public sector
+            'true': Central government
+        contact_opt_in:
+          hint: You can change these settings at any time.
+          legend: Can CCS contact you about any searches you save?
+          options:
+            'false': 'No'
+            'true': 'Yes'
         job_title: Job title
         name: Name
         organisation_address: Organisation address
         organisation_details: Organisation details
         organisation_name: Organisation name
         search_html: Search <a href="%{url}" target="_blank">central government departments, agencies and public bodies</a> if you’re unsure.
-        sector: Sector
         submit: Save and continue
         telephone_number: Telephone number
-        which_type_of_public_sector_org: Which type of public sector organisation are you buying for?
-        wider_public_sector: Wider public sector
         your_details: Personal details
       edit_address:
         add_address: Add address

--- a/db/migrate/20230425075107_add_contact_opt_in_for_buyer_details.rb
+++ b/db/migrate/20230425075107_add_contact_opt_in_for_buyer_details.rb
@@ -1,0 +1,5 @@
+class AddContactOptInForBuyerDetails < ActiveRecord::Migration[7.0]
+  def change
+    add_column :facilities_management_buyer_details, :contact_opt_in, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_14_114915) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_25_075107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_14_114915) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.uuid "user_id", null: false
+    t.boolean "contact_opt_in"
     t.index ["user_id"], name: "index_facilities_management_buyer_details_on_user_id"
   end
 

--- a/features/facilities_management/rm3830/buyer_details/buyer_details.feature
+++ b/features/facilities_management/rm3830/buyer_details/buyer_details.feature
@@ -10,6 +10,7 @@ Feature: Buyer details
       | Organisation name | Feel Good inc.    |
       | Postcode          | ST16 1AA          |
     And I check 'Central government' for the sector
+    And I check 'Yes' for being contacted
 
   Scenario: Save details for the buyer - add address normally
     And I click on 'Find address'
@@ -25,6 +26,7 @@ Feature: Buyer details
       | Organisation name     | Feel Good inc.                                            |
       | Organisation address  | Stafford Delivery Office, Newport Road, Stafford ST16 1AA |
       | Sector                | Central government                                        |
+      | Contact opt in        | Yes                                                       |
 
   Scenario: Save details for the buyer - add address manually
     And I click on 'Find address'
@@ -47,3 +49,4 @@ Feature: Buyer details
       | Organisation name     | Feel Good inc.                        |
       | Organisation address  | 112 Test street, Westminister AA1 1AA |
       | Sector                | Central government                    |
+      | Contact opt in        | Yes                                   |

--- a/features/facilities_management/rm3830/buyer_details/validations/buyer_details_validations.feature
+++ b/features/facilities_management/rm3830/buyer_details/validations/buyer_details_validations.feature
@@ -12,6 +12,7 @@ Feature: Buyer details - validations
       | Enter your organisation name                                    |
       | Enter a valid postcode, for example SW1A 1AA                    |
       | Select the type of public sector organisation you’re buying for |
+      | You must select an option                                       |
 
   @javascript
   Scenario Outline: Add address - frontend
@@ -33,6 +34,7 @@ Feature: Buyer details - validations
       | Organisation name | Feel Good inc.    |
       | Postcode          | test              |
     And I check 'Central government' for the sector
+    And I check 'Yes' for being contacted
     And I click on 'Save and continue'
     Then I should see the following error messages:
       | Enter a valid postcode, for example SW1A 1AA  |
@@ -45,6 +47,7 @@ Feature: Buyer details - validations
       | Organisation name | Feel Good inc.    |
       | Postcode          | ST16 1AA          |
     And I check 'Central government' for the sector
+    And I check 'Yes' for being contacted
     And I click on 'Save and continue'
     Then I should see the following error messages:
       | You must select an address to save your details |

--- a/features/facilities_management/rm6232/buyer_details/buyer_details.feature
+++ b/features/facilities_management/rm6232/buyer_details/buyer_details.feature
@@ -10,6 +10,7 @@ Feature: Buyer details
       | Organisation name | Feel Good inc.    |
       | Postcode          | ST16 1AA          |
     And I check 'Wider public sector' for the sector
+    And I check 'No' for being contacted
 
   Scenario: Save details for the buyer - add address normally
     And I click on 'Find address'
@@ -25,6 +26,7 @@ Feature: Buyer details
       | Organisation name     | Feel Good inc.                                  |
       | Organisation address  | The Goods Shed, Newport Road, Stafford ST16 1AA |
       | Sector                | Wider public sector                             |
+      | Contact opt in        | No                                              |
 
   Scenario: Save details for the buyer - add address manually
     And I click on 'Find address'
@@ -47,3 +49,4 @@ Feature: Buyer details
       | Organisation name     | Feel Good inc.                        |
       | Organisation address  | 112 Test street, Westminister AA1 1AA |
       | Sector                | Wider public sector                   |
+      | Contact opt in        | No                                    |

--- a/features/facilities_management/rm6232/buyer_details/validations/buyer_details_validations.feature
+++ b/features/facilities_management/rm6232/buyer_details/validations/buyer_details_validations.feature
@@ -12,6 +12,7 @@ Feature: Buyer details - validations
       | Enter your organisation name                                    |
       | Enter a valid postcode, for example SW1A 1AA                    |
       | Select the type of public sector organisation you’re buying for |
+      | You must select an option                                       |
 
   @javascript
   Scenario Outline: Add address - frontend
@@ -33,6 +34,7 @@ Feature: Buyer details - validations
       | Organisation name | Feel Good inc.    |
       | Postcode          | test              |
     And I check 'Central government' for the sector
+    And I check 'Yes' for being contacted
     And I click on 'Save and continue'
     Then I should see the following error messages:
       | Enter a valid postcode, for example SW1A 1AA  |
@@ -45,6 +47,7 @@ Feature: Buyer details - validations
       | Organisation name | Feel Good inc.    |
       | Postcode          | ST16 1AA          |
     And I check 'Central government' for the sector
+    And I check 'Yes' for being contacted
     And I click on 'Save and continue'
     Then I should see the following error messages:
       | You must select an address to save your details |

--- a/features/step_definitions/facilities_management/buyer_detail_steps.rb
+++ b/features/step_definitions/facilities_management/buyer_detail_steps.rb
@@ -2,6 +2,10 @@ Then('I check {string} for the sector') do |option|
   buyer_detail_page.sector.send(option.to_sym).choose
 end
 
+Then('I check {string} for being contacted') do |option|
+  buyer_detail_page.contact_opt_in.send(option.to_sym).choose
+end
+
 Then('I should see the postcode error message for buyer details') do
   expect(buyer_detail_page.postcode_error_message).to have_text('Enter a valid postcode, for example SW1A 1AA')
 end
@@ -11,6 +15,8 @@ Then('the following buyer details have been entered:') do |buyer_details_table|
     case field
     when 'Sector'
       expect(buyer_detail_page.sector.send(value.to_sym)).to be_checked
+    when 'Contact opt in'
+      expect(buyer_detail_page.contact_opt_in.send(value.to_sym)).to be_checked
     when 'Organisation address'
       expect(buyer_detail_page.buyer_details.send(field.to_sym)).to have_content value
     else

--- a/features/support/pages/buyer_detail.rb
+++ b/features/support/pages/buyer_detail.rb
@@ -13,6 +13,11 @@ module Pages
       element :'Wider public sector', '#facilities_management_buyer_detail_central_government_false'
     end
 
+    section :contact_opt_in, '#contact_opt_in-form-group' do
+      element :Yes, '#facilities_management_buyer_detail_contact_opt_in_true'
+      element :No, '#facilities_management_buyer_detail_contact_opt_in_false'
+    end
+
     element :postcode_error_message, '#organisation_address_postcode-error'
     element :change_address, '#change-input-2'
   end

--- a/spec/factories/buyer_details.rb
+++ b/spec/factories/buyer_details.rb
@@ -10,5 +10,6 @@ FactoryBot.define do
     organisation_address_county { 'MyString' }
     organisation_address_postcode { 'SW1W 9SZ' }
     central_government { true }
+    contact_opt_in { true }
   end
 end

--- a/spec/models/facilities_management/buyer_detail_spec.rb
+++ b/spec/models/facilities_management/buyer_detail_spec.rb
@@ -302,6 +302,82 @@ RSpec.describe FacilitiesManagement::BuyerDetail do
       end
     end
     # rubocop:enable RSpec/NestedGroups
+
+    context 'when considering central_government' do
+      before { buyer_detail.central_government = central_government }
+
+      context 'and it is blank' do
+        let(:central_government) { '' }
+
+        it 'is invalid and has the correct error message' do
+          expect(buyer_detail).not_to be_valid(:update)
+          expect(buyer_detail.errors[:central_government].first).to eq 'Select the type of public sector organisation you’re buying for'
+        end
+      end
+
+      context 'and it is nil' do
+        let(:central_government) { nil }
+
+        it 'is invalid and has the correct error message' do
+          expect(buyer_detail).not_to be_valid(:update)
+          expect(buyer_detail.errors[:central_government].first).to eq 'Select the type of public sector organisation you’re buying for'
+        end
+      end
+
+      context 'and it is true' do
+        let(:central_government) { true }
+
+        it 'is valid' do
+          expect(buyer_detail).to be_valid(:update)
+        end
+      end
+
+      context 'and it is false' do
+        let(:central_government) { false }
+
+        it 'is valid' do
+          expect(buyer_detail).to be_valid(:update)
+        end
+      end
+    end
+
+    context 'when considering contact_opt_in' do
+      before { buyer_detail.contact_opt_in = contact_opt_in }
+
+      context 'and it is blank' do
+        let(:contact_opt_in) { '' }
+
+        it 'is invalid and has the correct error message' do
+          expect(buyer_detail).not_to be_valid(:update)
+          expect(buyer_detail.errors[:contact_opt_in].first).to eq 'You must select an option'
+        end
+      end
+
+      context 'and it is nil' do
+        let(:contact_opt_in) { nil }
+
+        it 'is invalid and has the correct error message' do
+          expect(buyer_detail).not_to be_valid(:update)
+          expect(buyer_detail.errors[:contact_opt_in].first).to eq 'You must select an option'
+        end
+      end
+
+      context 'and it is true' do
+        let(:contact_opt_in) { true }
+
+        it 'is valid' do
+          expect(buyer_detail).to be_valid(:update)
+        end
+      end
+
+      context 'and it is false' do
+        let(:contact_opt_in) { false }
+
+        it 'is valid' do
+          expect(buyer_detail).to be_valid(:update)
+        end
+      end
+    end
   end
 
   describe '#full_organisation_address' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe User do
         user.buyer_detail.organisation_name = 'org name'
         user.buyer_detail.organisation_address_postcode = 'SW1W 9SZ'
         user.buyer_detail.central_government = false
+        user.buyer_detail.contact_opt_in = false
       end
 
       it 'will return true' do
@@ -84,6 +85,7 @@ RSpec.describe User do
         user.buyer_detail.organisation_address_town = 'Address town'
         user.buyer_detail.organisation_address_postcode = 'SW1W 9SZ'
         user.buyer_detail.central_government = false
+        user.buyer_detail.contact_opt_in = false
       end
 
       it 'will return false' do


### PR DESCRIPTION
Ticket: [FMFR-1368](https://crowncommercialservice.atlassian.net/browse/FMFR-1368)

I have added the new field for buyer details where buyers now have to opt in to be contacted by the category,
If the buyer has not answered this new question, they will be forced to before they can do any actions within the service (for example, start a search).

[FMFR-1368]: https://crowncommercialservice.atlassian.net/browse/FMFR-1368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ