### PR TITLE
FMFR-1389 - Update the cookie names to match the unified approach

### DIFF
--- a/app/controllers/concerns/cookie_settings_concern.rb
+++ b/app/controllers/concerns/cookie_settings_concern.rb
@@ -48,12 +48,12 @@ module CookieSettingsConcern
   COOKIE_UPDATE_OPTIONS = [
     {
       param_name: :ga_cookie_usage,
-      cookie_name: 'google_analytics_enabled',
+      cookie_name: 'usage',
       cookie_prefixes: %w[_ga _gi]
     },
     {
       param_name: :glassbox_cookie_usage,
-      cookie_name: 'glassbox_enabled',
+      cookie_name: 'glassbox',
       cookie_prefixes: %w[_cls]
     }
   ].freeze

--- a/app/javascript/packs/ccs.ts
+++ b/app/javascript/packs/ccs.ts
@@ -9,6 +9,7 @@ import initCookieBanner from '../src/shared/cookieBanner'
 import initDetailsLinks from '../src/facilitiesManagement/detailsLinks'
 import initFilterTable from '../src/facilitiesManagement/filterTable'
 import initFindAddress from '../src/facilitiesManagement/findAddress'
+import initGoogleAnalyticsDataLayer from '../src/shared/googleAnalyticsDataLayer'
 import initLimitInputToInteger from '../src/facilitiesManagement/integerInput'
 import initManagementReport from '../src/facilitiesManagement/rm3830/admin/managementReport'
 import initNestedAttributesFields from '../src/facilitiesManagement/rm3830/addNestedAttributes'
@@ -53,6 +54,7 @@ $(document).on('turbolinks:load', () => {
   // Shared TS
   initCheckboxAccordion()
   initCookieBanner()
+  initGoogleAnalyticsDataLayer()
   initPasswordStrength()
   initStepByStepNav()
 })

--- a/app/javascript/src/shared/cookieBanner.ts
+++ b/app/javascript/src/shared/cookieBanner.ts
@@ -4,8 +4,8 @@ type CookieBannerFormData = Record<string, string>
 
 interface CookiePreferences {
   settings_viewed: boolean
-  google_analytics_enabled: boolean
-  glassbox_enabled: boolean
+  usage: boolean
+  glassbox: boolean
 }
 
 interface CookieUpdateOption {
@@ -15,24 +15,24 @@ interface CookieUpdateOption {
 
 const cookieUpdateOptions: CookieUpdateOption[] = [
   {
-    cookieName: 'google_analytics_enabled',
+    cookieName: 'usage',
     cookiePrefixes: ['_ga', '_gi']
   },
   {
-    cookieName: 'glassbox_enabled',
+    cookieName: 'glassbox',
     cookiePrefixes: ['_cls']
   }
 ]
 
 const getCookiePreferences = (): CookiePreferences => {
-  const defaultCookieSettings = '{"google_analytics_enabled":true,"glassbox_enabled":false}'
+  const defaultCookieSettings = '{"usage":true,"glassbox":false}'
 
-  return JSON.parse(Cookies.get('crown_marketplace_cookie_options_v1') ?? defaultCookieSettings)
+  return JSON.parse(Cookies.get('cookie_preferences') ?? defaultCookieSettings)
 }
 
 const removeUnwantedCookies = (): void => {
   const cookieList: string[] = Object.keys(Cookies.get())
-  const cookiesToRemove: string[] = ['crown_marketplace_cookie_settings_viewed', 'crown_marketplace_google_analytics_enabled']
+  const cookiesToRemove: string[] = ['crown_marketplace_cookie_settings_viewed', 'crown_marketplace_google_analytics_enabled', 'crown_marketplace_cookie_options_v1']
   const cookiePreferences: CookiePreferences = getCookiePreferences()
   const cookiePrefixes: string[] = []
 
@@ -145,3 +145,4 @@ const initCookieBanner = (): void => {
 }
 
 export default initCookieBanner
+export { CookiePreferences }

--- a/app/javascript/src/shared/googleAnalyticsDataLayer.ts
+++ b/app/javascript/src/shared/googleAnalyticsDataLayer.ts
@@ -1,0 +1,55 @@
+import Cookies from 'js-cookie'
+import { CookiePreferences } from './cookieBanner'
+
+enum GrantType {
+  GRANTED = 'granted',
+  NOT_GRANTED = 'not granted'
+}
+
+declare global {
+  interface Window {
+    dataLayer: {
+      push: (data: {
+        event: 'gtm_consent_update',
+        usage_consent: GrantType,
+        glassbox_consent: GrantType,
+        marketing_consent: GrantType
+      }) => void
+    }
+  }
+}
+
+
+const getCookiePreferences = (): string => Cookies.get('cookie_preferences') ?? '{}'
+
+const getCookiePreferencesSaved = (): string => Cookies.get('cookie_preferences_saved') ?? '{}'
+
+const setCookiePreferencesSaved = (cookiePreferences: CookiePreferences) => {
+  Cookies.set('cookie_preferences_saved', JSON.stringify(cookiePreferences), { expires: 365 })
+}
+
+const getGrantedText = (state: boolean) => state ? GrantType.GRANTED : GrantType.NOT_GRANTED
+
+const updateDataLayer = (cookiePreferences: CookiePreferences) => {
+  window.dataLayer.push({
+    event: 'gtm_consent_update',
+    usage_consent: getGrantedText(cookiePreferences.usage),
+    glassbox_consent: getGrantedText(cookiePreferences.glassbox),
+    marketing_consent: GrantType.NOT_GRANTED
+  })
+
+  setCookiePreferencesSaved(cookiePreferences)
+}
+
+const initGoogleAnalyticsDataLayer = () => {
+  if (window.dataLayer) {
+    const cookiePreferences = getCookiePreferences()
+    const cookiePreferencesSaved = getCookiePreferencesSaved()
+
+    if (cookiePreferences !== cookiePreferencesSaved) {
+      updateDataLayer(JSON.parse(cookiePreferences))
+    }
+  }
+}
+
+export default initGoogleAnalyticsDataLayer

--- a/app/views/home/cookie_policy.html.erb
+++ b/app/views/home/cookie_policy.html.erb
@@ -127,6 +127,11 @@
           <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".cookie_banner_cookies.row_1.purpose") %></td>
           <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".cookie_banner_cookies.row_1.expires") %></td>
         </tr>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-!-padding-right-2" style="word-break: break-all;"><%= t(".cookie_banner_cookies.row_2.name") %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".cookie_banner_cookies.row_2.purpose") %></td>
+          <td class="govuk-table__cell govuk-!-padding-right-2"><%= t(".cookie_banner_cookies.row_2.expires") %></td>
+        </tr>
       </tbody>
     </table>
 

--- a/app/views/home/cookie_settings.html.erb
+++ b/app/views/home/cookie_settings.html.erb
@@ -66,11 +66,11 @@
 
         <div class="govuk-radios">
           <div class="govuk-radios__item">
-            <%= radio_button_tag :ga_cookie_usage, true, cookie_preferences_settings['google_analytics_enabled'], class: 'govuk-radios__input' %>
+            <%= radio_button_tag :ga_cookie_usage, true, cookie_preferences_settings['usage'], class: 'govuk-radios__input' %>
             <%= label_tag :ga_cookie_usage, t('.use_cookies.ga'), for: :ga_cookie_usage_true, class: 'govuk-label govuk-radios__label' %>
           </div>
           <div class="govuk-radios__item">
-            <%= radio_button_tag :ga_cookie_usage, false, !cookie_preferences_settings['google_analytics_enabled'], class: 'govuk-radios__input' %>
+            <%= radio_button_tag :ga_cookie_usage, false, !cookie_preferences_settings['usage'], class: 'govuk-radios__input' %>
             <%= label_tag :ga_cookie_usage, t('.dont_use_cookies.ga'), for: :ga_cookie_usage_false, class: 'govuk-label govuk-radios__label' %>
           </div>
         </div>
@@ -89,11 +89,11 @@
 
         <div class="govuk-radios">
           <div class="govuk-radios__item">
-            <%= radio_button_tag :glassbox_cookie_usage, true, cookie_preferences_settings['glassbox_enabled'], class: 'govuk-radios__input' %>
+            <%= radio_button_tag :glassbox_cookie_usage, true, cookie_preferences_settings['glassbox'], class: 'govuk-radios__input' %>
             <%= label_tag :glassbox_cookie_usage, t('.use_cookies.glassbox'), for: :glassbox_cookie_usage_true, class: 'govuk-label govuk-radios__label' %>
           </div>
           <div class="govuk-radios__item">
-            <%= radio_button_tag :glassbox_cookie_usage, false, !cookie_preferences_settings['glassbox_enabled'], class: 'govuk-radios__input' %>
+            <%= radio_button_tag :glassbox_cookie_usage, false, !cookie_preferences_settings['glassbox'], class: 'govuk-radios__input' %>
             <%= label_tag :glassbox_cookie_usage, t('.dont_use_cookies.glassbox'), for: :glassbox_cookie_usage_false, class: 'govuk-label govuk-radios__label' %>
           </div>
         </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -159,14 +159,14 @@ module Marketplace
   end
 
   def self.cookie_settings_name
-    :crown_marketplace_cookie_options_v1
+    :cookie_preferences
   end
 
   def self.default_cookie_options
     {
       settings_viewed: false,
-      google_analytics_enabled: false,
-      glassbox_enabled: false
+      usage: false,
+      glassbox: false
     }.stringify_keys
   end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
     policy.img_src     :self, :https, :data, 'https://*.google-analytics.com', 'https://*.googletagmanager.com'
     policy.object_src  :none
     policy.script_src  :self, :https, 'https://*.googletagmanager.com'
-    policy.style_src   :self, :https
+    policy.style_src   :self, "'unsafe-inline'", :https
 
     connect_src = ['https://*.google-analytics.com', 'https://*.analytics.google.com', 'https://*.googletagmanager.com']
     connect_src += ['http://localhost:3035', 'ws://localhost:3035'] if Rails.env.development?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,6 +282,10 @@ en:
         row_1:
           expires: 1 year
           purpose: Saves your cookie consent preferences
+        row_2:
+          expires: 1 year
+          name: cookie_preferences_saved
+          purpose: Allows us to check when your cookie settings have changed
       cookies_banner: Cookies banner
       ga_cookies:
         row_1:

--- a/features/helpers/facilities_management/cookies_helper.rb
+++ b/features/helpers/facilities_management/cookies_helper.rb
@@ -1,7 +1,7 @@
 def update_banner_cookie(status)
-  page.driver.browser.manage.add_cookie(name: 'crown_marketplace_cookie_options_v1', value: {
+  page.driver.browser.manage.add_cookie(name: 'cookie_preferences', value: {
     settings_viewed: status,
-    google_analytics_enabled: false,
-    glassbox_enabled: false
+    usage: false,
+    glassbox: false
   }.to_json)
 end

--- a/features/step_definitions/facilities_management/home_steps.rb
+++ b/features/step_definitions/facilities_management/home_steps.rb
@@ -105,10 +105,10 @@ Then('the header navigation links {string} visible') do |option|
 end
 
 COOKIE_TO_OPTION = {
-  'ga' => 'google_analytics_enabled',
-  'glassbox' => 'glassbox_enabled'
+  'ga' => 'usage',
+  'glassbox' => 'glassbox'
 }.freeze
 
 def cookie_settings
-  JSON.parse(CGI.unescape(page.driver.browser.manage.cookie_named('crown_marketplace_cookie_options_v1')[:value]))
+  JSON.parse(CGI.unescape(page.driver.browser.manage.cookie_named('cookie_preferences')[:value]))
 end

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -24,7 +24,7 @@ After('@allow_list') do
 end
 
 Before('not @javascript') do
-  page.driver.browser.set_cookie('crown_marketplace_cookie_options_v1=%7B%22settings_viewed%22%3Atrue%2C%22google_analytics_enabled%22%3Afalse%2C%22glassbox_enabled%22%3Afalse%7D')
+  page.driver.browser.set_cookie('cookie_preferences=%7B%22settings_viewed%22%3Atrue%2C%22usage%22%3Afalse%2C%22glassbox%22%3Afalse%7D')
 end
 
 Before('@contract_emails') do

--- a/spec/controllers/crown_marketplace/home_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/home_controller_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe CrownMarketplace::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => false
+            'usage' => true,
+            'glassbox' => false
           }
         )
       end
@@ -78,11 +78,11 @@ RSpec.describe CrownMarketplace::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => true
+            'usage' => false,
+            'glassbox' => true
           }
         )
       end
@@ -114,11 +114,11 @@ RSpec.describe CrownMarketplace::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => true
+            'usage' => true,
+            'glassbox' => true
           }
         )
       end
@@ -142,11 +142,11 @@ RSpec.describe CrownMarketplace::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => false
+            'usage' => false,
+            'glassbox' => false
           }
         )
       end

--- a/spec/controllers/facilities_management/rm3830/admin/home_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/home_controller_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => false
+            'usage' => true,
+            'glassbox' => false
           }
         )
       end
@@ -78,11 +78,11 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => true
+            'usage' => false,
+            'glassbox' => true
           }
         )
       end
@@ -114,11 +114,11 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => true
+            'usage' => true,
+            'glassbox' => true
           }
         )
       end
@@ -142,11 +142,11 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => false
+            'usage' => false,
+            'glassbox' => false
           }
         )
       end

--- a/spec/controllers/facilities_management/rm3830/home_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/home_controller_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe FacilitiesManagement::RM3830::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => false
+            'usage' => true,
+            'glassbox' => false
           }
         )
       end
@@ -78,11 +78,11 @@ RSpec.describe FacilitiesManagement::RM3830::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => true
+            'usage' => false,
+            'glassbox' => true
           }
         )
       end
@@ -114,11 +114,11 @@ RSpec.describe FacilitiesManagement::RM3830::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => true
+            'usage' => true,
+            'glassbox' => true
           }
         )
       end
@@ -142,11 +142,11 @@ RSpec.describe FacilitiesManagement::RM3830::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => false
+            'usage' => false,
+            'glassbox' => false
           }
         )
       end

--- a/spec/controllers/facilities_management/rm3830/supplier/home_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/supplier/home_controller_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => false
+            'usage' => true,
+            'glassbox' => false
           }
         )
       end
@@ -78,11 +78,11 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => true
+            'usage' => false,
+            'glassbox' => true
           }
         )
       end
@@ -114,11 +114,11 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => true
+            'usage' => true,
+            'glassbox' => true
           }
         )
       end
@@ -142,11 +142,11 @@ RSpec.describe FacilitiesManagement::RM3830::Supplier::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => false
+            'usage' => false,
+            'glassbox' => false
           }
         )
       end

--- a/spec/controllers/facilities_management/rm6232/admin/home_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/home_controller_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => false
+            'usage' => true,
+            'glassbox' => false
           }
         )
       end
@@ -78,11 +78,11 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => true
+            'usage' => false,
+            'glassbox' => true
           }
         )
       end
@@ -114,11 +114,11 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => true
+            'usage' => true,
+            'glassbox' => true
           }
         )
       end
@@ -142,11 +142,11 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => false
+            'usage' => false,
+            'glassbox' => false
           }
         )
       end

--- a/spec/controllers/facilities_management/rm6232/home_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/home_controller_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe FacilitiesManagement::RM6232::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => false
+            'usage' => true,
+            'glassbox' => false
           }
         )
       end
@@ -78,11 +78,11 @@ RSpec.describe FacilitiesManagement::RM6232::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => true
+            'usage' => false,
+            'glassbox' => true
           }
         )
       end
@@ -114,11 +114,11 @@ RSpec.describe FacilitiesManagement::RM6232::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => true
+            'usage' => true,
+            'glassbox' => true
           }
         )
       end
@@ -142,11 +142,11 @@ RSpec.describe FacilitiesManagement::RM6232::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['crown_marketplace_cookie_options_v1'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => false,
-            'glassbox_enabled' => false
+            'usage' => false,
+            'glassbox' => false
           }
         )
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -197,8 +197,8 @@ RSpec.describe ApplicationHelper do
     let(:default_cookie_settings) do
       {
         'settings_viewed' => false,
-        'google_analytics_enabled' => false,
-        'glassbox_enabled' => false
+        'usage' => false,
+        'glassbox' => false
       }
     end
 
@@ -209,14 +209,14 @@ RSpec.describe ApplicationHelper do
     end
 
     context 'when the cookie has been set' do
-      before { helper.request.cookies['crown_marketplace_cookie_options_v1'] = cookie_settings }
+      before { helper.request.cookies['cookie_preferences'] = cookie_settings }
 
       context 'and it is a hash' do
         let(:expected_cookie_settings) do
           {
             'settings_viewed' => true,
-            'google_analytics_enabled' => true,
-            'glassbox_enabled' => false
+            'usage' => true,
+            'glassbox' => false
           }
         end
         let(:cookie_settings) { expected_cookie_settings.to_json }

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe 'layouts/application.html.erb' do
   before do
     allow(view).to receive_messages(user_signed_in?: false, ccs_homepage_url: 'https://CCSHOMEPAGE', service_path_base: '/supply-teachers')
 
-    cookies[:crown_marketplace_cookie_options_v1] = {
+    cookies[:cookie_preferences] = {
       value: {
         'settings_viewed' => true,
-        'google_analytics_enabled' => true,
-        'glassbox_enabled' => true
+        'usage' => true,
+        'glassbox' => true
       }.to_json
     }
 


### PR DESCRIPTION
Ticket: [FMFR-1389](https://crowncommercialservice.atlassian.net/browse/FMFR-1389)

Update the cookie names to match the unified approach.
Add the data layer push for the GA consent mode.

[FMFR-1389]: https://crowncommercialservice.atlassian.net/browse/FMFR-1389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ