### PR TITLE
Rename `cookie_preferences` cookie to `cookie_preferences_cmp` so that it does not conflict with corporate website

### DIFF
--- a/app/javascript/src/shared/cookieBanner.ts
+++ b/app/javascript/src/shared/cookieBanner.ts
@@ -27,7 +27,7 @@ const cookieUpdateOptions: CookieUpdateOption[] = [
 const getCookiePreferences = (): CookiePreferences => {
   const defaultCookieSettings = '{"usage":true,"glassbox":false}'
 
-  return JSON.parse(Cookies.get('cookie_preferences') ?? defaultCookieSettings)
+  return JSON.parse(Cookies.get('cookie_preferences_cmp') ?? defaultCookieSettings)
 }
 
 const removeUnwantedCookies = (): void => {

--- a/app/javascript/src/shared/googleAnalyticsDataLayer.ts
+++ b/app/javascript/src/shared/googleAnalyticsDataLayer.ts
@@ -20,12 +20,12 @@ declare global {
 }
 
 
-const getCookiePreferences = (): string => Cookies.get('cookie_preferences') ?? '{}'
+const getCookiePreferences = (): string => Cookies.get('cookie_preferences_cmp') ?? '{}'
 
-const getCookiePreferencesSaved = (): string => Cookies.get('cookie_preferences_saved') ?? '{}'
+const getCookiePreferencesSaved = (): string => Cookies.get('cookie_preferences_cmp_saved') ?? '{}'
 
 const setCookiePreferencesSaved = (cookiePreferences: CookiePreferences) => {
-  Cookies.set('cookie_preferences_saved', JSON.stringify(cookiePreferences), { expires: 365 })
+  Cookies.set('cookie_preferences_cmp_saved', JSON.stringify(cookiePreferences), { expires: 365 })
 }
 
 const getGrantedText = (state: boolean) => state ? GrantType.GRANTED : GrantType.NOT_GRANTED

--- a/config/application.rb
+++ b/config/application.rb
@@ -164,7 +164,7 @@ module Marketplace
   end
 
   def self.cookie_settings_name
-    :cookie_preferences
+    :cookie_preferences_cmp
   end
 
   def self.default_cookie_options

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -289,7 +289,7 @@ en:
           purpose: Saves your cookie consent preferences
         row_2:
           expires: 1 year
-          name: cookie_preferences_saved
+          name: cookie_preferences_cmp_saved
           purpose: Allows us to check when your cookie settings have changed
       cookies_banner: Cookies banner
       ga_cookies:

--- a/features/helpers/facilities_management/cookies_helper.rb
+++ b/features/helpers/facilities_management/cookies_helper.rb
@@ -1,5 +1,5 @@
 def update_banner_cookie(status)
-  page.driver.browser.manage.add_cookie(name: 'cookie_preferences', value: {
+  page.driver.browser.manage.add_cookie(name: 'cookie_preferences_cmp', value: {
     settings_viewed: status,
     usage: false,
     glassbox: false

--- a/features/step_definitions/facilities_management/home_steps.rb
+++ b/features/step_definitions/facilities_management/home_steps.rb
@@ -108,5 +108,5 @@ COOKIE_TO_OPTION = {
 }.freeze
 
 def cookie_settings
-  JSON.parse(CGI.unescape(page.driver.browser.manage.cookie_named('cookie_preferences')[:value]))
+  JSON.parse(CGI.unescape(page.driver.browser.manage.cookie_named('cookie_preferences_cmp')[:value]))
 end

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -20,7 +20,7 @@ After('@allow_list') do
 end
 
 Before('not @javascript') do
-  page.driver.browser.set_cookie('cookie_preferences=%7B%22settings_viewed%22%3Atrue%2C%22usage%22%3Afalse%2C%22glassbox%22%3Afalse%7D')
+  page.driver.browser.set_cookie('cookie_preferences_cmp=%7B%22settings_viewed%22%3Atrue%2C%22usage%22%3Afalse%2C%22glassbox%22%3Afalse%7D')
 end
 
 Before('@management_report') do

--- a/spec/controllers/crown_marketplace/home_controller_spec.rb
+++ b/spec/controllers/crown_marketplace/home_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CrownMarketplace::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -78,7 +78,7 @@ RSpec.describe CrownMarketplace::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,
@@ -114,7 +114,7 @@ RSpec.describe CrownMarketplace::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -142,7 +142,7 @@ RSpec.describe CrownMarketplace::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,

--- a/spec/controllers/facilities_management/rm3830/admin/home_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm3830/admin/home_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -78,7 +78,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,
@@ -114,7 +114,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -142,7 +142,7 @@ RSpec.describe FacilitiesManagement::RM3830::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,

--- a/spec/controllers/facilities_management/rm6232/admin/home_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/admin/home_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -78,7 +78,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,
@@ -114,7 +114,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -142,7 +142,7 @@ RSpec.describe FacilitiesManagement::RM6232::Admin::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,

--- a/spec/controllers/facilities_management/rm6232/home_controller_spec.rb
+++ b/spec/controllers/facilities_management/rm6232/home_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe FacilitiesManagement::RM6232::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -78,7 +78,7 @@ RSpec.describe FacilitiesManagement::RM6232::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,
@@ -114,7 +114,7 @@ RSpec.describe FacilitiesManagement::RM6232::HomeController do
       let(:update_params) { { ga_cookie_usage: 'true', glassbox_cookie_usage: 'true' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => true,
@@ -142,7 +142,7 @@ RSpec.describe FacilitiesManagement::RM6232::HomeController do
       let(:update_params) { { ga_cookie_usage: 'false', glassbox_cookie_usage: 'false' } }
 
       it 'updates the cookie preferences' do
-        expect(JSON.parse(response.cookies['cookie_preferences'])).to eq(
+        expect(JSON.parse(response.cookies['cookie_preferences_cmp'])).to eq(
           {
             'settings_viewed' => true,
             'usage' => false,

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe ApplicationHelper do
     end
 
     context 'when the cookie has been set' do
-      before { helper.request.cookies['cookie_preferences'] = cookie_settings }
+      before { helper.request.cookies['cookie_preferences_cmp'] = cookie_settings }
 
       context 'and it is a hash' do
         let(:expected_cookie_settings) do

--- a/spec/views/layouts/application.html.erb_spec.rb
+++ b/spec/views/layouts/application.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'layouts/application.html.erb' do
   before do
     allow(view).to receive_messages(user_signed_in?: false, ccs_homepage_url: 'https://CCSHOMEPAGE', service_path_base: '/supply-teachers')
 
-    cookies[:cookie_preferences] = {
+    cookies[:cookie_preferences_cmp] = {
       value: {
         'settings_viewed' => true,
         'usage' => true,


### PR DESCRIPTION
Because the cookie_preferences is set by the corporate website which has the .crowncommercial.gov.uk, it will supersede any cookie we set as Crown Marketplace is hosted on a subdomain. Therefore, I have renamed the cookie to remove this conflict.