### PR TITLE
Update the healthcheck route to check for the apps status

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -16,3 +16,5 @@ CCS_APP_API_DATA_BUCKET=test
 GOV_NOTIFY_API_KEY=d7101cf9-2a94-4728-a1dd-428e3309886f-1b0cecdd-88af-48ed-972f-f36aadadb6bd
 
 RAILS_ENV_URL=http://localhost:3000
+
+GIT_COMMIT=expected-git-commit

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,11 +1,11 @@
 class HomeController < ApplicationController
-  before_action :authenticate_user!, :validate_service, except: %i[status index]
+  before_action :authenticate_user!, :validate_service, except: %i[healthcheck index]
 
   def index
     redirect_to ccs_homepage_url, allow_other_host: true
   end
 
-  def status
-    render layout: false
+  def healthcheck
+    render json: { status: :ok, git_commit: ENV.fetch('GIT_COMMIT', '') }
   end
 end

--- a/app/views/home/status.html.erb
+++ b/app/views/home/status.html.erb
@@ -1,1 +1,0 @@
-<p>GIT_COMMIT: <%= ENV['GIT_COMMIT'] %></p>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,8 +90,9 @@ Rails.application.configure do
   config.fail_silently = true
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  config.hosts << ENV.fetch('ENVIRONMENT_HOST', nil)
+  ENV.fetch('ENVIRONMENT_HOST', '').split(',').each do |application_domain|
+    config.hosts << application_domain
+  end
 
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path =~ /healthcheck/ } }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ require 'sidekiq/cron/web'
 
 Rails.application.routes.draw do
   get '/', to: 'home#index'
-  get '/status', to: 'home#status'
+  get '/healthcheck', to: 'home#healthcheck', format: :json
 
   authenticate :user, ->(u) { u.has_role? :ccs_employee } do
     mount Sidekiq::Web => '/sidekiq-log'

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -4,14 +4,22 @@ RSpec.describe HomeController do
   describe 'GET index' do
     it 'redirects to the CCS home page' do
       get :index
+
       expect(response).to redirect_to('https://www.crowncommercial.gov.uk/')
     end
   end
 
-  describe 'GET status' do
+  describe 'GET healthcheck' do
     it 'displays status information about the app' do
-      get :status
-      expect(response).to render_template(:status, layout: false)
+      get :healthcheck
+
+      expect(response.content_type).to eq('application/json; charset=utf-8')
+      expect(response.parsed_body).to eq(
+        {
+          'status' => 'ok',
+          'git_commit' => 'expected-git-commit'
+        }
+      )
     end
   end
 end


### PR DESCRIPTION
This is so the ECS tasks can check for the health of the container (it is currently being blocked)

The health check path needs to be updated to: `/healthcheck`